### PR TITLE
add DUNE ini file generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,9 +159,8 @@ before_script:
   # download pre-compiled static libSBML library
   - cd ext
   - wget "https://github.com/lkeegan/libsbml-static/releases/latest/download/libsbml-static-$TRAVIS_OS_NAME.tgz"
-  - mkdir -p libsbml
-  - tar xzvf libsbml-static-$TRAVIS_OS_NAME.tgz -C libsbml
-  - ls libsbml
+  - tar xzvf libsbml-static-$TRAVIS_OS_NAME.tgz
+  - ls */*
   - cd ..
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Translate the spatial model to a system of PDEs and simulate it: [WP1b status](h
         -   license: MIT
         -   included in source code
 
+    -   SymEngine symbolic manipulation library: <https://github.com/symengine/symengine>
+
+        -   license: MIT
+        -   included in binary
+
+    -   GNU Multiple Precision Arithmetic Library: <https://gmplib.org/>
+
+        -   license: LGPL
+        -   included in binary
+
     -   Catch2 testing framework: <https://github.com/catchorg/Catch2>
 
         -   license: BSL-1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,11 @@
 image:
   - Visual Studio 2015
 install:
-  - set PATH=%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
 
 before_build:
+  - mingw32-make --version
+  - g++ --version
   # note absolute paths currently hard coded in QT binaries
   # TODO: add a qt.conf file to override this, see: https://doc.qt.io/qt-5/qt-conf.html#overriding-paths
   # install pre-compiled Qt5 binaries & static libraries
@@ -21,12 +23,10 @@ before_build:
   - qmake -v
   # download pre-compiled static libSBML library
   - cd ext
-  - mkdir libsbml
-  - cd libsbml
   - appveyor DownloadFile "https://github.com/lkeegan/libsbml-static/releases/latest/download/libsbml-static-win32.zip"
   - 7z x libsbml-static-win32.zip
   - dir
-  - cd ..
+  - dir libsbml
   - cd ..
 
 build_script:

--- a/inc/mainwindow.hpp
+++ b/inc/mainwindow.hpp
@@ -57,6 +57,8 @@ class MainWindow : public QMainWindow {
 
   void action_Save_SBML_file_triggered();
 
+  void actionExport_Dune_ini_file_triggered();
+
   // Import menu actions
   void actionGeometry_from_image_triggered();
 

--- a/inc/reactions.hpp
+++ b/inc/reactions.hpp
@@ -1,0 +1,39 @@
+// Reaction compilation routines
+//  - construct stoich matrix and reaction terms as strings
+//  - along with a map of constants
+
+#pragma once
+
+#include <QDebug>
+#include <QStringList>
+
+#include "sbml.hpp"
+
+namespace reactions {
+
+class Reaction {
+ private:
+  sbml::SbmlDocWrapper *doc;
+
+ public:
+  // vector of reaction expressions as strings
+  std::vector<std::string> reacExpressions;
+  // matrix M_ij of stoichiometric coefficients
+  // i is the species index
+  // j is the reaction index
+  std::vector<std::vector<double>> M;
+  // vector of speciesIDs
+  std::vector<std::string> speciesIDs;
+  // vector of maps of constants
+  std::vector<std::map<std::string, double>> constants;
+  void init(sbml::SbmlDocWrapper *doc_ptr,
+            const std::vector<std::string> &species,
+            const std::vector<std::string> &reactionIDs);
+  Reaction(sbml::SbmlDocWrapper *doc_ptr,
+           const std::vector<std::string> &species,
+           const std::vector<std::string> &reactionIDs);
+  Reaction(sbml::SbmlDocWrapper *doc_ptr, const QStringList &species,
+           const QStringList &reactionIDs);
+};
+
+}  // namespace reactions

--- a/inc/sbml.hpp
+++ b/inc/sbml.hpp
@@ -95,6 +95,9 @@ class SbmlDocWrapper {
   // return raw XML as QString
   const QString &getXml();
 
+  // return DUNE ini file for current model
+  QString getDUNE();
+
   // returns true if species is fixed throughout the simulation
   bool isSpeciesConstant(const std::string &speciesID) const;
 

--- a/inc/simulate.hpp
+++ b/inc/simulate.hpp
@@ -8,7 +8,6 @@
 
 #include <QDebug>
 #include <QImage>
-#include <QPoint>
 
 #include "geometry.hpp"
 #include "numerics.hpp"
@@ -27,9 +26,6 @@ class ReacEval {
   std::vector<std::vector<double>> M;
   // vector of result of evaluating reactions
   std::vector<double> result;
-  bool addStoichCoeff(std::vector<double> &Mrow,
-                      const libsbml::SpeciesReference *spec_ref, double sign,
-                      const std::vector<std::string> &speciesIDs);
 
  public:
   // vector of species concentrations that Reaction expressions will use
@@ -39,8 +35,7 @@ class ReacEval {
   ReacEval() = default;
   ReacEval(sbml::SbmlDocWrapper *doc_ptr,
            const std::vector<std::string> &speciesID,
-           const std::vector<std::string> &reactionID,
-           std::size_t nRateRules = 0);
+           const std::vector<std::string> &reactionID);
   void evaluate();
   const std::vector<double> &getResult() const { return result; }
 };

--- a/inc/symbolic.hpp
+++ b/inc/symbolic.hpp
@@ -1,0 +1,41 @@
+// Symbolic algebras routines (simple wrapper around SymEngine)
+//  - takes a math expression as a string
+//     - with list of variables
+//     - with list of constants and their numeric values
+//  - parses expression
+//  - returns simplified expression with constants inlined as string
+//  - returns differential of expression wrt a variable as string
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "symengine/basic.h"
+#include "symengine/symbol.h"
+#include "symengine/symengine_rcp.h"
+
+namespace symbolic {
+
+class Symbolic {
+ public:
+  Symbolic(const std::string &expression,
+           const std::vector<std::string> &variables,
+           const std::map<std::string, double> &constants);
+  // simplify given expression
+  std::string simplify() const;
+  // differentiate given expression wrt a variable
+  std::string diff(const std::string &var) const;
+  // relabel variables as u_0, u_1, etc in order
+  std::string relabel(const std::vector<std::string> &variables,
+                      const std::string &label = "u_") const;
+
+ private:
+  SymEngine::RCP<const SymEngine::Basic> expr;
+  std::map<std::string, SymEngine::RCP<const SymEngine::Symbol>> symbols;
+  std::string toString(
+      const SymEngine::RCP<const SymEngine::Basic> &expr) const;
+};
+
+}  // namespace symbolic

--- a/spatial-model-editor.pro
+++ b/spatial-model-editor.pro
@@ -18,8 +18,10 @@ SOURCES += \
     src/mainwindow.cpp \
     src/numerics.cpp \
     src/qlabelmousetracker.cpp \
+    src/reactions.cpp \
     src/sbml.cpp \
     src/simulate.cpp \
+    src/symbolic.cpp \
     src/version.cpp \
     ext/qcustomplot/qcustomplot.cpp \
 
@@ -30,8 +32,10 @@ HEADERS += \
     inc/mainwindow.hpp \
     inc/numerics.hpp \
     inc/qlabelmousetracker.hpp \
+    inc/reactions.hpp \
     inc/sbml.hpp \
     inc/simulate.hpp \
+    inc/symbolic.hpp \
     inc/version.hpp \
     ext/qcustomplot/qcustomplot.h \
 
@@ -43,10 +47,9 @@ RESOURCES += \
 
 INCLUDEPATH += inc ext ext/qcustomplot
 
-# these static libraries are available from
+# these static libraries are available pre-compiled from
 # from https://github.com/lkeegan/libsbml-static
-LIBS += $$PWD/ext/libsbml/lib/libsbml-static.a $$PWD/ext/libsbml/lib/libexpat.a
-INCLUDEPATH += $$PWD/ext/libsbml/include
+LIBS += $$PWD/ext/libsbml/lib/libsbml-static.a $$PWD/ext/libsbml/lib/libexpat.a $$PWD/ext/symengine/lib/libsymengine.a $$PWD/ext/gmp/lib/libgmp.a
 
 # on windows add flags to support large object files
 # https://stackoverflow.com/questions/16596876/object-file-has-too-many-sections
@@ -62,7 +65,10 @@ mac: QMAKE_CXXFLAGS += -fvisibility=hidden
 unix: QMAKE_CXXFLAGS += -Wall -Wcast-align -Wconversion -Wdouble-promotion -Wextra -Wformat=2 -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-conversion -Wunused -Wpedantic
 
 # on osx/linux, include QT headers as system headers to supress compiler warnings
-mac|unix: QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_HEADERS]/qt5" \
+QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_HEADERS]/qt5" \
                         -isystem "$$[QT_INSTALL_HEADERS]/QtCore" \
                         -isystem "$$[QT_INSTALL_HEADERS]/QtWidgets" \
-                        -isystem "$$[QT_INSTALL_HEADERS]/QtGui"
+                        -isystem "$$[QT_INSTALL_HEADERS]/QtGui" \
+                        -isystem "$$PWD/ext/libsbml/include" \
+                        -isystem "$$PWD/ext/symengine/include" \
+                        -isystem "$$PWD/ext/gmp/include"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <locale>
+
 #include <QApplication>
 #include <QtGui>
 
@@ -23,6 +25,15 @@ int main(int argc, char *argv[]) {
   }
 
   QApplication a(argc, argv);
+
+  // Qt sets the locale according to the system one
+  // This can cause problems with symengine
+  // e.g. when a double is written as "3,142" vs "3.142"
+  // it looks for "." to identify a double, but then uses strtod
+  // to convert it, so "3.142" gets interpreted as "3"
+  // Here we reset to the default "C" locale to avoid these issues
+  std::locale::global(std::locale::classic());
+
   MainWindow w;
   w.show();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,6 +61,9 @@ void MainWindow::setupConnections() {
   connect(ui->action_Save_SBML_file, &QAction::triggered, this,
           &MainWindow::action_Save_SBML_file_triggered);
 
+  connect(ui->actionExport_Dune_ini_file, &QAction::triggered, this,
+          &MainWindow::actionExport_Dune_ini_file_triggered);
+
   connect(ui->actionE_xit, &QAction::triggered, this,
           []() { QApplication::quit(); });
 
@@ -176,7 +179,8 @@ void MainWindow::tabMain_currentChanged(int index) {
     REACTIONS = 3,
     FUNCTIONS = 4,
     SIMULATE = 5,
-    SBML = 6
+    SBML = 6,
+    DUNE = 7
   };
   ui->tabMain->setWhatsThis(ui->tabMain->tabWhatsThis(index));
   spdlog::debug("MainWindow::tabMain_currentChanged :: Tab changed to {} [{}]",
@@ -206,6 +210,9 @@ void MainWindow::tabMain_currentChanged(int index) {
       break;
     case TabIndex::SBML:
       ui->txtSBML->setText(sbmlDoc.getXml());
+      break;
+    case TabIndex::DUNE:
+      ui->txtDUNE->setText(sbmlDoc.getDUNE());
       break;
     default:
       qFatal("ui::tabMain :: Errror: Tab index %d not valid", index);
@@ -347,6 +354,22 @@ void MainWindow::action_Save_SBML_file_triggered() {
   }
 }
 
+void MainWindow::actionExport_Dune_ini_file_triggered() {
+  QString filename = QFileDialog::getSaveFileName(
+      this, "Export DUNE ini file", "", "DUNE ini file (*.ini)", nullptr,
+      QFileDialog::Option::DontUseNativeDialog);
+  if (!filename.isEmpty()) {
+    if (filename.right(4) != ".ini") {
+      filename.append(".ini");
+    }
+    QString iniFileString = sbmlDoc.getDUNE();
+    QFile f(filename);
+    if (f.open(QIODevice::ReadWrite | QIODevice::Text)) {
+      f.write(iniFileString.toUtf8());
+    }
+  }
+}
+
 void MainWindow::actionGeometry_from_image_triggered() {
   QString filename = QFileDialog::getOpenFileName(
       this, "Import geometry from image", "",
@@ -400,6 +423,8 @@ void MainWindow::action_About_triggered() {
                   .arg(QString::number(SPDLOG_VER_MAJOR),
                        QString::number(SPDLOG_VER_MINOR),
                        QString::number(SPDLOG_VER_PATCH)));
+  info.append(QString("<li>symenginge: 0.4.0</li>"));
+  info.append(QString("<li>gmp: 6.1.2</li>"));
   for (const auto &dep : {"expat", "libxml", "xerces-c", "bzip2", "zip"}) {
     if (libsbml::isLibSBMLCompiledWith(dep) != 0) {
       info.append(QString("<li>%1: %2</li>")

--- a/src/reactions.cpp
+++ b/src/reactions.cpp
@@ -1,0 +1,199 @@
+#include "reactions.hpp"
+
+#include "logger.hpp"
+
+namespace reactions {
+
+static std::map<std::string, double> getGlobalConstants(
+    sbml::SbmlDocWrapper *doc) {
+  std::map<std::string, double> constants;
+  const auto *model = doc->model;
+  // add all *constant* species as constants
+  for (unsigned k = 0; k < model->getNumSpecies(); ++k) {
+    const auto *spec = model->getSpecies(k);
+    if (doc->isSpeciesConstant(spec->getId())) {
+      spdlog::debug(
+          "reactions::getGlobalConstants :: found constant species {}",
+          spec->getId());
+      // todo: check if species is *also* non-spatial
+      double init_conc = 0;
+      // if SBML file specifies amount: convert to concentration
+      if (spec->isSetInitialAmount()) {
+        double amount = spec->getInitialAmount();
+        double vol = model->getCompartment(spec->getCompartment())->getSize();
+        init_conc = amount / vol;
+        spdlog::debug(
+            "reactions::getGlobalConstants :: converting amount {} to "
+            "concentration {} by dividing by vol {}",
+            amount, init_conc, vol);
+      } else {
+        init_conc = spec->getInitialConcentration();
+      }
+      constants[spec->getId()] = init_conc;
+    }
+  }
+  // add any parameters (that are not replaced by an AssignmentRule)
+  for (unsigned k = 0; k < model->getNumParameters(); ++k) {
+    const auto *param = model->getParameter(k);
+    if (model->getAssignmentRule(param->getId()) == nullptr) {
+      constants[param->getId()] = param->getValue();
+    }
+  }
+  // also get compartment volumes (the compartmentID may be used in the reaction
+  // equation, and it should be replaced with the value of the "Size"
+  // parameter for this compartment)
+  for (unsigned int k = 0; k < model->getNumCompartments(); ++k) {
+    const auto *comp = model->getCompartment(k);
+    constants[comp->getId()] = comp->getSize();
+  }
+  return constants;
+}
+
+static std::string inlineExpr(sbml::SbmlDocWrapper *doc,
+                              const std::string &expr) {
+  std::string inlined;
+  // inline any Function calls in expr
+  inlined = doc->inlineFunctions(expr);
+  // inline any Assignment Rules in expr
+  inlined = doc->inlineAssignments(inlined);
+  return inlined;
+}
+
+static bool addStoichCoeff(sbml::SbmlDocWrapper *doc, std::vector<double> &Mrow,
+                           const libsbml::SpeciesReference *spec_ref,
+                           double sign,
+                           const std::vector<std::string> &speciesIDs) {
+  const std::string &speciesID = spec_ref->getSpecies();
+  const auto *species = doc->model->getSpecies(speciesID);
+  const auto *compartment =
+      doc->model->getCompartment(species->getCompartment());
+  double volFactor = compartment->getSize();
+  spdlog::debug(
+      "reactions::addStoichCoeff :: species '{}', sign: {}, compartment "
+      "volume: "
+      "{}",
+      speciesID, sign, volFactor);
+  // if it is in the species vector, and not constant, insert into matrix M
+  auto it = std::find(speciesIDs.cbegin(), speciesIDs.cend(), speciesID);
+  if (it != speciesIDs.cend() && doc->isSpeciesReactive(speciesID)) {
+    std::size_t speciesIndex =
+        static_cast<std::size_t>(it - speciesIDs.cbegin());
+    double coeff = sign * spec_ref->getStoichiometry() / volFactor;
+    spdlog::debug("reactions::addStoichCoeff ::   -> stoich coeff[{}]: {}",
+                  speciesIndex, coeff);
+    Mrow[speciesIndex] += coeff;
+    return true;
+  }
+  return false;
+}
+
+void Reaction::init(sbml::SbmlDocWrapper *doc_ptr,
+                    const std::vector<std::string> &species,
+                    const std::vector<std::string> &reactionIDs) {
+  doc = doc_ptr;
+  speciesIDs = species;
+  spdlog::info("Reaction::Reaction :: species vector: {}", speciesIDs);
+  M.clear();
+  reacExpressions.clear();
+
+  // check if any species have a RateRule
+  // todo: not currently valid if raterule involves species in multiple
+  // compartments
+  // todo: check if should divide by volume here as well as for kinetic law
+  // i.e. if the rate rule is for amount like the kinetic law
+  for (std::size_t sIndex = 0; sIndex < speciesIDs.size(); ++sIndex) {
+    const auto *rule = doc->model->getRateRule(speciesIDs[sIndex]);
+    if (rule != nullptr) {
+      std::map<std::string, double> c = getGlobalConstants(doc);
+      std::string expr = inlineExpr(doc, rule->getFormula());
+      std::vector<double> Mrow(speciesIDs.size(), 0);
+      Mrow[sIndex] = 1.0;
+      M.push_back(Mrow);
+      reacExpressions.push_back(expr);
+      constants.push_back(c);
+      spdlog::info("Reaction::Reaction :: adding rate rule for species {}",
+                   speciesIDs[sIndex]);
+      spdlog::info("Reaction::Reaction ::   - expr: {}", expr);
+    }
+  }
+
+  // process each reaction
+  for (const auto &reacID : reactionIDs) {
+    const auto *reac = doc->model->getReaction(reacID);
+    bool isReaction = false;
+
+    std::map<std::string, double> c = getGlobalConstants(doc);
+
+    // construct row of stoichiometric coefficients for each
+    // species produced and consumed by this reaction
+    std::vector<double> Mrow(speciesIDs.size(), 0);
+    for (unsigned k = 0; k < reac->getNumProducts(); ++k) {
+      if (addStoichCoeff(doc, Mrow, reac->getProduct(k), +1.0, speciesIDs)) {
+        isReaction = true;
+      }
+    }
+    for (unsigned k = 0; k < reac->getNumReactants(); ++k) {
+      if (addStoichCoeff(doc, Mrow, reac->getReactant(k), -1.0, speciesIDs)) {
+        isReaction = true;
+      }
+    }
+    if (isReaction) {
+      // if matrix row is non-zero, i.e. reaction does something, then insert it
+      // into the M matrix, and construct the corresponding reaction term
+      M.push_back(Mrow);
+      // get mathematical formula
+      const auto *kin = reac->getKineticLaw();
+      std::string expr = inlineExpr(doc, kin->getFormula());
+
+      // TODO: deal with amount vs concentration issues correctly
+      // if getHasOnlySubstanceUnits is true for some (all?) species
+      // note: would also need to also do this in the inlining step,
+      // and in the stoich matrix factors
+
+      // get local parameters, append to global constants
+      // NOTE: if a parameter is set by an assignment rule
+      // it should *not* be added as a constant below:
+      // (it should no longer be present in expr after inlining)
+      for (unsigned k = 0; k < kin->getNumLocalParameters(); ++k) {
+        const auto *param = kin->getLocalParameter(k);
+        if (doc->model->getAssignmentRule(param->getId()) == nullptr) {
+          c[param->getId()] = param->getValue();
+        }
+      }
+      for (unsigned k = 0; k < kin->getNumParameters(); ++k) {
+        const auto *param = kin->getParameter(k);
+        if (doc->model->getAssignmentRule(param->getId()) == nullptr) {
+          c[param->getId()] = param->getValue();
+        }
+      }
+      // construct expression and add to reactions
+      reacExpressions.push_back(expr);
+      constants.push_back(c);
+      spdlog::info("Reaction::Reaction :: adding reaction {}", reacID);
+      spdlog::info("Reaction::Reaction ::   - stoichiometric matrix row: {}",
+                   Mrow);
+      spdlog::info("Reaction::Reaction ::   - expr: {}", expr);
+    }
+  }
+}
+
+Reaction::Reaction(sbml::SbmlDocWrapper *doc_ptr,
+                   const std::vector<std::string> &species,
+                   const std::vector<std::string> &reactionIDs) {
+  init(doc_ptr, species, reactionIDs);
+}
+
+Reaction::Reaction(sbml::SbmlDocWrapper *doc_ptr, const QStringList &species,
+                   const QStringList &reactionIDs) {
+  std::vector<std::string> svec;
+  for (const auto &s : species) {
+    svec.push_back(s.toStdString());
+  }
+  std::vector<std::string> rvec;
+  for (const auto &r : reactionIDs) {
+    rvec.push_back(r.toStdString());
+  }
+  init(doc_ptr, svec, rvec);
+}
+
+}  // namespace reactions

--- a/src/sbml.cpp
+++ b/src/sbml.cpp
@@ -4,6 +4,8 @@
 #include <unordered_set>
 
 #include "logger.hpp"
+#include "reactions.hpp"
+#include "symbolic.hpp"
 
 namespace sbml {
 
@@ -829,6 +831,152 @@ const QString &SbmlDocWrapper::getXml() {
       libsbml::writeSBMLToString(doc.get()), &std::free);
   xmlString = QString(xmlChar.get());
   return xmlString;
+}
+
+class iniFile {
+ private:
+  QString text;
+
+ public:
+  const QString &getText() { return text; }
+  void addSection(const QString &str) {
+    if (!text.isEmpty()) {
+      text.append("\n");
+    }
+    text.append(QString("[%1]\n").arg(str));
+  }
+  void addSection(const QString &str1, const QString &str2) {
+    addSection(QString("%1.%2").arg(str1, str2));
+  }
+  void addSection(const QString &str1, const QString &str2,
+                  const QString &str3) {
+    addSection(QString("%1.%2.%3").arg(str1, str2, str3));
+  }
+  void addValue(const QString &var, const QString &value) {
+    text.append(QString("%1 = %2\n").arg(var, value));
+  }
+  void addValue(const QString &var, int value) {
+    text.append(QString("%1 = %2\n").arg(var, QString::number(value)));
+  }
+  void addValue(const QString &var, double value) {
+    text.append(QString("%1 = %2\n").arg(var, QString::number(value)));
+  }
+};
+
+QString SbmlDocWrapper::getDUNE() {
+  iniFile ini;
+
+  double begin_time = 0.0;
+  double end_time = 0.01;
+
+  // standard boilerplate
+  ini.addSection("logging");
+  ini.addValue("default.level", "trace");
+  ini.addSection("logging.backend.model");
+  ini.addValue("level", "trace");
+  ini.addValue("indent", 2);
+
+  // grid
+  ini.addSection("grid");
+  ini.addValue("file", "grid.msh");
+
+  // simulation
+  ini.addSection("model");
+  ini.addValue("begin_time", begin_time);
+  ini.addValue("end_time", end_time);
+
+  // list of compartments with corresponding gmsh surface index - 1
+  ini.addSection("model.compartements");
+  for (int i = 0; i < compartments.size(); ++i) {
+    ini.addValue(compartments[i], i);
+  }
+
+  // list of membranes (?)
+
+  // for each compartment
+  for (const auto &compartmentID : compartments) {
+    // runtime
+    ini.addSection("model", compartmentID);
+    ini.addValue("name", compartmentID);
+    ini.addValue("begin_time", begin_time);
+    ini.addValue("end_time", end_time);
+
+    // initial concentrations
+    ini.addSection("model", compartmentID, "initial");
+    int i_species = 0;
+    for (const auto &speciesID : species.at(compartmentID)) {
+      ini.addValue(QString("u_%1").arg(QString::number(i_species)),
+                   model->getSpecies(speciesID.toStdString())
+                       ->getInitialConcentration());
+      ++i_species;
+    }
+
+    // reactions
+    if (reactions.find(compartmentID) != reactions.cend()) {
+      ini.addSection("model", compartmentID, "reaction");
+      reactions::Reaction reacs(this, species.at(compartmentID),
+                                reactions.at(compartmentID));
+      // reaction term
+      std::vector<std::string> uExpressions;
+      std::vector<std::string> uVars;
+      for (std::size_t i = 0; i < reacs.speciesIDs.size(); ++i) {
+        uVars.push_back("u_" + std::to_string(i));
+      }
+      for (std::size_t i = 0; i < reacs.speciesIDs.size(); ++i) {
+        QString lhs = QString("u_%1").arg(QString::number(i));
+        QString rhs;
+        for (std::size_t j = 0; j < reacs.reacExpressions.size(); ++j) {
+          // get reaction term
+          QString expr = QString("%1*(%2) ")
+                             .arg(QString::number(reacs.M.at(j).at(i)),
+                                  reacs.reacExpressions[j].c_str());
+          // parse and inline constants
+          symbolic::Symbolic sym(expr.toStdString(), reacs.speciesIDs,
+                                 reacs.constants[j]);
+          // relabel species to u vector components
+          QString newTerm = sym.relabel(reacs.speciesIDs).c_str();
+          // add term if non-zero
+          if (newTerm != QString("0.0")) {
+            if (!rhs.isEmpty()) {
+              rhs.append(" + ");
+            }
+            rhs.append(QString("(%1)").arg(newTerm));
+          }
+        }
+        if (rhs.isEmpty()) {
+          rhs = "0.0";
+        }
+        // reparse full rhs to simplify
+        symbolic::Symbolic sym(rhs.toStdString(), uVars, {});
+        rhs = sym.simplify().c_str();
+
+        uExpressions.push_back(rhs.toStdString());
+        ini.addValue(lhs, rhs);
+      }
+
+      // reaction term jacobian
+      ini.addSection("model", compartmentID, "jacobian");
+      for (std::size_t i = 0; i < reacs.speciesIDs.size(); ++i) {
+        for (std::size_t j = 0; j < reacs.speciesIDs.size(); ++j) {
+          symbolic::Symbolic sym(uExpressions[i], uVars, {});
+          QString lhs = QString("d(u_%1)/d(u_%2)")
+                            .arg(QString::number(i), QString::number(j));
+          QString rhs = sym.diff(uVars[j]).c_str();
+          ini.addValue(lhs, rhs);
+        }
+      }
+    }
+
+    // diffusion coefficients
+    ini.addSection("model", compartmentID, "diffusion");
+    i_species = 0;
+    for (const auto &speciesID : species.at(compartmentID)) {
+      ini.addValue(QString("u_%1").arg(QString::number(i_species)),
+                   mapSpeciesIdToField.at(speciesID).diffusionConstant);
+      ++i_species;
+    }
+  }
+  return ini.getText();
 }
 
 bool SbmlDocWrapper::isSpeciesConstant(const std::string &speciesID) const {

--- a/src/symbolic.cpp
+++ b/src/symbolic.cpp
@@ -1,0 +1,59 @@
+#include "symbolic.hpp"
+
+#include "symengine/eval.h"
+#include "symengine/parser.h"
+#include "symengine/subs.h"
+#include "symengine/symengine_exception.h"
+#include "symengine/visitor.h"
+
+#include "logger.hpp"
+
+#include <iostream>
+
+namespace symbolic {
+
+Symbolic::Symbolic(const std::string &expression,
+                   const std::vector<std::string> &variables,
+                   const std::map<std::string, double> &constants) {
+  spdlog::debug("Symbolic::Symbolic :: parsing {}", expression);
+  for (const auto &v : variables) {
+    symbols[v] = SymEngine::symbol(v);
+  }
+  SymEngine::map_basic_basic d;
+  for (const auto &p : constants) {
+    d[SymEngine::symbol(p.first)] = SymEngine::real_double(p.second);
+    spdlog::debug("Symbolic::Symbolic ::   --> constant {} = {}", p.first,
+                  p.second);
+  }
+  expr = SymEngine::parse(expression)->subs(d);
+  spdlog::debug("Symbolic::Symbolic :: --> {}", *expr);
+}
+
+std::string Symbolic::simplify() const { return toString(expr); }
+
+std::string Symbolic::diff(const std::string &var) const {
+  auto dexpr_dvar = expr->diff(symbols.at(var));
+  return toString(dexpr_dvar);
+}
+
+std::string Symbolic::relabel(const std::vector<std::string> &variables,
+                              const std::string &label) const {
+  SymEngine::map_basic_basic d;
+  spdlog::debug("Symbolic::relabel :: expr = {}", *expr);
+  std::vector<SymEngine::RCP<const SymEngine::Symbol>> u;
+  for (std::size_t i = 0; i < variables.size(); ++i) {
+    u.push_back(SymEngine::symbol(label + std::to_string(i)));
+    d[symbols.at(variables.at(i))] = u[i];
+    spdlog::debug("Symbolic::relabel ::   - {} -> {}",
+                  *symbols.at(variables.at(i)), *u[i]);
+  }
+  auto eu = expr->subs(d);
+  return toString(eu);
+}
+
+std::string Symbolic::toString(
+    const SymEngine::RCP<const SymEngine::Basic> &e) const {
+  return e->__str__();
+}
+
+}  // namespace symbolic

--- a/test.pro
+++ b/test.pro
@@ -17,12 +17,15 @@ SOURCES += \
     test/src/test_qlabelmousetracker.cpp \
     test/src/test_sbml.cpp \
     test/src/test_simulate.cpp \
+    test/src/test_symbolic.cpp \
     src/geometry.cpp \
     src/mainwindow.cpp \
     src/numerics.cpp \
     src/qlabelmousetracker.cpp \
+    src/reactions.cpp \
     src/sbml.cpp \
     src/simulate.cpp \
+    src/symbolic.cpp \
     src/version.cpp \
     ext/qcustomplot/qcustomplot.cpp
 
@@ -50,10 +53,9 @@ unix: QMAKE_CXXFLAGS += --coverage
 unix: QMAKE_LFLAGS += --coverage
 unix: QMAKE_CXXFLAGS += -Wall -Wcast-align -Wconversion -Wdouble-promotion -Wextra -Wformat=2 -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-conversion -Wunused -Wpedantic
 
-# these static libraries are available from
+# these static libraries are available pre-compiled from
 # from https://github.com/lkeegan/libsbml-static
-LIBS += $$PWD/ext/libsbml/lib/libsbml-static.a $$PWD/ext/libsbml/lib/libexpat.a
-QMAKE_CXXFLAGS += -isystem $$PWD/ext/libsbml/include
+LIBS += $$PWD/ext/libsbml/lib/libsbml-static.a $$PWD/ext/libsbml/lib/libexpat.a $$PWD/ext/symengine/lib/libsymengine.a $$PWD/ext/gmp/lib/libgmp.a
 
 # on windows add flags to support large object files
 # https://stackoverflow.com/questions/16596876/object-file-has-too-many-sections
@@ -63,8 +65,12 @@ win32: QMAKE_CXXFLAGS += -Wa,-mbig-obj
 mac: QMAKE_CXXFLAGS += -fvisibility=hidden
 
 # on osx/linux, include QT headers as system headers to supress compiler warnings
-mac|unix: QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_HEADERS]/qt5" \
+QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_HEADERS]/qt5" \
                         -isystem "$$[QT_INSTALL_HEADERS]/QtCore" \
                         -isystem "$$[QT_INSTALL_HEADERS]/QtWidgets" \
                         -isystem "$$[QT_INSTALL_HEADERS]/QtGui" \
-                        -isystem "$$[QT_INSTALL_HEADERS]/QtTest"
+                        -isystem "$$[QT_INSTALL_HEADERS]/QtTest" \
+                        -isystem "$$PWD/ext/libsbml/include" \
+                        -isystem "$$PWD/ext/symengine/include" \
+                        -isystem "$$PWD/ext/gmp/include"
+

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,12 +1,20 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
+#include <locale>
+
 #include <QApplication>
 
 int main(int argc, char *argv[]) {
   Catch::StringMaker<double>::precision = 15;
 
   QApplication a(argc, argv);
+
+  // Qt sets the locale according to the system one
+  // This can cause problems with numerical code
+  // e.g. when a double is "3,142" vs "3.142"
+  // Here we reset the default "C" locale to avoid these issues
+  std::locale::global(std::locale::classic());
 
   int result = Catch::Session().run(argc, argv);
 

--- a/test/src/test_mainwindow.cpp
+++ b/test/src/test_mainwindow.cpp
@@ -320,6 +320,7 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
       libsbml::readSBMLFromString(sbml_test_data::very_simple_model().xml));
   libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
   openTempSBMLFile(&w, ui, mwt);
+  REQUIRE(ui.tabMain->currentIndex() == 0);
   REQUIRE(ui.listCompartments->count() == 3);
 
   // create geometry image
@@ -390,6 +391,7 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
                   key_delay);
   CAPTURE(QTest::qWaitFor([&ui]() { return ui.tabMain->currentIndex() == 1; }));
+  REQUIRE(ui.tabMain->currentIndex() == 1);
   REQUIRE(ui.listMembranes->count() == 3);
   // select each item in listMembranes
   ui.listMembranes->setFocus();
@@ -407,6 +409,7 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
                   key_delay);
   QApplication::processEvents();
+  REQUIRE(ui.tabMain->currentIndex() == 2);
   REQUIRE(ui.listSpecies->topLevelItemCount() == 3);
   // select each item in listSpecies
   ui.listSpecies->setFocus();
@@ -431,6 +434,7 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
                   key_delay);
   QApplication::processEvents();
+  REQUIRE(ui.tabMain->currentIndex() == 3);
   REQUIRE(ui.listReactions->topLevelItemCount() == 3);
   // select each item in listReactions
   ui.listReactions->setFocus();
@@ -446,6 +450,7 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
                   key_delay);
   QApplication::processEvents();
+  REQUIRE(ui.tabMain->currentIndex() == 4);
   REQUIRE(ui.listFunctions->count() == 0);
   // select each item in listSpecies
   ui.listFunctions->setFocus();
@@ -463,5 +468,18 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   QApplication::processEvents();
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
                   key_delay);
+  REQUIRE(ui.tabMain->currentIndex() == 5);
   ui.btnSimulate->click();
+
+  // display SBML tab
+  QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
+                  key_delay);
+  QApplication::processEvents();
+  REQUIRE(ui.tabMain->currentIndex() == 6);
+
+  // display DUNE tab
+  QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,
+                  key_delay);
+  QApplication::processEvents();
+  REQUIRE(ui.tabMain->currentIndex() == 7);
 }

--- a/test/src/test_symbolic.cpp
+++ b/test/src/test_symbolic.cpp
@@ -1,0 +1,71 @@
+#include "catch.hpp"
+#include "symbolic.hpp"
+
+#include <locale>
+
+TEST_CASE("5+5: no vars, no constants", "[symbolic]") {
+  // mathematical expression as string
+  std::string expr = "5+5";
+  // names of variables in expression
+  std::vector<std::string> vars = {};
+  // names and values of constants in expression
+  std::map<std::string, double> constants = {};
+  // parse expression
+  symbolic::Symbolic sym(expr, vars, constants);
+  // ouput these variables as part of the test
+  CAPTURE(expr);
+  CAPTURE(vars);
+  CAPTURE(constants);
+  // simplify expression
+  REQUIRE(sym.simplify() == "10");
+}
+
+TEST_CASE("3*x + 7*x: one var, no constants", "[symbolic]") {
+  std::string expr = "3*x + 7 * x";
+  symbolic::Symbolic sym(expr, {"x"}, {});
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == "10*x");
+  REQUIRE(sym.diff("x") == "10");
+}
+
+TEST_CASE("1.324*x + 2*3: one var, no constants", "[symbolic]") {
+  std::string expr = "1.324 * x + 2*3";
+  symbolic::Symbolic sym(expr, {"x"}, {});
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == "6 + 1.324*x");
+  REQUIRE(sym.diff("x") == "1.324");
+}
+
+TEST_CASE("3*x + 4/x - 1.0*x + 0.2*x*x - 0.1: one var, no constants",
+          "[symbolic]") {
+  std::string expr = "3*x + 4/x - 1.0*x + 0.2*x*x - 0.1";
+  symbolic::Symbolic sym(expr, {"x"}, {});
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == "-0.1 + 2.0*x + 4*x**(-1) + 0.2*x**2");
+  REQUIRE(sym.diff("x") == "2.0 + 0.4*x - 4*x**(-2)");
+}
+
+TEST_CASE("3*x + 4/y - 1.0*x + 0.2*x*y - 0.1: two vars, no constants",
+          "[symbolic]") {
+  std::string expr = "3*x + 4/y - 1.0*x + 0.2*x*y - 0.1";
+  symbolic::Symbolic sym(expr, {"x", "y", "z"}, {});
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == "-0.1 + 2.0*x + 0.2*x*y + 4*y**(-1)");
+  REQUIRE(sym.diff("x") == "2.0 + 0.2*y");
+  REQUIRE(sym.diff("y") == "0.2*x - 4*y**(-2)");
+  REQUIRE(sym.diff("z") == "0");
+}
+
+TEST_CASE("3*x + alpha*x - a*n/x: one var, constants", "[symbolic]") {
+  std::map<std::string, double> constants;
+  constants["alpha"] = 0.5;
+  constants["a"] = 0.8 + 1e-11;
+  constants["n"] = -23;
+  constants["Unused"] = -99;
+  std::string expr = "3*x + alpha*x - a*n*x";
+  symbolic::Symbolic sym(expr, {"x", "y"}, constants);
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == "21.90000000023*x");
+  REQUIRE(sym.diff("x") == "21.90000000023");
+  REQUIRE(sym.diff("y") == "0");
+}

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -1270,6 +1270,29 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="tabDUNE">
+        <attribute name="title">
+         <string>DUNE</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QTextBrowser" name="txtDUNE">
+           <property name="lineWrapMode">
+            <enum>QTextEdit::NoWrap</enum>
+           </property>
+           <property name="acceptRichText">
+            <bool>false</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByMouse</set>
+           </property>
+           <property name="openLinks">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>
@@ -1301,6 +1324,7 @@
     <addaction name="action_Open_SBML_file"/>
     <addaction name="menuOpen_example_SBML_file"/>
     <addaction name="action_Save_SBML_file"/>
+    <addaction name="actionExport_Dune_ini_file"/>
     <addaction name="actionE_xit"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -1468,6 +1492,14 @@
   <action name="actionliver_simplified_2">
    <property name="text">
     <string>&amp;liver-simplified</string>
+   </property>
+  </action>
+  <action name="actionExport_Dune_ini_file">
+   <property name="text">
+    <string>Export &amp;Dune ini file</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
  - add tab showing DUNE ini file
  - add File->export DUNE ini file menu option
  - generated DUNE ini file contains
     - list of compartments
     - reaction terms as infix strings
     - Jacobian of reactions
     - all state variables relabelled to u_i vector coefficients
     - all functions inlined
     - all constants substituted
     - initial concentration & diffusion coeffs
  - refactor reactions into a Reaction class
     - constructs each reaction term as string + map of constants
     - can then be used by Simulate to compile/evalute them
     - or by SbmlWrapper to construct DUNE ini file
  - add a Symbolic class to do symbolic algebra
     - relabel variables e.g. to "u_0,u_1,.." for dune
     - differentiate analytically (e.g. for DUNE Jacobian)
     - constant folding / evaluation to simplify expressions
     - uses the SymEngine library (which also depends on gmp)

also

  - use mingw64 from MSYS2 on appveyor
  - include libSBML headers as system headers
  - added symengine and gmp dependencies