### PR TITLE
mesh improvements

### DIFF
--- a/inc/colours.hpp
+++ b/inc/colours.hpp
@@ -1,0 +1,24 @@
+// a set of default colours for display purposes
+
+#pragma once
+
+#include <vector>
+
+#include <QColor>
+
+namespace colours {
+
+class indexedColours {
+ private:
+  const std::vector<QColor> colours{
+      {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
+      {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},
+      {210, 245, 60}, {250, 190, 190}, {0, 128, 128},  {230, 190, 255},
+      {170, 110, 40}, {255, 250, 200}, {128, 0, 0},    {170, 255, 195},
+      {128, 128, 0},  {255, 215, 180}, {0, 0, 128},    {128, 128, 128}};
+
+ public:
+  const QColor &operator[](std::size_t i) const;
+};
+
+}  // namespace colours

--- a/inc/mainwindow.hpp
+++ b/inc/mainwindow.hpp
@@ -72,7 +72,15 @@ class MainWindow : public QMainWindow {
 
   void btnChangeCompartment_clicked();
 
-  void btnGenerateMesh_clicked();
+  void tabCompartmentGeometry_currentChanged(int index);
+
+  void spinBoundaryIndex_valueChanged(int value);
+
+  void spinMaxBoundaryPoints_valueChanged(int value);
+
+  void spinMaxTriangleArea_valueChanged(int value);
+
+  void generateMesh(int value = 0);
 
   void listCompartments_currentTextChanged(const QString &currentText);
 

--- a/inc/mesh.hpp
+++ b/inc/mesh.hpp
@@ -52,36 +52,54 @@ struct Boundary {
 
 class Mesh {
  private:
-  const std::vector<QPoint> nearestNeighbourDirectionPoints = {
+  std::size_t defaultBoundaryMaxPoints = 12;
+  std::size_t defaultCompartmentMaxTriangleArea = 40;
+  std::vector<QPoint> nearestNeighbourDirectionPoints = {
       QPoint(1, 0), QPoint(-1, 0), QPoint(0, 1),  QPoint(0, -1),
       QPoint(1, 1), QPoint(1, -1), QPoint(-1, 1), QPoint(-1, -1)};
+  // input data
   QImage img;
+  std::vector<QPointF> compartmentInteriorPoints;
+  std::vector<std::size_t> boundaryMaxPoints;
+  std::vector<std::size_t> compartmentMaxTriangleArea;
+  // output data
+  std::vector<Boundary> fullBoundaries;
   std::vector<Boundary> boundaries;
   std::vector<QPointF> vertices;
   std::vector<std::vector<QTriangleF>> triangles;
   std::vector<std::array<std::size_t, 4>> triangleIDs;
-  std::size_t maxPoints;
   inline int pointToIndex(const QPoint& p) const {
     return p.x() + img.width() * p.y();
   }
   inline QPoint indexToPoint(int i) const {
     return QPoint(i % img.width(), i / img.width());
   }
-  void simplifyBoundary(Boundary& boundaryPoints) const;
-  void constructBoundaries();
-  void constructMesh(const std::vector<QPointF>& regions,
-                     double maxTriangleArea);
+  void simplifyBoundary(Boundary& boundaryPoints, std::size_t maxPoints) const;
+  void updateBoundary(std::size_t boundaryIndex);
+  void updateBoundaries();
+  void constructFullBoundaries();
+  void constructMesh();
 
  public:
-  explicit Mesh(const QImage& image, const std::vector<QPointF>& regions = {},
-                double maxTriangleArea = -1,
-                std::size_t maxBoundaryPoints = 13);
+  Mesh() = default;
+  explicit Mesh(const QImage& image,
+                const std::vector<QPointF>& interiorPoints = {},
+                const std::vector<std::size_t>& maxPoints = {},
+                const std::vector<std::size_t>& maxTriangleArea = {});
+  void setBoundaryMaxPoints(std::size_t boundaryIndex, std::size_t maxPoints);
+  std::size_t getBoundaryMaxPoints(std::size_t boundaryIndex) const;
+  void setCompartmentMaxTriangleArea(std::size_t compartmentIndex,
+                                     std::size_t maxTriangleArea);
+  std::size_t getCompartmentMaxTriangleArea(std::size_t compartmentIndex) const;
   const std::vector<Boundary>& getBoundaries() const { return boundaries; }
   const std::vector<QPointF>& getVertices() const { return vertices; }
   const std::vector<std::vector<QTriangleF>>& getTriangles() const {
     return triangles;
   }
-  QString getGMSH() const;
+  QImage getBoundariesImage(const QSize& size,
+                            std::size_t boldBoundaryIndex) const;
+  QImage getMeshImage(const QSize& size, std::size_t compartmentIndex) const;
+  QString getGMSH(double pixelPhysicalSize = 1.0) const;
 };
 
 }  // namespace mesh

--- a/inc/sbml.hpp
+++ b/inc/sbml.hpp
@@ -18,6 +18,7 @@
 #include "sbml/packages/spatial/extension/SpatialExtension.h"
 
 #include "geometry.hpp"
+#include "mesh.hpp"
 
 namespace sbml {
 
@@ -68,6 +69,9 @@ class SbmlDocWrapper {
   QRgb getCompartmentColour(const QString &compartmentID) const;
   void setCompartmentColour(const QString &compartmentID, QRgb colour,
                             bool updateSBML = true);
+  // mesh
+  mesh::Mesh mesh;
+  void updateMesh();
   QPointF getCompartmentInteriorPoint(const QString &compartmentID) const;
   void setCompartmentInteriorPoint(const QString &compartmentID,
                                    const QPointF &point);
@@ -132,22 +136,6 @@ class SbmlDocWrapper {
   std::vector<std::vector<std::pair<QPoint, QPoint>>> membranePairs;
   std::map<QString, std::size_t> mapMembraneToIndex;
   std::map<QString, QImage> mapMembraneToImage;
-};
-
-// a set of default colours for display purposes
-class defaultSpeciesColours {
- private:
-  const std::vector<QColor> colours{
-      {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
-      {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},
-      {210, 245, 60}, {250, 190, 190}, {0, 128, 128},  {230, 190, 255},
-      {170, 110, 40}, {255, 250, 200}, {128, 0, 0},    {170, 255, 195},
-      {128, 128, 0},  {255, 215, 180}, {0, 0, 128},    {128, 128, 128}};
-
- public:
-  const QColor &operator[](std::size_t i) const {
-    return colours[i % colours.size()];
-  }
 };
 
 }  // namespace sbml

--- a/spatial-model-editor.pro
+++ b/spatial-model-editor.pro
@@ -10,10 +10,11 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # disable qtDebug() output in release build
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 
-CONFIG += c++11
+CONFIG += c++14
 
 SOURCES += \
     src/main.cpp \
+    src/colours.cpp \
     src/dune.cpp \
     src/geometry.cpp \
     src/mainwindow.cpp \
@@ -28,6 +29,7 @@ SOURCES += \
     src/version.cpp
 
 HEADERS += \
+    inc/colours.hpp \
     inc/dune.hpp \
     inc/geometry.hpp \
     inc/exprtk_wrapper.hpp \

--- a/src/colours.cpp
+++ b/src/colours.cpp
@@ -1,0 +1,9 @@
+#include "colours.hpp"
+
+namespace colours {
+
+const QColor& indexedColours::operator[](std::size_t i) const {
+  return colours[i % colours.size()];
+}
+
+}  // namespace colours

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3,7 +3,9 @@
 #include <set>
 
 #include <QDebug>
+#include <QPainter>
 
+#include "colours.hpp"
 #include "logger.hpp"
 
 static int qPointToInt(const QPoint& point) {
@@ -131,13 +133,17 @@ BoundaryBoolGrid::BoundaryBoolGrid(const QImage& inputImage)
       }
       int largestColIndex = *colours.rbegin();
       std::size_t neighbours = colours.size() - 1;
+      // QImage has (0,0) in top left
+      // we want to generate mesh with (0,0) in bottom left
+      // so here we invert the y value
+      QPoint bottomLeftIndexedPoint = QPoint(x, img.height() - 1 - y);
       if (neighbours == 1 && largestColIndex == colIndex) {
         // - point has one other colour as neighbour
         // - this colour index is the larger
-        setBoundaryPoint(point);
+        setBoundaryPoint(bottomLeftIndexedPoint);
       } else if (neighbours > 1) {
         // - point has multiple colour neighbours
-        setBoundaryPoint(point, true);
+        setBoundaryPoint(bottomLeftIndexedPoint, true);
       }
     }
   }
@@ -149,19 +155,83 @@ static double triangleArea(const QPoint& a, const QPoint& b, const QPoint& c) {
                          b.x() * a.y() - c.x() * b.y() - a.x() * c.y());
 }
 
-Mesh::Mesh(const QImage& image, const std::vector<QPointF>& regions,
-           double maxTriangleArea, std::size_t maxBoundaryPoints)
-    : img(image), maxPoints(maxBoundaryPoints) {
-  constructBoundaries();
-  constructMesh(regions, maxTriangleArea);
+Mesh::Mesh(const QImage& image, const std::vector<QPointF>& interiorPoints,
+           const std::vector<std::size_t>& maxPoints,
+           const std::vector<std::size_t>& maxTriangleArea)
+    : img(image),
+      compartmentInteriorPoints(interiorPoints),
+      boundaryMaxPoints(maxPoints),
+      compartmentMaxTriangleArea(maxTriangleArea) {
+  constructFullBoundaries();
+  spdlog::info("Mesh::Mesh :: found {} boundaries", fullBoundaries.size());
+  for (const auto& boundary : fullBoundaries) {
+    spdlog::info("Mesh::Mesh ::   - {} points, loop={}", boundary.points.size(),
+                 boundary.isLoop);
+  }
+  boundaries = fullBoundaries;
+  if (boundaryMaxPoints.empty()) {
+    // if boundary points not specified use default value
+    boundaryMaxPoints = std::vector<std::size_t>(fullBoundaries.size(),
+                                                 defaultBoundaryMaxPoints);
+    spdlog::info(
+        "Mesh::Mesh :: no boundaryMaxPoints values specified, using default "
+        "value: {}",
+        defaultBoundaryMaxPoints);
+  }
+  updateBoundaries();
+  spdlog::info("Mesh::Mesh :: simplified {} boundaries", boundaries.size());
+  for (const auto& boundary : boundaries) {
+    spdlog::info("Mesh::Mesh ::   - {} points, loop={}", boundary.points.size(),
+                 boundary.isLoop);
+  }
+  if (compartmentMaxTriangleArea.empty()) {
+    // if triangle areas not specified use default value
+    compartmentMaxTriangleArea = std::vector<std::size_t>(
+        interiorPoints.size(), defaultCompartmentMaxTriangleArea);
+    spdlog::info(
+        "Mesh::Mesh :: no max triangle areas specified, using default value: "
+        "{}",
+        defaultCompartmentMaxTriangleArea);
+  }
+  // todo: holes?
+  constructMesh();
 }
 
-// Visvalingam polyline simplification
+void Mesh::setBoundaryMaxPoints(std::size_t boundaryIndex,
+                                std::size_t maxPoints) {
+  spdlog::info(
+      "Mesh::setBoundaryMaxPoint :: boundaryIndex {}: max points {} -> {}",
+      boundaryIndex, boundaryMaxPoints.at(boundaryIndex), maxPoints);
+  boundaryMaxPoints.at(boundaryIndex) = maxPoints;
+  updateBoundary(boundaryIndex);
+}
+
+std::size_t Mesh::getBoundaryMaxPoints(std::size_t boundaryIndex) const {
+  return boundaryMaxPoints.at(boundaryIndex);
+}
+
+void Mesh::setCompartmentMaxTriangleArea(std::size_t compartmentIndex,
+                                         std::size_t maxTriangleArea) {
+  spdlog::info(
+      "Mesh::setCompartmentMaxTriangleArea :: compIndex {}: max triangle area "
+      "{} -> {}",
+      compartmentIndex, compartmentMaxTriangleArea.at(compartmentIndex),
+      maxTriangleArea);
+  compartmentMaxTriangleArea.at(compartmentIndex) = maxTriangleArea;
+  constructMesh();
+}
+
+std::size_t Mesh::getCompartmentMaxTriangleArea(
+    std::size_t compartmentIndex) const {
+  return compartmentMaxTriangleArea.at(compartmentIndex);
+}
+
+// in-place Visvalingam polyline simplification
 // NB: very inefficient & not quite right:
 // when recalculating triangle, if new one is smaller
 // than the one just removed, should use the just-removed value
 // for the area - but good enough for now
-void Mesh::simplifyBoundary(Boundary& bp) const {
+void Mesh::simplifyBoundary(Boundary& bp, std::size_t maxPoints) const {
   std::size_t size = bp.points.size();
   double minArea = std::numeric_limits<double>::max();
   double totalArea = 0;
@@ -187,10 +257,6 @@ void Mesh::simplifyBoundary(Boundary& bp) const {
     totalArea += area;
     ++iter;
   }
-  // use total area of triangles as a measure of the complexity
-  spdlog::debug("Mesh::simplifyBoundary :: {} points, area {}", size,
-                totalArea);
-
   if (size < 4 || (minArea > 0 && size <= maxPoints)) {
     // if we have less than 4 points,
     // or less than maxPoints and the minArea is non-zero,
@@ -200,19 +266,34 @@ void Mesh::simplifyBoundary(Boundary& bp) const {
   // remove point with smallest triangle
   bp.points.erase(iterSmallest);
   // repeat
-  simplifyBoundary(bp);
+  simplifyBoundary(bp, maxPoints);
 }
 
-void Mesh::constructBoundaries() {
-  boundaries.clear();
+void Mesh::updateBoundary(std::size_t boundaryIndex) {
+  // reset boundary to full un-simplified one
+  boundaries.at(boundaryIndex) = fullBoundaries.at(boundaryIndex);
+  // simplify it
+  simplifyBoundary(boundaries.at(boundaryIndex),
+                   boundaryMaxPoints.at(boundaryIndex));
+}
+
+void Mesh::updateBoundaries() {
+  for (std::size_t i = 0; i < boundaries.size(); ++i) {
+    updateBoundary(i);
+  }
+}
+
+void Mesh::constructFullBoundaries() {
+  fullBoundaries.clear();
 
   // add image boundary loop
-  boundaries.emplace_back();
-  boundaries.back().points.push_back(QPoint(0, 0));
-  boundaries.back().points.push_back(QPoint(0, img.height() - 1));
-  boundaries.back().points.push_back(QPoint(img.width() - 1, img.height() - 1));
-  boundaries.back().points.push_back(QPoint(img.width() - 1, 0));
-  boundaries.back().isLoop = true;
+  fullBoundaries.emplace_back();
+  fullBoundaries.back().points.push_back(QPoint(0, 0));
+  fullBoundaries.back().points.push_back(QPoint(0, img.height() - 1));
+  fullBoundaries.back().points.push_back(
+      QPoint(img.width() - 1, img.height() - 1));
+  fullBoundaries.back().points.push_back(QPoint(img.width() - 1, 0));
+  fullBoundaries.back().isLoop = true;
 
   // construct bool grid of all boundary points
   BoundaryBoolGrid bbg(img);
@@ -234,7 +315,6 @@ void Mesh::constructBoundaries() {
     bbg.visitPoint(fp);
     for (const auto& dfp : nearestNeighbourDirectionPoints) {
       if (bbg.isBoundary(fp + dfp) && bbg.fixedPointCounter.at(i) > 0) {
-        qDebug() << "fp start" << fp;
         Boundary boundary;
         boundary.points.push_back(fp);
         QPoint currPoint = fp + dfp;
@@ -247,8 +327,6 @@ void Mesh::constructBoundaries() {
             // we are outside of the initial fixed point radius
             boundary.points.push_back(currPoint);
           }
-          qDebug() << currPoint;
-          qDebug() << bbg.isFixed(currPoint);
           bbg.visitPoint(currPoint);
           for (const auto& directionPoint : nearestNeighbourDirectionPoints) {
             if (bbg.isBoundary(currPoint + directionPoint)) {
@@ -260,8 +338,9 @@ void Mesh::constructBoundaries() {
         // add final fixed point to boundary line
         boundary.points.push_back(bbg.getFixedPoint(currPoint));
         // we now have a line between two fixed points
-        simplifyBoundary(boundary);
-        boundaries.push_back(boundary);
+        // remove any degenerate points to give the fullBoundary
+        simplifyBoundary(boundary, std::numeric_limits<std::size_t>::max());
+        fullBoundaries.push_back(boundary);
         --bbg.fixedPointCounter[i];
         --bbg.fixedPointCounter[bbg.getFixedPointIndex(currPoint)];
       }
@@ -290,14 +369,12 @@ void Mesh::constructBoundaries() {
       }
     }
     if (foundStartPoint) {
-      qDebug() << "Start" << startPoint;
       Boundary boundary;
       boundary.isLoop = true;
       QPoint currPoint = startPoint;
       bool finished = false;
       while (!finished) {
         boundary.points.push_back(currPoint);
-        qDebug() << currPoint;
         finished = true;
         bbg.visitPoint(currPoint);
         for (const auto& directionPoint : nearestNeighbourDirectionPoints) {
@@ -309,14 +386,14 @@ void Mesh::constructBoundaries() {
           }
         }
       }
-      simplifyBoundary(boundary);
-      boundaries.push_back(boundary);
+      // remove any degenerate points
+      simplifyBoundary(boundary, std::numeric_limits<std::size_t>::max());
+      fullBoundaries.push_back(boundary);
     }
   } while (foundStartPoint);
 }
 
-void Mesh::constructMesh(const std::vector<QPointF>& regions,
-                         double maxTriangleArea) {
+void Mesh::constructMesh() {
   // points may be used by multiple boundary lines,
   // so first construct a set of unique points with map to their index
   std::map<int, std::size_t> mapPointToIndex;
@@ -349,10 +426,11 @@ void Mesh::constructMesh(const std::vector<QPointF>& regions,
       boundarySegmentsVector.back().push_back({i0, i1});
     }
   }
-  // interior point for each compartment
+  // interior point & max triangle area for each compartment
   std::vector<triangle_wrapper::Compartment> compartments;
-  for (const auto& interiorPoint : regions) {
-    compartments.emplace_back(interiorPoint, maxTriangleArea);
+  for (std::size_t i = 0; i < compartmentInteriorPoints.size(); ++i) {
+    compartments.emplace_back(compartmentInteriorPoints[i],
+                              compartmentMaxTriangleArea[i]);
   }
   // generate mesh
   triangle_wrapper::Triangulate triangulate(
@@ -370,9 +448,95 @@ void Mesh::constructMesh(const std::vector<QPointF>& regions,
   }
 }
 
-QString Mesh::getGMSH() const {
-  // note: gmsh indexing starts with 1
-  // note: gmsh (0,0) is bottom left, but in Qt it is top left, so flip y coords
+static double getScaleFactor(const QImage& img, const QSize& size) {
+  double scaleFactor = 1;
+  if (img.width() * size.height() > img.height() * size.width()) {
+    scaleFactor = static_cast<double>(size.width() - 2) /
+                  static_cast<double>(img.width());
+  } else {
+    scaleFactor = static_cast<double>(size.height() - 2) /
+                  static_cast<double>(img.height());
+  }
+  return scaleFactor;
+}
+
+QImage Mesh::getBoundariesImage(const QSize& size,
+                                std::size_t boldBoundaryIndex) const {
+  double scaleFactor = getScaleFactor(img, size);
+  // construct boundary image
+  QImage boundaryImage(static_cast<int>(scaleFactor * img.width()),
+                       static_cast<int>(scaleFactor * img.height()),
+                       QImage::Format_ARGB32);
+  boundaryImage.fill(QColor(0, 0, 0, 0));
+
+  QPainter p(&boundaryImage);
+  // draw boundary lines
+  for (std::size_t k = 0; k < boundaries.size(); ++k) {
+    const auto& boundary = boundaries[k];
+    std::size_t maxPoint = boundary.points.size();
+    if (!boundary.isLoop) {
+      --maxPoint;
+    }
+    int penSize = 2;
+    if (k == boldBoundaryIndex) {
+      penSize = 5;
+    }
+    p.setPen(QPen(colours::indexedColours()[k], penSize));
+    for (std::size_t i = 0; i < maxPoint; ++i) {
+      p.drawEllipse(boundary.points[i] * scaleFactor, penSize, penSize);
+      p.drawLine(
+          boundary.points[i] * scaleFactor,
+          boundary.points[(i + 1) % boundary.points.size()] * scaleFactor);
+    }
+  }
+  p.end();
+  // flip image on y-axis, to change (0,0) from bottom-left to top-left corner
+  return boundaryImage.mirrored(false, true);
+}
+
+QImage Mesh::getMeshImage(const QSize& size,
+                          std::size_t compartmentIndex) const {
+  double scaleFactor = getScaleFactor(img, size);
+  // construct mesh image
+  QImage meshImage(static_cast<int>(scaleFactor * img.width()),
+                   static_cast<int>(scaleFactor * img.height()),
+                   QImage::Format_ARGB32);
+  meshImage.fill(QColor(0, 0, 0, 0));
+  QPainter p(&meshImage);
+  // draw vertices
+  p.setPen(QPen(Qt::red, 2));
+  for (const auto& v : vertices) {
+    p.drawEllipse(v * scaleFactor, 2, 2);
+  }
+  // fill triangles
+  for (const auto& t : triangles[compartmentIndex]) {
+    QPainterPath path;
+    path.moveTo(t.back() * scaleFactor);
+    for (const auto& tp : t) {
+      path.lineTo(tp * scaleFactor);
+    }
+    p.fillPath(path, QBrush(QColor(235, 235, 255)));
+  }
+  // draw triangle lines
+  for (std::size_t k = 0; k < triangles.size(); ++k) {
+    p.setPen(QPen(Qt::gray, 1, Qt::DotLine));
+    if (k == compartmentIndex) {
+      p.setPen(QPen(Qt::black, 3, Qt::SolidLine));
+    }
+    for (const auto& t : triangles[k]) {
+      p.drawLine(t[0] * scaleFactor, t[1] * scaleFactor);
+      p.drawLine(t[1] * scaleFactor, t[2] * scaleFactor);
+      p.drawLine(t[2] * scaleFactor, t[0] * scaleFactor);
+    }
+  }
+  p.end();
+
+  return meshImage.mirrored(false, true);
+}
+
+QString Mesh::getGMSH(double pixelPhysicalSize) const {
+  // note: gmsh indexing starts with 1, so need to add 1 to all indices
+  // note: gmsh (0,0) is bottom left, but in Qt it is top left, so flip y
   // todo: use actual xy values in physical units instead of pixels
   QString msh;
   msh.append("$MeshFormat\n");
@@ -383,20 +547,31 @@ QString Mesh::getGMSH() const {
   for (std::size_t i = 0; i < vertices.size(); ++i) {
     msh.append(QString("%1 %2 %3 %4\n")
                    .arg(i + 1)
-                   .arg(vertices[i].x())
-                   .arg(img.height() - 1 - vertices[i].y())
+                   .arg(vertices[i].x() * pixelPhysicalSize)
+                   .arg(vertices[i].y() * pixelPhysicalSize)
                    .arg(0));
   }
   msh.append("$EndNodes\n");
   msh.append("$Elements\n");
   msh.append(QString("%1\n").arg(triangleIDs.size()));
-  for (std::size_t i = 0; i < triangleIDs.size(); ++i) {
-    msh.append(QString("%1 2 2 %2 %2 %3 %4 %5\n")
-                   .arg(i + 1)
-                   .arg(triangleIDs[i][0] + 1)
-                   .arg(triangleIDs[i][1] + 1)
-                   .arg(triangleIDs[i][2] + 1)
-                   .arg(triangleIDs[i][3] + 1));
+  // order triangles by compartment index
+  std::size_t maxCompIndex = 0;
+  for (const auto& t : triangleIDs) {
+    maxCompIndex = std::max(t[0], maxCompIndex);
+  }
+  std::size_t triangleIndex = 1;
+  for (std::size_t compIndex = 0; compIndex <= maxCompIndex; ++compIndex) {
+    for (const auto& t : triangleIDs) {
+      if (t[0] == compIndex) {
+        msh.append(QString("%1 2 2 %2 %2 %3 %4 %5\n")
+                       .arg(triangleIndex)
+                       .arg(t[0] + 1)
+                       .arg(t[1] + 1)
+                       .arg(t[2] + 1)
+                       .arg(t[3] + 1));
+        ++triangleIndex;
+      }
+    }
   }
   msh.append("$EndElements\n");
   return msh;

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.4.1";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.4.2";

--- a/test.pro
+++ b/test.pro
@@ -7,7 +7,7 @@ TEMPLATE = app
 
 DEFINES += QT_DEPRECATED_WARNINGS
 
-CONFIG += c++11
+CONFIG += c++14
 
 SOURCES += \
     test/src/main.cpp \
@@ -21,6 +21,7 @@ SOURCES += \
     test/src/test_sbml.cpp \
     test/src/test_simulate.cpp \
     test/src/test_symbolic.cpp \
+    src/colours.cpp \
     src/dune.cpp \
     src/geometry.cpp \
     src/mainwindow.cpp \

--- a/test/src/test_mainwindow.cpp
+++ b/test/src/test_mainwindow.cpp
@@ -7,6 +7,7 @@
 #include "sbml_test_data/ABtoC.hpp"
 #include "sbml_test_data/very_simple_model.hpp"
 
+#include "colours.hpp"
 #include "logger.hpp"
 #include "qlabelmousetracker.hpp"
 
@@ -422,14 +423,14 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
                     key_delay);
   }
   REQUIRE(ui.lblSpeciesColour->pixmap()->toImage().pixelColor(0, 0) ==
-          sbml::defaultSpeciesColours()[3]);
+          colours::indexedColours()[3]);
   // just click Enter, so accept default colour, ie no-op
   mwt.setMessage();
   mwt.start();
   QTest::mouseClick(ui.btnChangeSpeciesColour, Qt::LeftButton,
                     Qt::KeyboardModifier(), QPoint(), key_delay);
   REQUIRE(ui.lblSpeciesColour->pixmap()->toImage().pixelColor(0, 0) ==
-          sbml::defaultSpeciesColours()[3]);
+          colours::indexedColours()[3]);
 
   // display reactions tab
   QTest::keyPress(w.windowHandle(), Qt::Key_Tab, Qt::ControlModifier,

--- a/test/src/test_sbml.cpp
+++ b/test/src/test_sbml.cpp
@@ -8,6 +8,7 @@
 #include "sbml_test_data/very_simple_model.hpp"
 #include "sbml_test_data/yeast_glycolysis.hpp"
 
+#include "colours.hpp"
 #include "logger.hpp"
 
 void createSBMLlvl2doc(const std::string &filename) {
@@ -363,9 +364,9 @@ SCENARIO("SBML test data: ABtoC.xml", "[sbml][non-gui]") {
         REQUIRE(s.reactions.at("comp")[0] == "r1");
       }
       THEN("species have default colours") {
-        REQUIRE(s.getSpeciesColour("A") == sbml::defaultSpeciesColours()[0]);
-        REQUIRE(s.getSpeciesColour("B") == sbml::defaultSpeciesColours()[1]);
-        REQUIRE(s.getSpeciesColour("C") == sbml::defaultSpeciesColours()[2]);
+        REQUIRE(s.getSpeciesColour("A") == colours::indexedColours()[0]);
+        REQUIRE(s.getSpeciesColour("B") == colours::indexedColours()[1]);
+        REQUIRE(s.getSpeciesColour("C") == colours::indexedColours()[2]);
       }
       WHEN("species colours changed") {
         QColor newA = QColor(12, 12, 12);

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -298,7 +298,7 @@
                  <string>The boundaries of the geometry of the compartments</string>
                 </property>
                 <property name="currentIndex">
-                 <number>1</number>
+                 <number>2</number>
                 </property>
                 <widget class="QWidget" name="tabCompartmentImage">
                  <attribute name="title">
@@ -339,42 +339,48 @@
                 </widget>
                 <widget class="QWidget" name="tabCompartmentBoundary">
                  <attribute name="title">
-                  <string>Boundary</string>
+                  <string>Boundaries</string>
                  </attribute>
                  <layout class="QHBoxLayout" name="horizontalLayout_12">
                   <item>
                    <layout class="QGridLayout" name="gridLayout_3">
                     <item row="1" column="1">
-                     <widget class="QLineEdit" name="txtMaxBoundaryPoints">
-                      <property name="inputMethodHints">
-                       <set>Qt::ImhFormattedNumbersOnly</set>
+                     <widget class="QSpinBox" name="spinBoundaryIndex">
+                      <property name="wrapping">
+                       <bool>true</bool>
                       </property>
-                      <property name="text">
-                       <string>10</string>
-                      </property>
-                      <property name="maxLength">
-                       <number>16</number>
-                      </property>
-                      <property name="clearButtonEnabled">
-                       <bool>false</bool>
+                      <property name="maximum">
+                       <number>0</number>
                       </property>
                      </widget>
                     </item>
                     <item row="1" column="2">
-                     <widget class="QPushButton" name="btnGenerateBoundary">
+                     <widget class="QLabel" name="lblMaxBoundaryPointsLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
                       <property name="text">
-                       <string>Generate &amp;boundary</string>
+                       <string>Max points:</string>
                       </property>
                      </widget>
                     </item>
                     <item row="1" column="0">
-                     <widget class="QLabel" name="lblMaxBoundaryPoints">
+                     <widget class="QLabel" name="lblBoundaryIndexLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
                       <property name="text">
-                       <string>Max boundary points:</string>
+                       <string>Boundary:</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="0" column="0" colspan="3">
+                    <item row="0" column="0" colspan="5">
                      <widget class="QLabel" name="lblCompBoundary">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -383,15 +389,14 @@
                        </sizepolicy>
                       </property>
                       <property name="toolTip">
-                       <string>The mesh representing the geometry of the compartment</string>
+                       <string>The boundary lines separating the compartments</string>
                       </property>
                       <property name="statusTip">
-                       <string>The mesh representing the geometry of the compartment</string>
+                       <string>The boundary lines separating the compartments</string>
                       </property>
                       <property name="whatsThis">
-                       <string>&lt;h4&gt;Compartment Geometry: Mesh&lt;/h4&gt;
-&lt;p&gt;The compartment geometry mesh is generated from all the pixels in the compartment geometry image on the left that have the colour assigned to this compartment&lt;/p&gt;
-&lt;p&gt;To change the geometry, click 'Select compartment geometry...', then click on the geometry image on the left.&lt;/p&gt;</string>
+                       <string>&lt;h4&gt;Compartment Geometry: Boundaries&lt;/h4&gt;
+&lt;p&gt;The boundary lines separate the compartments. Each line consists of a set of vertices connected by straight lines, and these vertices will also be included in the final mesh.&lt;/p&gt;</string>
                       </property>
                       <property name="text">
                        <string>none</string>
@@ -401,6 +406,16 @@
                       </property>
                       <property name="alignment">
                        <set>Qt::AlignCenter</set>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="3" colspan="2">
+                     <widget class="QSpinBox" name="spinMaxBoundaryPoints">
+                      <property name="minimum">
+                       <number>3</number>
+                      </property>
+                      <property name="value">
+                       <number>12</number>
                       </property>
                      </widget>
                     </item>
@@ -415,36 +430,6 @@
                  <layout class="QVBoxLayout" name="verticalLayout_3">
                   <item>
                    <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="1" column="1">
-                     <widget class="QLineEdit" name="txtMaxTriangleArea">
-                      <property name="inputMethodHints">
-                       <set>Qt::ImhFormattedNumbersOnly</set>
-                      </property>
-                      <property name="text">
-                       <string>15</string>
-                      </property>
-                      <property name="maxLength">
-                       <number>16</number>
-                      </property>
-                      <property name="clearButtonEnabled">
-                       <bool>false</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="2">
-                     <widget class="QPushButton" name="btnGenerateMesh">
-                      <property name="text">
-                       <string>Generate &amp;mesh</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QLabel" name="label">
-                      <property name="text">
-                       <string>Max triangle area:</string>
-                      </property>
-                     </widget>
-                    </item>
                     <item row="0" column="0" colspan="3">
                      <widget class="QLabel" name="lblCompMesh">
                       <property name="sizePolicy">
@@ -472,6 +457,32 @@
                       </property>
                       <property name="alignment">
                        <set>Qt::AlignCenter</set>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="lblMaxTriangleAreaLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Max triangle area:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1" colspan="2">
+                     <widget class="QSpinBox" name="spinMaxTriangleArea">
+                      <property name="minimum">
+                       <number>2</number>
+                      </property>
+                      <property name="maximum">
+                       <number>9999</number>
+                      </property>
+                      <property name="value">
+                       <number>32</number>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
  - order triangles in gmsh output by compartment (as gmsh does)
  - flip y axis in gmsh output:
     - (0,0) is now the bottom-left corner
     - triangles are still oriented anti-clockwise
  - rescale x,y mesh pixel values to physical values
  - fill triangles in current mesh