### PR TITLE
add dune-copasi as static library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,19 +31,11 @@ matrix:
         - "jwm &"
         - sleep 1
       script:
-        # compile and run unit tests
-        - mkdir build-tests
-        - cd build-tests
-        - qmake CONFIG+=release ../test.pro
-        - make -j2
-        - ./test -d=yes
-        - cd ../
-        # compile release executable
-        - mkdir build
-        - cd build
-        - qmake CONFIG+=release ../spatial-model-editor.pro
-        - make -j2
+        - bash ci-build.sh release
+        # run tests
+        - ./build-tests/test -a
         # check dependencies of resulting executable
+        - cd build
         - ldd spatial-model-editor
     ##############################################################
     # osx release build: xcode 10.3, macOS 10.14 (target >= 10.12)
@@ -53,20 +45,14 @@ matrix:
       compiler: clang
       env:
         - DEPLOY_FILE="spatial-model-editor.dmg"
+      install:
+        - export MACOSX_DEPLOYMENT_TARGET=10.14
       script:
-        # compile and run unit tests
-        - mkdir build-tests
-        - cd build-tests
-        - qmake CONFIG+=release ../test.pro
-        - make -j2
-        - ./test.app/Contents/MacOS/test -d=yes
-        - cd ../
-        # compile release executable
-        - mkdir build
-        - cd build
-        - qmake CONFIG+=release ../spatial-model-editor.pro
-        - make -j2
+        - bash ci-build.sh release
+        # run tests
+        - ./build-tests/test.app/Contents/MacOS/test -a
         # check dependencies of resulting executable
+        - cd build
         - otool -L spatial-model-editor.app/Contents/MacOS/spatial-model-editor
         # package app dir as a .dmg
         - hdiutil create spatial-model-editor -fs HFS+ -srcfolder spatial-model-editor.app
@@ -100,20 +86,19 @@ matrix:
         - "jwm &"
         - sleep 1
       script:
-        # compile and run unit tests
-        - mkdir build-tests
-        - cd build-tests
-        - qmake CONFIG+=debug ../test.pro
-        - make -j2
+        # build tests & compile executable using sonar-source build wrapper
+        # only use 1 core to avoid running out of memory on travis
+        - bash ci-build.sh debug make "build-wrapper-linux-x86-64 --out-dir ../bw-output" 1
+        # run tests
         # make list of "leaks" from system libraries that LeakSanitizer should ignore
-        - echo "leak:libfontconfig.so" > suppr.txt
-        - echo "leak:libX11.so" >> suppr.txt
         # NB: can also set ASAN_OPTIONS=fast_unwind_on_malloc=0
         # to see more info about any memory leaks from linked libraries
-        - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./test -d=yes
+        - echo "leak:libfontconfig.so" > suppr.txt
+        - echo "leak:libX11.so" >> suppr.txt
+        - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./build-tests/test -a
         # generate gcov test coverage data for sonar-source & codecov.io
-        - mkdir ../gcov
-        - cd ../gcov
+        - mkdir gcov
+        - cd gcov
         - gcov -r -p ../build-tests/*.gcno
         # only want coverage data for src and inc folders
         - mkdir tmp
@@ -130,19 +115,10 @@ matrix:
         - bash <(curl -s https://codecov.io/bash) -X gcov -f "gcov/*"
         # get blame info for sonar-scanner
         - git fetch --unshallow
-        # compile debug version of executable
-        - mkdir build
-        - cd build
-        - qmake CONFIG+=debug ../spatial-model-editor.pro
-        # wrap make call with sonar-source build wrapper
-        - build-wrapper-linux-x86-64 --out-dir ../bw-output make -j2
-        - cd ../
         # upload to sonar-scanner
         - sonar-scanner -Dsonar.login=$SONAR_LOGIN
 
 before_script:
-  # on osx, this should make clang compile for target osx>=10.12
-  - export MACOSX_DEPLOYMENT_TARGET=10.12
   # install pre-compiled Qt5 binaries & static libraries to $QT5_INSTALL_PREFIX
   # note absolute paths currently hard coded in QT binaries
   # to override this, add a qt.conf file (https://doc.qt.io/qt-5/qt-conf.html#overriding-paths)
@@ -150,23 +126,14 @@ before_script:
   - sudo tar xzvf qt5-static-$TRAVIS_OS_NAME.tgz -C /
   # export path for Qt5 binaries
   - export PATH=$QT5_INSTALL_PREFIX/bin:$PATH
-  - qmake -v
-  # build qcustomplot library
-  - cd ext/qcustomplot
-  - qmake qcustomplot.pro
-  - make -j2
-  - ls
-  - cd ../../
-  # build triangle library
-  - cd ext/triangle
-  - make -j2
-  - cd ../../
   # download pre-compiled static libSBML (and other) libraries
   - cd ext
   - wget "https://github.com/lkeegan/libsbml-static/releases/latest/download/libsbml-static-$TRAVIS_OS_NAME.tgz"
   - tar xzvf libsbml-static-$TRAVIS_OS_NAME.tgz
   - wget "https://github.com/lkeegan/llvm-static/releases/latest/download/llvm-static-$TRAVIS_OS_NAME.tgz"
   - tar xzvf llvm-static-$TRAVIS_OS_NAME.tgz
+  - wget "https://github.com/lkeegan/dune-copasi-static/releases/latest/download/dune-copasi-static-$TRAVIS_OS_NAME.tgz"
+  - tar xzvf dune-copasi-static-$TRAVIS_OS_NAME.tgz
   - ls */*
   - cd ..
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ A GUI to convert non-spatial SBML models of bio-chemical reactions into 2d spati
 
 ## Project status
 
-### WP1a
-Allow the user to describe a spatial model: [WP1a status](https://github.com/lkeegan/spatial-model-editor/projects/1)
+### [WP1a](https://github.com/lkeegan/spatial-model-editor/projects/1)
+Allow the user to describe a spatial model: import/export SBML, add geometry, diffusion coefficients, spatially varying initial concentrations, etc.
 
-(a partial re-implementation of the spatial model editing part of <https://github.com/fbergmann/edit-spatial> using C++/Qt5, with all dependencies statically linked so that it can be supplied as a stand-alone compiled executable for linux, windows and osx.)
-
-### WP1b
-Translate the spatial model to a system of PDEs and simulate it: [WP1b status](https://github.com/lkeegan/spatial-model-editor/projects/2)
+### [WP1b](https://github.com/lkeegan/spatial-model-editor/projects/2)
+Translate the spatial model to a system of PDEs and simulate it: generate 2d triangular mesh, construct PDEs and Jacobians, simulate using DUNE, visualize simulation results, etc.
 
 ## Implementation details
 
@@ -47,6 +45,11 @@ Translate the spatial model to a system of PDEs and simulate it: [WP1b status](h
 -   _Documentation_: documentation is at <https://spatial-model-editor.readthedocs.io> and is compiled with each commit
 
 -   _Dependencies_: the result is a standalone GUI executable that includes these statically linked libraries:
+
+    -   dune-copasi Biochemical System Simulator <https://gitlab.dune-project.org/copasi/dune-copasi>
+
+        -   license: [GPL2 + runtime exception](https://dune-project.org/about/license/)
+        -   using pre-compiled binaries from <https://github.com/lkeegan/dune-copasi-static>
 
     -   libSBML <http://sbml.org/Software/libSBML>
 
@@ -97,6 +100,16 @@ Translate the spatial model to a system of PDEs and simulate it: [WP1b status](h
 
         -   license: "Private, research, and institutional use is free."
         -   included in source code
+
+    -   muParser <https://github.com/beltoforion/muparser>
+
+        -   license: [MIT](https://github.com/beltoforion/muparser/blob/master/License.txt)
+        -   using pre-compiled binaries from <https://github.com/lkeegan/libsbml-static>
+
+    -   libTIFF <http://www.libtiff.org/>
+
+        -   license: [MIT](http://www.libtiff.org/misc.html)
+        -   using pre-compiled binaries from <https://github.com/lkeegan/libsbml-static>
 
     -   Catch2 testing framework: <https://github.com/catchorg/Catch2>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,9 @@
 image:
   - Visual Studio 2015
 install:
-  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - set PATH=C:\msys64\usr\bin;%PATH%
 
 before_build:
-  - mingw32-make --version
-  - g++ --version
   # note absolute paths currently hard coded in QT binaries
   # to override this, add a qt.conf file (https://doc.qt.io/qt-5/qt-conf.html#overriding-paths)
   # install pre-compiled Qt5 binaries & static libraries
@@ -21,45 +19,27 @@ before_build:
   # export path for Qt5 binaries
   - set PATH=C:\projects\qt5-static\install\bin;%PATH%
   - qmake -v
-  # build qcustomplot library
-  - cd ext\qcustomplot
-  - qmake qcustomplot.pro
-  - mingw32-make -j2
-  - dir
-  - dir release
-  - mv release/* .
-  - dir
-  - cd ..\..\
-  # build triangle library
-  - cd ext\triangle
-  - mingw32-make -j2
-  - cd ..\..\
   # download pre-compiled static libSBML (and other) libraries
-  - cd ext
+  - cp -r * C:\msys64\home\appveyor\.
+  - dir C:\msys64\home\appveyor
+  - cd C:\msys64\home\appveyor\ext
   - appveyor DownloadFile "https://github.com/lkeegan/libsbml-static/releases/latest/download/libsbml-static-windows.zip"
   - 7z x libsbml-static-windows.zip
   - appveyor DownloadFile "https://github.com/lkeegan/llvm-static/releases/latest/download/llvm-static-windows.zip"
   - 7z x llvm-static-windows.zip
+  - appveyor DownloadFile "https://github.com/lkeegan/dune-copasi-static/releases/latest/download/dune-copasi-static-windows.zip"
+  - 7z x dune-copasi-static-windows.zip
   - dir
   - dir libsbml
-  - cd ..
+  - cd %APPVEYOR_BUILD_FOLDER%
 
 build_script:
-  # compile and run unit tests
-  - mkdir build-tests
-  - cd build-tests
-  - qmake CONFIG+=release ..\test.pro
-  - mingw32-make -j2
-  - release\test.exe -d=yes
-  - cd ..
-  # compile release executable
-  - mkdir build
-  - cd build
-  - qmake CONFIG+=release ..\spatial-model-editor.pro
-  - mingw32-make -j2
+  - bash -l ci-build.sh release mingw32-make
+  - C:\msys64\home\appveyor\build-tests\release\test.exe -a
+  - cp C:\msys64\home\appveyor\build\release\spatial-model-editor.exe %APPVEYOR_BUILD_FOLDER%\.
 
 artifacts:
-  - path: build/release/spatial-model-editor.exe
+  - path: spatial-model-editor.exe
     name: spatial-model-editor
 
 deploy:

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+BUILDTYPE=${1:-"release"}
+MAKECMD=${2:-"make"}
+MAKEWRAPPER=${3:-""}
+NPROCS=${4:-2}
+
+# make sure we get the right mingw64 version of g++ on appveyor
+PATH=/mingw64/bin:$PATH
+g++ --version
+qmake --version
+make --version
+
+# on osx, this should make clang compile for target osx>=10.12
+export MACOSX_DEPLOYMENT_TARGET=10.12
+
+# compile qcustomplot library
+cd ext/qcustomplot
+qmake qcustomplot.pro
+$MAKECMD -j$NPROCS
+ls
+cd ../../
+
+# compile triangle library
+cd ext/triangle
+$MAKECMD -j$NPROCS
+cd ../../
+
+# compile unit tests
+mkdir build-tests
+cd build-tests
+qmake ../test.pro CONFIG+=$BUILDTYPE
+$MAKECMD -j$NPROCS
+cd ../
+
+# compile executable
+mkdir build
+cd build
+qmake ../spatial-model-editor.pro CONFIG+=$BUILDTYPE
+$MAKEWRAPPER $MAKECMD -j$NPROCS
+cd ../

--- a/common.pri
+++ b/common.pri
@@ -69,10 +69,11 @@ unix: QMAKE_CXXFLAGS += -Wall -Wcast-align -Wconversion -Wdouble-promotion -Wext
 # on windows statically link libgcc & libstdc++ to avoid missing dll errors:
 win32: QMAKE_LFLAGS += -static-libgcc -static-libstdc++
 
-# on linux (but not mac) statically link libstdc++
-unix:!mac {
-    QMAKE_LFLAGS += -static-libstdc++
-}
+# on linux & mac statically link libstdc++
+unix: QMAKE_LFLAGS += -static-libstdc++
+
+# dune won't compile without c++17 features only available in osx >= 10.14
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
 
 # for linux debug build, remove optimizations, add coverage & ASAN
 CONFIG(debug, debug|release) {

--- a/ext/ext.pri
+++ b/ext/ext.pri
@@ -5,7 +5,10 @@ LIBS += \
     $$PWD/expat/lib/libexpat.a \
     $$PWD/symengine/lib/libsymengine.a \
     $$PWD/gmp/lib/libgmp.a \
+    $$PWD/gmp/lib/libgmpxx.a \
     $$PWD/spdlog/lib/spdlog/libspdlog.a \
+    $$PWD/libtiff/lib/libtiff.a \
+    $$PWD/muparser/lib/libmuparser.a \
 
 # these LLVM core static libraries are available pre-compiled from
 # https://github.com/lkeegan/llvm-static
@@ -47,9 +50,54 @@ LIBS += \
     $$PWD/llvm/lib/libLLVMDemangle.a \
 
 # these static libraries should be compiled first in their directories
+win32: LIBS += $$PWD/qcustomplot/release/libqcustomplot.a
+unix: LIBS += $$PWD/qcustomplot/libqcustomplot.a
+LIBS += $$PWD/triangle/triangle.o
+
+# dune requires some definitions
+DEFINES += DUNE_LOGGING_VENDORED_FMT=1 ENABLE_GMP=1 ENABLE_UG=1 HAVE_CONFIG_H MUPARSER_STATIC UG_USE_NEW_DIMENSION_DEFINES
+
+# on windows dune-copasi pdelab_expression_adapter doesn't compile unless we first remove unicode support
+# NB: may be due to compiling muparser without unicode support?
+DEFINES -= UNICODE _UNICODE
+
+# these static libraries are available pre-compiled from
+# https://github.com/lkeegan/dune-copasi-static
 LIBS += \
-    $$PWD/qcustomplot/libqcustomplot.a \
-    $$PWD/triangle/triangle.o \
+    $$PWD/dune/dune-logging/build-cmake/lib/libdune-logging.a \
+    $$PWD/dune/dune-logging/build-cmake/lib/libdune-logging-fmt.a \
+    $$PWD/dune/dune-pdelab/build-cmake/lib/libdunepdelab.a \
+    $$PWD/dune/dune-grid/build-cmake/lib/libdunegrid.a \
+    $$PWD/dune/dune-geometry/build-cmake/lib/libdunegeometry.a \
+    $$PWD/dune/dune-uggrid/build-cmake/lib/libugS3.a \
+    $$PWD/dune/dune-uggrid/build-cmake/lib/libugS2.a \
+    $$PWD/dune/dune-uggrid/build-cmake/lib/libugL.a \
+    $$PWD/dune/dune-common/build-cmake/lib/libdunecommon.a \
+    $$PWD/dune/dune-copasi/build-cmake/dune/copasi/libdune_copasi_lib.a \
+
+INCLUDEPATH += \
+    $$PWD/dune/dune-copasi \
+    $$PWD/dune/dune-copasi/build-cmake \
+    $$PWD/dune/dune-uggrid/low \
+    $$PWD/dune/dune-uggrid/gm \
+    $$PWD/dune/dune-uggrid/dom \
+    $$PWD/dune/dune-uggrid/np \
+    $$PWD/dune/dune-uggrid/ui \
+    $$PWD/dune/dune-uggrid/np/algebra \
+    $$PWD/dune/dune-uggrid/np/udm \
+    $$PWD/dune/dune-multidomaingrid \
+    $$PWD/dune/dune-pdelab \
+    $$PWD/dune/dune-logging \
+    $$PWD/dune/dune-common \
+    $$PWD/dune/dune-uggrid \
+    $$PWD/dune/dune-geometry \
+    $$PWD/dune/dune-typetree \
+    $$PWD/dune/dune-istl \
+    $$PWD/dune/dune-grid \
+    $$PWD/dune/dune-localfunctions \
+    $$PWD/dune/dune-functions \
+    $$PWD/dune/dune-logging/vendor/fmt/include \
+    $$PWD/dune/dune-logging/build-cmake/dune/vendor/fmt \
 
 # include QT and ext headers as system headers to suppress compiler warnings
 QMAKE_CXXFLAGS += \
@@ -60,6 +108,29 @@ QMAKE_CXXFLAGS += \
     -isystem "$$PWD/triangle" \
     -isystem "$$PWD/spdlog/include" \
     -isystem "$$PWD/llvm/include" \
+    -isystem "$$PWD/muparser/include" \
+    -isystem "$$PWD/libtiff/include" \
+    -isystem "$$PWD/build/dune-copasi" \
+    -isystem "$$PWD/build/dune-copasi/build-cmake" \
+    -isystem "$$PWD/build/dune-uggrid/low" \
+    -isystem "$$PWD/build/dune-uggrid/gm" \
+    -isystem "$$PWD/build/dune-uggrid/dom" \
+    -isystem "$$PWD/build/dune-uggrid/np" \
+    -isystem "$$PWD/build/dune-uggrid/ui" \
+    -isystem "$$PWD/build/dune-uggrid/np/algebra" \
+    -isystem "$$PWD/build/dune-uggrid/np/udm" \
+    -isystem "$$PWD/build/dune-multidomaingrid" \
+    -isystem "$$PWD/build/dune-pdelab" \
+    -isystem "$$PWD/build/dune-logging" \
+    -isystem "$$PWD/build/dune-common" \
+    -isystem "$$PWD/build/dune-uggrid" \
+    -isystem "$$PWD/build/dune-geometry" \
+    -isystem "$$PWD/build/dune-typetree" \
+    -isystem "$$PWD/build/dune-istl" \
+    -isystem "$$PWD/build/dune-grid" \
+    -isystem "$$PWD/build/dune-localfunctions" \
+    -isystem "$$PWD/build/dune-functions" \
+    -isystem "$$PWD/build/dune-logging/build-cmake/dune/vendor/fmt" \
 
 # LLVM on linux also needs libdl:
 unix:!mac {

--- a/inc/boundary.hpp
+++ b/inc/boundary.hpp
@@ -44,10 +44,13 @@ class Boundary {
  private:
   // full set of ordered vertices that make up the boundary
   std::vector<QPoint> vertices;
+  // unit vector perpendicular to boundary
+  std::vector<QPointF> normalUnitVectors;
   // vertex indices in reverse order of importance
   std::vector<std::size_t> orderedBoundaryIndices;
   std::size_t maxPoints;
   void removeDegenerateVertices();
+  void constructNormalUnitVectors();
   std::vector<std::size_t>::const_iterator smallestTrianglePointIndex(
       const std::vector<std::size_t>& pointIndices) const;
 

--- a/inc/dune.hpp
+++ b/inc/dune.hpp
@@ -1,8 +1,52 @@
-// DUNE ini file converter
-//  - constructs DUNE ini file
-//  - uses iniFile class to construct simple ini file one line at a time
+// DUNE solver interface
+//  - DuneSimulation: wrapper to dune-copasi library
+//  - DuneConverter: construct DUNE ini file
+//  - iniFile class: simple ini file generation one line at a time
 
 #pragma once
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#pragma GCC diagnostic ignored "-Wpessimizing-move"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wsubobject-linkage"
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <dune/common/exceptions.hh>
+#include <dune/common/parallel/mpihelper.hh>
+#include <dune/common/parametertree.hh>
+#include <dune/common/parametertreeparser.hh>
+#include <dune/copasi/gmsh_reader.hh>
+#include <dune/copasi/model_diffusion_reaction.cc>
+#include <dune/copasi/model_diffusion_reaction.hh>
+#include <dune/copasi/model_multidomain_diffusion_reaction.cc>
+#include <dune/copasi/model_multidomain_diffusion_reaction.hh>
+#include <dune/grid/io/file/gmshreader.hh>
+#include <dune/grid/multidomaingrid.hh>
+#include <dune/logging/logging.hh>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include <QString>
 
 #include "sbml.hpp"
 
@@ -33,6 +77,41 @@ class DuneConverter {
  private:
   const sbml::SbmlDocWrapper &doc;
   iniFile ini;
+};
+
+constexpr int dim = 2;
+using HostGrid = Dune::UGGrid<dim>;
+using MDGTraits = Dune::mdgrid::DynamicSubDomainCountTraits<dim, 1>;
+using Grid = Dune::mdgrid::MultiDomainGrid<HostGrid, MDGTraits>;
+
+using QTriangleF = std::array<QPointF, 3>;
+
+class DuneSimulation {
+ private:
+  // Dune objects
+  Dune::ParameterTree config;
+  std::shared_ptr<Grid> grid_ptr;
+  std::shared_ptr<HostGrid> host_grid_ptr;
+  std::unique_ptr<Dune::Copasi::ModelMultiDomainDiffusionReaction<dune::Grid>>
+      model;
+  // index of compartment/species name in these vectors is the Dune index:
+  std::vector<std::string> compartmentNames;
+  std::vector<std::vector<std::string>> speciesNames;
+  std::map<std::string, double> mapSpeciesIDToAvConc;
+  // dimensions of model
+  QSizeF geometrySize;
+  // triangles that make up each compartment
+  std::vector<std::vector<QTriangleF>> triangles;
+  void initDuneModel(const sbml::SbmlDocWrapper &sbmlDoc);
+  void updateCompartmentNames();
+  void updateSpeciesNames();
+  void updateTriangles();
+
+ public:
+  explicit DuneSimulation(const sbml::SbmlDocWrapper &sbmlDoc);
+  void doTimestep(double dt);
+  QImage getConcImage(const QSize &imageSize = QSize(800, 800));
+  double getAverageConcentration(const std::string &speciesID) const;
 };
 
 }  // namespace dune

--- a/inc/mainwindow.hpp
+++ b/inc/mainwindow.hpp
@@ -27,6 +27,10 @@ class MainWindow : public QMainWindow {
   QShortcut *shortcutSetMathBackend;
   simulate::BACKEND simMathBackend = simulate::BACKEND::SYMENGINE_LLVM;
 
+  // temp debugging shortcut:
+  QShortcut *shortcutToggleDune;
+  bool useDuneSimulator = false;
+
   QPixmap lblSpeciesColourPixmap;
   QPixmap lblCompartmentColourPixmap;
 

--- a/src/boundary.cpp
+++ b/src/boundary.cpp
@@ -155,6 +155,24 @@ void Boundary::removeDegenerateVertices() {
   return;
 }
 
+void Boundary::constructNormalUnitVectors() {
+  normalUnitVectors.clear();
+  if (!isLoop) {
+    // for now we only support for closed loops
+    return;
+  }
+  normalUnitVectors.reserve(vertices.size());
+  // calculate unit vector normal (perpendicular) to boundary
+  for (std::size_t i = 0; i < vertices.size(); ++i) {
+    std::size_t ip = (i + 1) % vertices.size();
+    std::size_t im = (i + vertices.size() - 1) % vertices.size();
+    QPoint delta = vertices[ip] - vertices[im];
+    auto normal = QPointF(-delta.y(), delta.x());
+    normal /= sqrt(QPointF::dotProduct(normal, normal));
+    normalUnitVectors.push_back(normal);
+  }
+}
+
 // Visvalingam polyline simplification
 // return index of vertex which forms smallest area triangle
 // NB: very inefficient & not quite right:
@@ -194,8 +212,8 @@ std::vector<std::size_t>::const_iterator Boundary::smallestTrianglePointIndex(
 
 Boundary::Boundary(const std::vector<QPoint>& boundaryPoints, bool isClosedLoop)
     : vertices(boundaryPoints), isLoop(isClosedLoop) {
-  // remove degenerate points from vertices
   removeDegenerateVertices();
+  constructNormalUnitVectors();
 
   // construct list of points in reverse order of importance
   // start by using all points

--- a/src/dune.cpp
+++ b/src/dune.cpp
@@ -1,9 +1,14 @@
 #include "dune.hpp"
 
+#include <QFile>
+#include <QImage>
+#include <QPainter>
+
 #include "logger.hpp"
 #include "pde.hpp"
 #include "reactions.hpp"
 #include "symbolic.hpp"
+#include "utils.hpp"
 
 namespace dune {
 
@@ -225,17 +230,197 @@ DuneConverter::DuneConverter(const sbml::SbmlDocWrapper &SbmlDoc,
 
   // logger settings
   ini.addSection("logging");
-  ini.addValue("default.level", "trace");
+  ini.addValue("default.level", "debug");
 
   ini.addSection("logging.backend.model");
-  ini.addValue("level", "trace");
+  ini.addValue("level", "debug");
   ini.addValue("indent", 2);
 
   ini.addSection("logging.backend.solver");
-  ini.addValue("level", "trace");
+  ini.addValue("level", "debug");
   ini.addValue("indent", 4);
 }
 
-QString dune::DuneConverter::getIniFile() const { return ini.getText(); }
+QString DuneConverter::getIniFile() const { return ini.getText(); }
+
+void DuneSimulation::initDuneModel(const sbml::SbmlDocWrapper &sbmlDoc) {
+  geometrySize = sbmlDoc.getCompartmentImage().size() * sbmlDoc.getPixelWidth();
+  // export gmsh file `grid.msh` in the same dir
+  QFile f2("grid.msh");
+  if (f2.open(QIODevice::ReadWrite | QIODevice::Text)) {
+    f2.write(sbmlDoc.mesh.getGMSH().toUtf8());
+  }
+  f2.close();
+
+  // pass dune ini file directly as istream
+  std::stringstream ssIni(
+      dune::DuneConverter(sbmlDoc).getIniFile().toStdString());
+  Dune::ParameterTreeParser::readINITree(ssIni, config);
+
+  // init Dune logging if not already done & mute it
+  if (!Dune::Logging::Logging::initialized()) {
+    auto &mpi_helper = Dune::MPIHelper::instance(0, nullptr);
+    auto comm = mpi_helper.getCollectiveCommunication();
+    Dune::Logging::Logging::init(comm, config.sub("logging"));
+    // Dune::Logging::Logging::mute();
+  }
+
+  // NB: msh file needs to be file for gmshreader
+  std::tie(grid_ptr, host_grid_ptr) =
+      Dune::Copasi::GmshReader<dune::Grid>::read("grid.msh", config);
+
+  // initialize model
+  model = std::make_unique<
+      Dune::Copasi::ModelMultiDomainDiffusionReaction<dune::Grid>>(
+      grid_ptr, config.sub("model"));
+}
+
+void DuneSimulation::updateCompartmentNames() {
+  const auto &compartments = config.sub("model.compartments").getValueKeys();
+  compartmentNames.resize(compartments.size());
+  for (const auto &compartment : compartments) {
+    std::size_t iDomain =
+        config.sub("model.compartments").get<std::size_t>(compartment);
+    SPDLOG_DEBUG("compartment[{}]: {}", iDomain, compartment);
+    if (iDomain >= compartmentNames.size()) {
+      SPDLOG_ERROR(
+          "found compartment index {}, but there are only {} compartments",
+          iDomain, compartmentNames.size());
+    }
+    compartmentNames[iDomain] = compartment;
+  }
+}
+
+void DuneSimulation::updateSpeciesNames() {
+  speciesNames.clear();
+  for (std::size_t iDomain = 0; iDomain < compartmentNames.size(); ++iDomain) {
+    SPDLOG_DEBUG("compartment[{}]: {}", iDomain, compartmentNames.at(iDomain));
+    // NB: species index is position in *sorted* list of species names
+    // so make copy of list of names from ini file and sort it
+    auto names =
+        config.sub("model." + compartmentNames.at(iDomain) + ".initial")
+            .getValueKeys();
+    std::sort(names.begin(), names.end());
+    SPDLOG_DEBUG("  - species: {}", names);
+    speciesNames.push_back(std::move(names));
+  }
+}
+
+void DuneSimulation::updateTriangles() {
+  triangles.clear();
+  for (std::size_t iDomain = 0; iDomain < compartmentNames.size(); ++iDomain) {
+    triangles.emplace_back();
+    const auto &gridview =
+        grid_ptr->subDomain(static_cast<int>(iDomain)).leafGridView();
+    SPDLOG_TRACE("compartment[{}]: {}", iDomain, compartmentNames.at(iDomain));
+    // get vertices of triangles:
+    for (const auto e : elements(gridview)) {
+      const auto &geo = e.geometry();
+      assert(geo.type().isTriangle());
+      QPointF c0(geo.corner(0)[0], geo.corner(0)[1]);
+      QPointF c1(geo.corner(1)[0], geo.corner(1)[1]);
+      QPointF c2(geo.corner(2)[0], geo.corner(2)[1]);
+      triangles.back().push_back({{c0, c1, c2}});
+    }
+    SPDLOG_TRACE("  - found {} triangles", triangles.back().size());
+  }
+}
+
+DuneSimulation::DuneSimulation(const sbml::SbmlDocWrapper &sbmlDoc) {
+  initDuneModel(sbmlDoc);
+  updateCompartmentNames();
+  updateSpeciesNames();
+  updateTriangles();
+  // temp call to construct map to av concentrations as side effect
+  // todo: remove this
+  QImage img = getConcImage();
+}
+
+void DuneSimulation::doTimestep(double dt) {
+  model->end_time() = model->current_time() + dt;
+  model->run();
+}
+
+QImage DuneSimulation::getConcImage(const QSize &imageSize) {
+  // resize to imageSize but maintain aspect ratio
+  double scaleFactor = std::min(imageSize.width() / geometrySize.width(),
+                                imageSize.height() / geometrySize.height());
+  QImage img(imageSize, QImage::Format_ARGB32_Premultiplied);
+  img.fill(0);
+  QPainter p(&img);
+  p.setRenderHint(QPainter::Antialiasing);
+  p.setPen(QPen(Qt::black, 1));
+  QBrush fillBrush(QColor(0, 0, 0));
+  for (std::size_t iDomain = 0; iDomain < compartmentNames.size(); ++iDomain) {
+    SPDLOG_TRACE("compartment[{}]: {}", iDomain, compartmentNames.at(iDomain));
+    const auto &gridview =
+        grid_ptr->subDomain(static_cast<int>(iDomain)).leafGridView();
+
+    // get average conc for each triangle & species
+    // also keep track of max conc for each species
+    // todo: ensure species colours match GUI simulator colours
+    // todo: do linear interpolation between vertices instead of av over
+    // triangle (i.e. 1st order instead of 0th order)
+    std::vector<std::vector<double>> conc;
+    std::vector<double> concMax;
+    const auto &species = speciesNames.at(iDomain);
+    const auto &compTriangles = triangles.at(iDomain);
+    for (std::size_t iSpecies = 0; iSpecies < species.size(); ++iSpecies) {
+      auto gf = model->get_grid_function(model->states(), iDomain, iSpecies);
+      using GF = decltype(gf);
+      using Range = typename GF::Traits::RangeType;
+      using Domain = typename GF::Traits::DomainType;
+      Range result;
+      double m = 0;
+      conc.emplace_back();
+      conc.back().reserve(compTriangles.size());
+      for (const auto e : elements(gridview)) {
+        double av = 0;
+        for (const auto &dom : {Domain{0, 0}, Domain{1, 0}, Domain{0, 1}}) {
+          gf.evaluate(e, dom, result);
+          av += result / 3.0;
+        }
+        m = std::max(m, av);
+        conc.back().push_back(av);
+      }
+      concMax.push_back(m < 1e-15 ? 1.0 : m);
+      mapSpeciesIDToAvConc[species.at(iSpecies)] =
+          std::accumulate(conc.back().begin(), conc.back().end(), 0.0) /
+          static_cast<double>(conc.back().size());
+      SPDLOG_TRACE("  - species[{}]: {} - max = {}", iSpecies,
+                   species.at(iSpecies), concMax.back());
+    }
+
+    // equal contribution from each field
+    double alpha = 1.0 / static_cast<double>(species.size());
+    for (std::size_t i = 0; i < compTriangles.size(); ++i) {
+      int r = 0;
+      int g = 0;
+      int b = 0;
+      for (std::size_t i_f = 0; i_f < species.size(); ++i_f) {
+        double c = alpha * conc[i_f][i] / concMax[i_f];
+        QColor col = utils::indexedColours()[i_f];
+        r += static_cast<int>(col.red() * c);
+        g += static_cast<int>(col.green() * c);
+        b += static_cast<int>(col.blue() * c);
+      }
+      const auto &t = compTriangles[i];
+      QPainterPath path(t[0] * scaleFactor);
+      path.lineTo(t[1] * scaleFactor);
+      path.lineTo(t[2] * scaleFactor);
+      path.lineTo(t[0] * scaleFactor);
+      fillBrush.setColor(qRgb(r, g, b));
+      p.setBrush(fillBrush);
+      p.drawPath(path);
+    }
+  }
+  p.end();
+  return img.mirrored(false, true);
+}
+
+double DuneSimulation::getAverageConcentration(
+    const std::string &speciesID) const {
+  return mapSpeciesIDToAvConc.at(speciesID);
+}
 
 }  // namespace dune

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.4.6";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.5.0";


### PR DESCRIPTION
  - add DuneSimulation class to wrap it
  - construct image of concentrations
    - uses average concentration over triangle (zeroth-order)
    - todo: interpolate between triangle corners (first-order)
  - suppress GCC compiler warnings for DUNE includes

also
  - boundary class constructs unit vectors perpendicular to boundary points for closed loops
  - DUNE uses C++17, requires building for osx >= 10.14
     - statically link libstdc++ to allow binary to run on older osx versions
  - use common build script for linux/osx/win CI
     - change to using msys on windows