### PR TITLE
dune fixes

### DIFF
--- a/inc/pde.hpp
+++ b/inc/pde.hpp
@@ -15,13 +15,15 @@ namespace pde {
 
 class PDE {
  private:
+  std::vector<std::string> species;
   std::vector<std::string> rhs;
   std::vector<std::vector<std::string>> jacobian;
 
  public:
   explicit PDE(const sbml::SbmlDocWrapper *doc_ptr,
                const std::vector<std::string> &speciesIDs,
-               const std::vector<std::string> &reactionIDs);
+               const std::vector<std::string> &reactionIDs,
+               const std::vector<std::string> &relabelledSpeciesIDs = {});
   const std::vector<std::string> &getRHS() const;
   const std::vector<std::vector<std::string>> &getJacobian() const;
 };

--- a/inc/symbolic.hpp
+++ b/inc/symbolic.hpp
@@ -63,6 +63,8 @@ class Symbolic {
   std::string simplify(std::size_t i = 0) const;
   // differentiate given expression wrt a variable
   std::string diff(const std::string &var, std::size_t i = 0) const;
+  // relabel variables
+  void relabel(const std::vector<std::string> &newVariables);
   // evaluate compiled expressions
   void eval(std::vector<double> &results, const std::vector<double> &vars = {});
   void evalLLVM(std::vector<double> &results,

--- a/src/sbml.cpp
+++ b/src/sbml.cpp
@@ -578,9 +578,9 @@ void SbmlDocWrapper::updateMembraneList() {
         std::size_t index = iter->second;
         if (!membranePairs[index].empty()) {
           // generate membrane name, compartments ordered by colour
-          QString name = compartments[i] + "-" + compartments[j];
+          QString name = compartments[i] + "_" + compartments[j];
           if (colA > colB) {
-            name = compartments[j] + "-" + compartments[i];
+            name = compartments[j] + "_" + compartments[i];
           }
           membranes.push_back(name);
           // map name to index of membrane location pairs
@@ -643,9 +643,9 @@ void SbmlDocWrapper::updateReactionList() {
       // membrane name is compA-compB, ordered by colour
       QRgb colA = mapCompartmentToColour[compA];
       QRgb colB = mapCompartmentToColour[compB];
-      QString membraneID = compA + "-" + compB;
+      QString membraneID = compA + "_" + compB;
       if (colA > colB) {
-        membraneID = compB + "-" + compA;
+        membraneID = compB + "_" + compA;
       }
       // check that compartments map to colours - if not do nothing
       if (colA != 0 && colB != 0) {

--- a/test.pro
+++ b/test.pro
@@ -14,6 +14,7 @@ SOURCES += \
     test/src/test_mesh.cpp \
     test/src/test_numerics.cpp \
     test/src/test_ostream_overloads.cpp \
+    test/src/test_pde.cpp \
     test/src/test_qlabelmousetracker.cpp \
     test/src/test_reactions.cpp \
     test/src/test_sbml.cpp \
@@ -27,5 +28,6 @@ HEADERS += \
     test/inc/sbml_test_data/ABtoC.hpp \
     test/inc/sbml_test_data/very_simple_model.hpp \
     test/inc/sbml_test_data/yeast_glycolysis.hpp \
+    test/inc/sbml_test_data/invalid_dune_names.hpp \
 
 INCLUDEPATH += test/inc

--- a/test/inc/sbml_test_data/invalid_dune_names.hpp
+++ b/test/inc/sbml_test_data/invalid_dune_names.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+namespace sbml_test_data {
+
+struct invalid_dune_names {
+  const char* xml = R"=====(<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:spatial="http://www.sbml.org/sbml/level3/version1/spatial/version1" level="3" version="2" spatial:required="true">
+  <model metaid="COPASI0" id="New_Model" name="New Model" substanceUnits="substance" timeUnits="second" volumeUnits="volume" areaUnits="area" lengthUnits="metre" extentUnits="substance">
+    <listOfUnitDefinitions>
+      <unitDefinition id="volume" name="volume">
+        <listOfUnits>
+          <unit kind="litre" exponent="1" scale="-3" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance" name="substance">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="-3" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment metaid="COPASI1" id="comp" name="comp" spatialDimensions="3" size="1" units="volume" constant="true">
+        <spatial:compartmentMapping spatial:id="comp_compartmentMapping" spatial:domainType="comp_domainType" spatial:unitSize="1"/>
+      </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="COPASI2" id="dim" name="A" compartment="comp" initialConcentration="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+      <species metaid="COPASI3" id="x" name="B" compartment="comp" initialConcentration="1" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+      <species metaid="COPASI4" id="x_" name="C" compartment="comp" initialConcentration="0" substanceUnits="substance" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" spatial:isSpatial="true"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="dim_diffusionConstant" value="1" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="dim" spatial:type="isotropic"/>
+      </parameter>
+      <parameter id="x_diffusionConstant" value="1" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="x" spatial:type="isotropic"/>
+      </parameter>
+      <parameter id="x__diffusionConstant" value="1" constant="true">
+        <spatial:diffusionCoefficient spatial:variable="x_" spatial:type="isotropic"/>
+      </parameter>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="COPASI5" id="r1" name="r1" reversible="false" compartment="comp" spatial:isLocal="true">
+        <listOfReactants>
+          <speciesReference species="dim" stoichiometry="1" constant="true"/>
+          <speciesReference species="x" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="x_" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> comp </ci>
+              <ci> k1 </ci>
+              <ci> dim </ci>
+              <ci> x </ci>
+            </apply>
+          </math>
+          <listOfLocalParameters>
+            <localParameter id="k1" name="k1" value="0.1"/>
+          </listOfLocalParameters>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+    <spatial:geometry spatial:coordinateSystem="cartesian">
+      <spatial:listOfCoordinateComponents>
+        <spatial:coordinateComponent spatial:id="xCoord" spatial:type="cartesianX">
+          <spatial:boundaryMin spatial:id="xBoundaryMin" spatial:value="0"/>
+          <spatial:boundaryMax spatial:id="xBoundaryMax" spatial:value="0"/>
+        </spatial:coordinateComponent>
+        <spatial:coordinateComponent spatial:id="yCoord" spatial:type="cartesianY">
+          <spatial:boundaryMin spatial:id="yBoundaryMin" spatial:value="0"/>
+          <spatial:boundaryMax spatial:id="yBoundaryMax" spatial:value="0"/>
+        </spatial:coordinateComponent>
+      </spatial:listOfCoordinateComponents>
+      <spatial:listOfDomainTypes>
+        <spatial:domainType spatial:id="comp_domainType" spatial:spatialDimensions="2"/>
+      </spatial:listOfDomainTypes>
+      <spatial:listOfDomains>
+        <spatial:domain spatial:id="comp_domain" spatial:domainType="comp_domainType">
+          <spatial:listOfInteriorPoints>
+            <spatial:interiorPoint spatial:coord1="0" spatial:coord2="0"/>
+          </spatial:listOfInteriorPoints>
+        </spatial:domain>
+      </spatial:listOfDomains>
+      <spatial:listOfGeometryDefinitions>
+        <spatial:sampledFieldGeometry spatial:id="sampledFieldGeometry" spatial:isActive="true" spatial:sampledField="geometryImage">
+          <spatial:listOfSampledVolumes>
+            <spatial:sampledVolume spatial:id="comp_sampledVolume" spatial:domainType="comp_domainType" spatial:sampledValue="4294967295"/>
+          </spatial:listOfSampledVolumes>
+        </spatial:sampledFieldGeometry>
+      </spatial:listOfGeometryDefinitions>
+      <spatial:listOfSampledFields>
+        <spatial:sampledField spatial:id="geometryImage" spatial:dataType="uint32" spatial:numSamples1="3" spatial:numSamples2="1" spatial:interpolationType="nearestNeighbor" spatial:compression="uncompressed" spatial:samplesLength="3">4294967295 4289374890 4283585106</spatial:sampledField>
+      </spatial:listOfSampledFields>
+    </spatial:geometry>
+  </model>
+</sbml>)=====";
+};
+
+}  // namespace sbml_test_data

--- a/test/src/test_ostream_overloads.cpp
+++ b/test/src/test_ostream_overloads.cpp
@@ -1,50 +1,49 @@
+#include "catch.hpp"
 #include "ostream_overloads.hpp"
 
-#include "catch.hpp"
-
-TEST_CASE("QByteArray", "[ostream]") {
+TEST_CASE("QByteArray", "[ostream][non-gui]") {
   std::stringstream ss;
   QByteArray qba("abc");
   ss << qba;
   REQUIRE(ss.str() == "\"abc\"");
 }
 
-TEST_CASE("QLatin1String", "[ostream]") {
+TEST_CASE("QLatin1String", "[ostream][non-gui]") {
   std::stringstream ss;
   QLatin1String qls("abQ!");
   ss << qls;
   REQUIRE(ss.str() == "\"abQ!\"");
 }
 
-TEST_CASE("QString", "[ostream]") {
+TEST_CASE("QString", "[ostream][non-gui]") {
   std::stringstream ss;
   QString qs("Q~z");
   ss << qs;
   REQUIRE(ss.str() == "\"Q~z\"");
 }
 
-TEST_CASE("QPoint", "[ostream]") {
+TEST_CASE("QPoint", "[ostream][non-gui]") {
   std::stringstream ss;
   QPoint p(23, 66);
   ss << p;
   REQUIRE(ss.str() == "(23,66)");
 }
 
-TEST_CASE("QPointF", "[ostream]") {
+TEST_CASE("QPointF", "[ostream][non-gui]") {
   std::stringstream ss;
   QPointF p(0.231, -9.66);
   ss << p;
   REQUIRE(ss.str() == "(0.231,-9.66)");
 }
 
-TEST_CASE("QSize", "[ostream]") {
+TEST_CASE("QSize", "[ostream][non-gui]") {
   std::stringstream ss;
   QSize p(1024, 768);
   ss << p;
   REQUIRE(ss.str() == "1024x768");
 }
 
-TEST_CASE("QColor", "[ostream]") {
+TEST_CASE("QColor", "[ostream][non-gui]") {
   std::stringstream ss;
   QColor c(123, 22, 99);
   ss << c;

--- a/test/src/test_pde.cpp
+++ b/test/src/test_pde.cpp
@@ -1,0 +1,68 @@
+#include <QFile>
+
+#include "catch.hpp"
+#include "logger.hpp"
+#include "pde.hpp"
+#include "sbml_test_data/invalid_dune_names.hpp"
+
+TEST_CASE("PDE", "[pde][non-gui]") {
+  std::unique_ptr<libsbml::SBMLDocument> doc(
+      libsbml::readSBMLFromString(sbml_test_data::invalid_dune_names().xml));
+  libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
+  sbml::SbmlDocWrapper s;
+  s.importSBMLFile("tmp.xml");
+  pde::PDE pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"});
+  REQUIRE(pde.getRHS()[0] == "-0.1*x*dim");
+  REQUIRE(pde.getRHS()[1] == "-0.1*x*dim");
+  REQUIRE(pde.getRHS()[2] == "0.1*x*dim");
+  REQUIRE(pde.getJacobian()[0][0] == "-0.1*x");
+  REQUIRE(pde.getJacobian()[0][1] == "-0.1*dim");
+  REQUIRE(pde.getJacobian()[0][2] == "0");
+  REQUIRE(pde.getJacobian()[0][3] == "0");
+  REQUIRE(pde.getJacobian()[0][4] == "0");
+  REQUIRE(pde.getJacobian()[2][0] == "0.1*x");
+  REQUIRE(pde.getJacobian()[2][1] == "0.1*dim");
+  REQUIRE(pde.getJacobian()[2][2] == "0");
+}
+
+TEST_CASE("PDE with relabeling of variables", "[pde][non-gui]") {
+  std::unique_ptr<libsbml::SBMLDocument> doc(
+      libsbml::readSBMLFromString(sbml_test_data::invalid_dune_names().xml));
+  libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
+  sbml::SbmlDocWrapper s;
+  s.importSBMLFile("tmp.xml");
+  pde::PDE pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"},
+               {"dim_", "x__", "x_", "cos__", "cos_"});
+  REQUIRE(pde.getRHS()[0] == "-0.1*x__*dim_");
+  REQUIRE(pde.getRHS()[1] == "-0.1*x__*dim_");
+  REQUIRE(pde.getRHS()[2] == "0.1*x__*dim_");
+  REQUIRE(pde.getJacobian()[0][0] == "-0.1*x__");
+  REQUIRE(pde.getJacobian()[0][1] == "-0.1*dim_");
+  REQUIRE(pde.getJacobian()[0][2] == "0");
+  REQUIRE(pde.getJacobian()[0][3] == "0");
+  REQUIRE(pde.getJacobian()[0][4] == "0");
+  REQUIRE(pde.getJacobian()[2][0] == "0.1*x__");
+  REQUIRE(pde.getJacobian()[2][1] == "0.1*dim_");
+  REQUIRE(pde.getJacobian()[2][2] == "0");
+}
+
+TEST_CASE("PDE: invalid relabeling of variables is ignored",
+          "[pde][invalid][non-gui]") {
+  std::unique_ptr<libsbml::SBMLDocument> doc(
+      libsbml::readSBMLFromString(sbml_test_data::invalid_dune_names().xml));
+  libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
+  sbml::SbmlDocWrapper s;
+  s.importSBMLFile("tmp.xml");
+  pde::PDE pde(&s, {"dim", "x", "x_", "cos", "cos_"}, {"r1"}, {"z", "y"});
+  REQUIRE(pde.getRHS()[0] == "-0.1*x*dim");
+  REQUIRE(pde.getRHS()[1] == "-0.1*x*dim");
+  REQUIRE(pde.getRHS()[2] == "0.1*x*dim");
+  REQUIRE(pde.getJacobian()[0][0] == "-0.1*x");
+  REQUIRE(pde.getJacobian()[0][1] == "-0.1*dim");
+  REQUIRE(pde.getJacobian()[0][2] == "0");
+  REQUIRE(pde.getJacobian()[0][3] == "0");
+  REQUIRE(pde.getJacobian()[0][4] == "0");
+  REQUIRE(pde.getJacobian()[2][0] == "0.1*x");
+  REQUIRE(pde.getJacobian()[2][1] == "0.1*dim");
+  REQUIRE(pde.getJacobian()[2][2] == "0");
+}

--- a/test/src/test_simulate.cpp
+++ b/test/src/test_simulate.cpp
@@ -1,12 +1,10 @@
-#include "simulate.hpp"
-
 #include <QFile>
 
 #include "catch.hpp"
-#include "sbml_test_data/very_simple_model.hpp"
-
 #include "logger.hpp"
 #include "sbml.hpp"
+#include "sbml_test_data/very_simple_model.hpp"
+#include "simulate.hpp"
 
 SCENARIO("simulate very_simple_model: single pixel geometry",
          "[simulate][non-gui]") {
@@ -33,7 +31,7 @@ SCENARIO("simulate very_simple_model: single pixel geometry",
 
   // check we have identified the compartments and membranes
   REQUIRE(s.compartments == QStringList{"c1", "c2", "c3"});
-  REQUIRE(s.membranes == QStringList{"c1-c2", "c2-c3"});
+  REQUIRE(s.membranes == QStringList{"c1_c2", "c2_c3"});
 
   // check fields have correct compartments & sizes
   geometry::Field &fa1 = s.mapSpeciesIdToField.at("A_c1");
@@ -57,14 +55,14 @@ SCENARIO("simulate very_simple_model: single pixel geometry",
 
   // check membranes have correct compartment pairs & sizes
   geometry::Membrane &m0 = s.membraneVec[0];
-  REQUIRE(m0.membraneID == "c1-c2");
+  REQUIRE(m0.membraneID == "c1_c2");
   REQUIRE(m0.compA->compartmentID == "c1");
   REQUIRE(m0.compB->compartmentID == "c2");
   REQUIRE(m0.indexPair.size() == 1);
   REQUIRE(m0.indexPair[0] == std::pair<std::size_t, std::size_t>{0, 0});
 
   geometry::Membrane &m1 = s.membraneVec[1];
-  REQUIRE(m1.membraneID == "c2-c3");
+  REQUIRE(m1.membraneID == "c2_c3");
   REQUIRE(m1.compA->compartmentID == "c2");
   REQUIRE(m1.compB->compartmentID == "c3");
   REQUIRE(m1.indexPair.size() == 1);
@@ -235,13 +233,13 @@ SCENARIO("simulate very_simple_model: 2d geometry", "[simulate][non-gui]") {
 
   // check membranes have correct compartment pairs & sizes
   geometry::Membrane &m0 = s.membraneVec[0];
-  REQUIRE(m0.membraneID == "c1-c2");
+  REQUIRE(m0.membraneID == "c1_c2");
   REQUIRE(m0.compA->compartmentID == "c1");
   REQUIRE(m0.compB->compartmentID == "c2");
   REQUIRE(m0.indexPair.size() == 338);
 
   geometry::Membrane &m1 = s.membraneVec[1];
-  REQUIRE(m1.membraneID == "c2-c3");
+  REQUIRE(m1.membraneID == "c2_c3");
   REQUIRE(m1.compA->compartmentID == "c2");
   REQUIRE(m1.compB->compartmentID == "c3");
   REQUIRE(m1.indexPair.size() == 108);

--- a/test/src/test_symbolic.cpp
+++ b/test/src/test_symbolic.cpp
@@ -1,8 +1,6 @@
-#include "symbolic.hpp"
-
 #include "catch.hpp"
-
 #include "logger.hpp"
+#include "symbolic.hpp"
 
 TEST_CASE("5+5: no vars, no constants", "[symbolic][non-gui]") {
   // mathematical expression as string
@@ -167,4 +165,29 @@ TEST_CASE("3*x + alpha*x - a*n/x: one var, constants", "[symbolic][non-gui]") {
     REQUIRE(res[0] == dbl_approx(3 * x + constants["alpha"] * x -
                                  constants["a"] * constants["n"] * x));
   }
+}
+
+TEST_CASE("relabel one expression with two vars", "[symbolic][non-gui]") {
+  std::string expr = "3*x + 12*sin(y)";
+  symbolic::Symbolic sym(expr, {"x", "y"});
+  CAPTURE(expr);
+  REQUIRE(sym.diff("x") == "3");
+  REQUIRE(sym.diff("y") == "12*cos(y)");
+  sym.relabel({"newX", "newY"});
+  REQUIRE(sym.simplify() == "3*newX + 12*sin(newY)");
+  REQUIRE(sym.diff("newX") == "3");
+  REQUIRE(sym.diff("newY") == "12*cos(newY)");
+}
+
+TEST_CASE("invalid variable relabeling is a no-op", "[symbolic][non-gui]") {
+  std::string expr = "3*x + 12*sin(y)";
+  symbolic::Symbolic sym(expr, {"x", "y"});
+  CAPTURE(expr);
+  REQUIRE(sym.simplify() == expr);
+  REQUIRE(sym.diff("x") == "3");
+  REQUIRE(sym.diff("y") == "12*cos(y)");
+  sym.relabel({"a"});
+  REQUIRE(sym.simplify() == expr);
+  sym.relabel({"a", "b", "c"});
+  REQUIRE(sym.simplify() == expr);
 }


### PR DESCRIPTION
  - set dune logging according to GUI logging setting
    - disable in release build
    - enable verbose logging in debug build
  - check that species names are valid for dune
    - if species name coincides with a reserved word, append an underscore to the species name
    - then check for name clashes with existing species names
       - in case of clash, append another underscore
  - add tests