### PR TITLE
dune initial conditions & visualization improvements

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -21,6 +21,7 @@ SOURCES += \
     src/sbml.cpp \
     src/simulate.cpp \
     src/symbolic.cpp \
+    src/tiff.cpp \
     src/triangulate.cpp \
     src/utils.cpp \
     src/version.cpp \
@@ -42,6 +43,7 @@ HEADERS += \
     inc/sbml.hpp \
     inc/simulate.hpp \
     inc/symbolic.hpp \
+    inc/tiff.hpp \
     inc/triangulate.hpp \
     inc/utils.hpp \
     inc/version.hpp \
@@ -61,7 +63,7 @@ include(ext/ext.pri)
 
 # set logging level (at compile time)
 CONFIG(release, debug|release):DEFINES += SPDLOG_ACTIVE_LEVEL="SPDLOG_LEVEL_INFO"
-CONFIG(debug, debug|release):DEFINES += SPDLOG_ACTIVE_LEVEL="SPDLOG_LEVEL_TRACE"
+CONFIG(debug, debug|release):DEFINES += SPDLOG_ACTIVE_LEVEL="SPDLOG_LEVEL_DEBUG"
 
 # on linux, enable GCC compiler warnings
 unix: QMAKE_CXXFLAGS += -Wall -Wcast-align -Wconversion -Wdouble-promotion -Wextra -Wformat=2 -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-conversion -Wunused -Wpedantic

--- a/ext/ext.pri
+++ b/ext/ext.pri
@@ -73,7 +73,7 @@ LIBS += \
     $$PWD/dune/dune-uggrid/build-cmake/lib/libugS2.a \
     $$PWD/dune/dune-uggrid/build-cmake/lib/libugL.a \
     $$PWD/dune/dune-common/build-cmake/lib/libdunecommon.a \
-    $$PWD/dune/dune-copasi/build-cmake/dune/copasi/libdune_copasi_lib.a \
+    $$PWD/dune/dune-copasi/build-cmake/lib/libdune_copasi_lib.a \
 
 INCLUDEPATH += \
     $$PWD/dune/dune-copasi \

--- a/inc/geometry.hpp
+++ b/inc/geometry.hpp
@@ -9,9 +9,8 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include <QImage>
+#include <unordered_map>
 
 namespace geometry {
 

--- a/inc/mainwindow.hpp
+++ b/inc/mainwindow.hpp
@@ -3,7 +3,6 @@
 #include <QMainWindow>
 
 #include "qcustomplot.h"
-
 #include "sbml.hpp"
 #include "simulate.hpp"
 
@@ -113,6 +112,8 @@ class MainWindow : public QMainWindow {
   void radInitialConcentration_toggled();
 
   void txtInitialConcentration_editingFinished();
+
+  void btnAnalyticConcentration_clicked();
 
   void btnImportConcentration_clicked();
 

--- a/inc/ostream_overloads.hpp
+++ b/inc/ostream_overloads.hpp
@@ -11,18 +11,17 @@
 
 #pragma once
 
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include <QByteArray>
 #include <QColor>
 #include <QLatin1String>
 #include <QPoint>
 #include <QSize>
 #include <QString>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 // Qt types
 
@@ -37,6 +36,8 @@ std::ostream &operator<<(std::ostream &os, const QPoint &value);
 std::ostream &operator<<(std::ostream &os, const QPointF &value);
 
 std::ostream &operator<<(std::ostream &os, const QSize &value);
+
+std::ostream &operator<<(std::ostream &os, const QSizeF &value);
 
 std::ostream &operator<<(std::ostream &os, const QColor &value);
 

--- a/inc/sbml.hpp
+++ b/inc/sbml.hpp
@@ -10,13 +10,12 @@
 #include <QImage>
 #include <QStringList>
 
+#include "geometry.hpp"
+#include "mesh.hpp"
 #include "sbml/SBMLTypes.h"
 #include "sbml/extension/SBMLDocumentPlugin.h"
 #include "sbml/packages/spatial/common/SpatialExtensionTypes.h"
 #include "sbml/packages/spatial/extension/SpatialExtension.h"
-
-#include "geometry.hpp"
-#include "mesh.hpp"
 
 namespace sbml {
 
@@ -69,9 +68,15 @@ class SbmlDocWrapper {
   // add default 2d Parametric & SampledField geometry to SBML
   void writeDefaultGeometryToSBML();
 
+  void setFieldConcAnalytic(geometry::Field &field, const std::string &expr);
+
   void initMembraneColourPairs();
   void updateMembraneList();
   void updateReactionList();
+
+  // remove initialAssignment and related things from SBML
+  // (sampledField, spatialref, etc)
+  void removeInitialAssignment(const std::string &speciesID);
 
   // update mesh object
   void updateMesh();
@@ -143,6 +148,12 @@ class SbmlDocWrapper {
   const QImage &getMembraneImage(const QString &membraneID) const;
 
   // species concentrations
+  void setAnalyticConcentration(const QString &speciesID,
+                                const QString &analyticExpression);
+  QString getAnalyticConcentration(const QString &speciesID) const;
+
+  std::string getSpeciesSampledFieldInitialAssignment(
+      const std::string &speciesID) const;
   void importConcentrationFromImage(const QString &speciesID,
                                     const QString &filename);
   QImage getConcentrationImage(const QString &speciesID) const;

--- a/inc/tiff.hpp
+++ b/inc/tiff.hpp
@@ -1,0 +1,16 @@
+// Wrapper around libTIFF
+//  - writes field concentration as 16-bit grayscale tiff
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "geometry.hpp"
+
+namespace utils {
+
+double writeTIFF(const std::string& filename, const geometry::Field& field,
+                 double pixelWidth = 1.0);
+
+}

--- a/inc/utils.hpp
+++ b/inc/utils.hpp
@@ -1,17 +1,40 @@
 // utilities
+//  - decltypeStr<T>: type of T as a string
+//    (taken from https://stackoverflow.com/a/56766138)
 //  - stringToVector: convert space-delimited list of values to a vector
 //  - vectorToString: convert vector of values to a space-delimited list
 //  - indexedColours: a set of default colours for display purposes
 
 #pragma once
 
+#include <QColor>
 #include <iomanip>
 #include <iterator>
 #include <sstream>
 #include <vector>
-#include <QColor>
 
 namespace utils {
+
+template <typename T>
+constexpr auto decltypeStr() {
+  std::string_view name, prefix, suffix;
+#ifdef __clang__
+  name = __PRETTY_FUNCTION__;
+  prefix = "auto type_name() [T = ";
+  suffix = "]";
+#elif defined(__GNUC__)
+  name = __PRETTY_FUNCTION__;
+  prefix = "constexpr auto type_name() [with T = ";
+  suffix = "]";
+#elif defined(_MSC_VER)
+  name = __FUNCSIG__;
+  prefix = "auto __cdecl type_name<";
+  suffix = ">(void)";
+#endif
+  name.remove_prefix(prefix.size());
+  name.remove_suffix(suffix.size());
+  return name;
+}
 
 template <class T>
 std::vector<T> stringToVector(const std::string &str) {

--- a/resources/models/ABtoC.xml
+++ b/resources/models/ABtoC.xml
@@ -41,6 +41,12 @@
       <parameter id="C_diffusionConstant" value="25" constant="true">
         <spatial:diffusionCoefficient spatial:variable="C" spatial:type="isotropic"/>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfInitialAssignments>
       <initialAssignment symbol="A">

--- a/resources/models/brusselator-model.xml
+++ b/resources/models/brusselator-model.xml
@@ -39,6 +39,12 @@
       <parameter id="X_diffusionConstant" value="0.2" constant="true">
         <spatial:diffusionCoefficient spatial:variable="X" spatial:type="isotropic"/>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfInitialAssignments>
       <initialAssignment symbol="X">

--- a/resources/models/circadian-clock.xml
+++ b/resources/models/circadian-clock.xml
@@ -2076,6 +2076,12 @@
       <parameter id="Cn_initialConcentration" constant="true">
         <spatial:spatialSymbolReference spatial:spatialRef="Cn_initialConcentration"/>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfInitialAssignments>
       <initialAssignment symbol="P0">

--- a/resources/models/gray-scott.xml
+++ b/resources/models/gray-scott.xml
@@ -164,6 +164,12 @@
       <parameter id="V_diffusionConstant" value="0.005" constant="true">
         <spatial:diffusionCoefficient spatial:variable="V" spatial:type="isotropic"/>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfInitialAssignments>
       <initialAssignment symbol="U">

--- a/resources/models/liver-simplified.xml
+++ b/resources/models/liver-simplified.xml
@@ -1056,6 +1056,12 @@
           </COPASI>
         </annotation>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfRules>
       <assignmentRule variable="IkBa_phosphorylation_kcat">

--- a/resources/models/very-simple-model.xml
+++ b/resources/models/very-simple-model.xml
@@ -57,6 +57,12 @@
       <parameter id="A_c1_diffusionConstant" value="15" constant="true">
         <spatial:diffusionCoefficient spatial:variable="A_c1" spatial:type="isotropic"/>
       </parameter>
+      <parameter id="x" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
+      </parameter>
+      <parameter id="y" constant="false">
+        <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
+      </parameter>
     </listOfParameters>
     <listOfReactions>
       <reaction id="A_uptake" name="A_uptake" reversible="false" compartment="c1" spatial:isLocal="true">

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -173,8 +173,8 @@ void Field::setUniformConcentration(double concentration) {
 }
 
 QImage Field::getConcentrationImage() const {
-  auto img =
-      QImage(geometry->getCompartmentImage().size(), QImage::Format_ARGB32);
+  auto img = QImage(geometry->getCompartmentImage().size(),
+                    QImage::Format_ARGB32_Premultiplied);
   img.fill(qRgba(0, 0, 0, 0));
   // for now rescale conc to [0,1] to multiply species colour
   double cmax = *std::max_element(conc.begin(), conc.end());
@@ -183,9 +183,9 @@ QImage Field::getConcentrationImage() const {
   }
   for (std::size_t i = 0; i < geometry->ix.size(); ++i) {
     double scale = conc[i] / cmax;
-    int r = static_cast<int>(std::round(scale * red));
-    int g = static_cast<int>(std::round(scale * green));
-    int b = static_cast<int>(std::round(scale * blue));
+    int r = static_cast<int>(scale * red);
+    int g = static_cast<int>(scale * green);
+    int b = static_cast<int>(scale * blue);
     img.setPixel(geometry->ix[i], qRgb(r, g, b));
   }
   return img;
@@ -211,10 +211,10 @@ std::vector<double> Field::getConcentrationArray() const {
 void Field::applyDiffusionOperator() {
   const Compartment *g = geometry;
   double pixelWidth = g->pixelWidth;
+  double d = diffusionConstant / pixelWidth / pixelWidth;
   for (std::size_t i = 0; i < geometry->ix.size(); ++i) {
-    dcdt[i] = (diffusionConstant / pixelWidth / pixelWidth) *
-              (conc[g->up_x(i)] + conc[g->dn_x(i)] + conc[g->up_y(i)] +
-               conc[g->dn_y(i)] - 4.0 * conc[i]);
+    dcdt[i] = d * (conc[g->up_x(i)] + conc[g->dn_x(i)] + conc[g->up_y(i)] +
+                   conc[g->dn_y(i)] - 4.0 * conc[i]);
   }
 }
 

--- a/src/ostream_overloads.cpp
+++ b/src/ostream_overloads.cpp
@@ -24,6 +24,10 @@ std::ostream &operator<<(std::ostream &os, const QSize &value) {
   return os << value.width() << "x" << value.height();
 }
 
+std::ostream &operator<<(std::ostream &os, const QSizeF &value) {
+  return os << value.width() << "x" << value.height();
+}
+
 std::ostream &operator<<(std::ostream &os, const QColor &value) {
   return os << std::hex << value.rgba();
 }

--- a/src/simulate.cpp
+++ b/src/simulate.cpp
@@ -237,6 +237,9 @@ void Simulate::integrateForwardsEuler(double dt) {
 }
 
 QImage Simulate::getConcentrationImage() {
+  if (field.empty()) {
+    return QImage();
+  }
   QImage img(field[0]->geometry->getCompartmentImage().size(),
              QImage::Format_ARGB32);
   img.fill(qRgba(0, 0, 0, 0));

--- a/src/tiff.cpp
+++ b/src/tiff.cpp
@@ -1,0 +1,78 @@
+#include "tiff.hpp"
+
+#include "logger.hpp"
+#include "tiffio.h"
+#include "utils.hpp"
+
+namespace utils {
+
+using TiffDataType = uint16_t;
+constexpr int TiffDataTypeBits = std::numeric_limits<TiffDataType>::digits;
+constexpr TiffDataType TiffDataTypeMaxValue =
+    std::numeric_limits<TiffDataType>::max();
+
+double writeTIFF(const std::string& filename, const geometry::Field& field,
+                 double pixelWidth) {
+  // get concentration & max value
+  const auto& conc = field.conc;
+  SPDLOG_TRACE("found {} concentration values", conc.size());
+  double maxConc = *std::max_element(conc.begin(), conc.end());
+  SPDLOG_TRACE("  - max value: {}", maxConc);
+
+  // convert to array of type TiffDataType
+  SPDLOG_TRACE("using TIFF data type: {}", decltypeStr<TiffDataType>());
+  SPDLOG_TRACE("  - size in bits: {}", TiffDataTypeBits);
+  SPDLOG_TRACE("  - max value: {}", TiffDataTypeMaxValue);
+  auto width =
+      static_cast<std::size_t>(field.geometry->getCompartmentImage().width());
+  auto height =
+      static_cast<std::size_t>(field.geometry->getCompartmentImage().height());
+  SPDLOG_TRACE("  - image size {}x{}", width, height);
+  auto tifValues = std::vector<std::vector<TiffDataType>>(
+      height, std::vector<TiffDataType>(width, 0));
+  double scaleFactor = TiffDataTypeMaxValue / maxConc;
+  for (std::size_t i = 0; i < field.geometry->ix.size(); ++i) {
+    auto x = static_cast<std::size_t>(field.geometry->ix[i].x());
+    auto y = static_cast<std::size_t>(field.geometry->ix[i].y());
+    auto val = static_cast<TiffDataType>(scaleFactor * conc[i]);
+    tifValues[y][x] = val;
+  }
+
+  // write to TIFF
+  TIFF* tif = TIFFOpen(filename.c_str(), "w");
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  // 16-bit grayscale - one uint16_t per pixel:
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, TiffDataTypeBits);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  // only affects how the data is stored
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, 8);
+  // NB: same orientation as QImage: (0,0) in top left
+  TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  // NB: black == 0
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+  // NB: ignored by DUNE:
+  TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_CENTIMETER);
+  // NB: factor to convert from pixel location to physical location
+  // pixelX = TIFFTAG_XRESOLUTION * physicalX, etc.
+  TIFFSetField(tif, TIFFTAG_XRESOLUTION, 1.0 / pixelWidth);
+  TIFFSetField(tif, TIFFTAG_YRESOLUTION, 1.0 / pixelWidth);
+  // NB: location of (0,0) pixel (ignored by DUNE):
+  TIFFSetField(tif, TIFFTAG_XPOSITION, 0.0);
+  TIFFSetField(tif, TIFFTAG_YPOSITION, 0.0);
+  for (std::size_t y = 0; y < static_cast<std::size_t>(height); y++) {
+    int ret = TIFFWriteScanline(tif, tifValues.at(y).data(),
+                                static_cast<uint32_t>(y));
+    if (ret != 1) {
+      SPDLOG_ERROR("TIFFWriteScanline error on row {}", y);
+    }
+  }
+  TIFFClose(tif);
+
+  return maxConc;
+}
+
+}  // namespace utils

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.5.1";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.5.2";

--- a/test/src/test_mainwindow.cpp
+++ b/test/src/test_mainwindow.cpp
@@ -1,14 +1,12 @@
-#include "mainwindow.hpp"
-
 #include <QtTest>
 
 #include "catch.hpp"
+#include "logger.hpp"
+#include "mainwindow.hpp"
+#include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
 #include "sbml_test_data/ABtoC.hpp"
 #include "sbml_test_data/very_simple_model.hpp"
-
-#include "logger.hpp"
-#include "qlabelmousetracker.hpp"
 #include "utils.hpp"
 
 // class that provides a pointer to each Widget in mainWindow
@@ -455,14 +453,14 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   // QTest::keyClick(ui.listSpecies, Qt::Key_Down, Qt::ControlModifier,
   // key_delay);
   REQUIRE(ui.chkSpeciesIsConstant->isChecked() == true);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
   // toggle is spatial checkbox
   QTest::mouseClick(ui.chkSpeciesIsSpatial, Qt::LeftButton,
                     Qt::KeyboardModifiers(), QPoint(1, 1), key_delay);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
   QTest::mouseClick(ui.chkSpeciesIsSpatial, Qt::LeftButton,
                     Qt::KeyboardModifiers(), QPoint(1, 1), key_delay);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
   // toggle is constant checkbox
   QTest::mouseClick(ui.chkSpeciesIsConstant, Qt::LeftButton,
                     Qt::KeyboardModifiers(), QPoint(1, 1), key_delay);
@@ -473,14 +471,14 @@ SCENARIO("Load SBML file", "[gui][mainwindow]") {
   // select second item in listSpecies
   QTest::keyClick(ui.listSpecies, Qt::Key_Down, Qt::ControlModifier, key_delay);
   REQUIRE(ui.chkSpeciesIsConstant->isChecked() == false);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
   // toggle is spatial checkbox
   QTest::mouseClick(ui.chkSpeciesIsSpatial, Qt::LeftButton,
                     Qt::KeyboardModifiers(), QPoint(1, 1), key_delay);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
   QTest::mouseClick(ui.chkSpeciesIsSpatial, Qt::LeftButton,
                     Qt::KeyboardModifiers(), QPoint(1, 1), key_delay);
-  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == false);
+  REQUIRE(ui.chkSpeciesIsSpatial->isChecked() == true);
   QTest::keyClick(ui.listSpecies, Qt::Key_Enter, Qt::ControlModifier,
                   key_delay);
   // keep pressing down until we have selected the B_c3 species

--- a/test/src/test_ostream_overloads.cpp
+++ b/test/src/test_ostream_overloads.cpp
@@ -43,6 +43,13 @@ TEST_CASE("QSize", "[ostream][non-gui]") {
   REQUIRE(ss.str() == "1024x768");
 }
 
+TEST_CASE("QSizeF", "[ostream][non-gui]") {
+  std::stringstream ss;
+  QSizeF p(1024.3, 768.99);
+  ss << p;
+  REQUIRE(ss.str() == "1024.3x768.99");
+}
+
 TEST_CASE("QColor", "[ostream][non-gui]") {
   std::stringstream ss;
   QColor c(123, 22, 99);

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -109,7 +109,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="tabGeometry">
         <property name="whatsThis">
@@ -693,8 +693,8 @@
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
                <layout class="QGridLayout" name="gridSpeciesSettings">
-                <item row="0" column="0">
-                 <widget class="QLabel" name="lblSpeciesIsSpacial">
+                <item row="0" column="1" colspan="6">
+                 <widget class="QCheckBox" name="chkSpeciesIsSpatial">
                   <property name="toolTip">
                    <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
                   </property>
@@ -705,7 +705,61 @@
                    <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
                   </property>
                   <property name="text">
-                   <string>Spatial:</string>
+                   <string>species concentration has a spatial dependence</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1" colspan="6">
+                 <widget class="QCheckBox" name="chkSpeciesIsConstant">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>'Constant': species concentration cannot be altered by the simulation</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>species concentration is fixed throughout the whole simulation</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0" rowspan="2">
+                 <widget class="QLabel" name="lblInitConc">
+                  <property name="text">
+                   <string>Initial Concentration:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="lblSpeciesColourLabel">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>The colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>The colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>The colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="text">
+                   <string>Colour:</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -738,135 +792,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="1">
-                 <widget class="QRadioButton" name="radInitialConcentrationVarying">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Spatially varying initial concentration: varies with position</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>Spatially varying initial concentration: varies with position</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;Spatially varying initial concentration&lt;/h4&gt;
-&lt;p&gt;The initial concentration of the species can vary depending on the location within the compartment.&lt;/p&gt;</string>
-                  </property>
-                  <property name="text">
-                   <string>Spatially varying</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="2" colspan="3">
-                 <widget class="QPushButton" name="btnImportConcentration">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Import an image of the spatial concentration of this species</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>Import an image of the spatial concentration of this species</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;import from image&lt;/h4&gt;&lt;p&gt;Import an image of the spatial concentration of this species&lt;/p&gt;</string>
-                  </property>
-                  <property name="text">
-                   <string>import from image...</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="lblSpeciesIsConstant">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>A constant species has a fixed concentration</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>A constant species has a fixed concentration</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-                  </property>
-                  <property name="text">
-                   <string>Constant:</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0" rowspan="2">
-                 <widget class="QLabel" name="lblInitConc">
-                  <property name="text">
-                   <string>Initial Concentration:</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="6" column="0">
-                 <widget class="QLabel" name="lblDiffConst">
-                  <property name="toolTip">
-                   <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
-&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
-                  </property>
-                  <property name="text">
-                   <string>Diffusion Constant:</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="7" column="0">
-                 <widget class="QLabel" name="lblSpeciesColourLabel">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>The colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>The colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>The colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="text">
-                   <string>Colour:</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="5">
+                <item row="3" column="6">
                  <widget class="QComboBox" name="cmbImportExampleConcentration">
                   <property name="currentText">
                    <string>example images...</string>
@@ -901,55 +827,52 @@
                   </item>
                  </widget>
                 </item>
-                <item row="2" column="2" colspan="4">
-                 <widget class="QLineEdit" name="txtInitialConcentration">
+                <item row="6" column="0">
+                 <widget class="QLabel" name="lblDiffConst">
+                  <property name="toolTip">
+                   <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
+&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>Diffusion Constant:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="lblSpeciesIsConstant">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                 </widget>
-                </item>
-                <item row="0" column="1" colspan="5">
-                 <widget class="QCheckBox" name="chkSpeciesIsSpatial">
                   <property name="toolTip">
-                   <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                   <string>A constant species has a fixed concentration</string>
                   </property>
                   <property name="statusTip">
-                   <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                   <string>A constant species has a fixed concentration</string>
                   </property>
                   <property name="whatsThis">
-                   <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+                   <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
                   </property>
                   <property name="text">
-                   <string>species concentration has a spatial dependence</string>
+                   <string>Constant:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                   </property>
                  </widget>
                 </item>
-                <item row="7" column="5">
-                 <widget class="QPushButton" name="btnChangeSpeciesColour">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Change the colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>Change the colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>Change the colour that is used to display the concentration of this species</string>
-                  </property>
-                  <property name="text">
-                   <string>change colour...</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="7" column="1" colspan="4">
+                <item row="7" column="1" colspan="5">
                  <widget class="QLabel" name="lblSpeciesColour">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -980,7 +903,96 @@
                   </property>
                  </widget>
                 </item>
-                <item row="6" column="1" colspan="5">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblSpeciesIsSpacial">
+                  <property name="toolTip">
+                   <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>Spatial:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QRadioButton" name="radInitialConcentrationVarying">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>Spatially varying initial concentration: varies with position</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>Spatially varying initial concentration: varies with position</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;Spatially varying initial concentration&lt;/h4&gt;
+&lt;p&gt;The initial concentration of the species can vary depending on the location within the compartment.&lt;/p&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>Spatially varying</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="3" colspan="3">
+                 <widget class="QPushButton" name="btnImportConcentration">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>Import an image of the spatial concentration of this species</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>Import an image of the spatial concentration of this species</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>&lt;h4&gt;import from image&lt;/h4&gt;&lt;p&gt;Import an image of the spatial concentration of this species&lt;/p&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>import from image...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="6">
+                 <widget class="QPushButton" name="btnChangeSpeciesColour">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>Change the colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>Change the colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>Change the colour that is used to display the concentration of this species</string>
+                  </property>
+                  <property name="text">
+                   <string>change colour...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1" colspan="6">
                  <widget class="QLineEdit" name="txtDiffusionConstant">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1000,25 +1012,26 @@
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="1" colspan="5">
-                 <widget class="QCheckBox" name="chkSpeciesIsConstant">
+                <item row="3" column="2">
+                 <widget class="QPushButton" name="btnAnalyticConcentration">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="toolTip">
-                   <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>'Constant': species concentration cannot be altered by the simulation</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-                  </property>
                   <property name="text">
-                   <string>species concentration is fixed throughout the whole simulation</string>
+                   <string>analytic...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2" colspan="5">
+                 <widget class="QLineEdit" name="txtInitialConcentration">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
add analytic initial conditions
  - resolves #71
  - as initialAssignment in SBML
  - as `.initial` in DUNE ini file
  - in both cases they take precedence over any initialCondition value
  - todo: syntax checking of analytic expression given by user

add `x`, `y` as parameters
  - in SBML they are spatial refs to the X and Y spatial coordinates
  - use them in analytic initial conditions
  - todo: check for clashes with existing `x` or `y` vars when importing SBML

add image initial conditions for DUNE
  - resolves #70
  - create 16-bit grayscale TIFF of initial concentration
     - zero concentration = black
     - max concentration = white
     - set TIFFTAG_XRESOLUTION, TIFFTAG_YRESOLUTION to inverse pixelWidth
     - add species_initialConcentration to [model.data]
  - DUNE then imports and rescales this to [0,1]
     - in `initial` can then refer to species_initialConcentration(x,y)
     - where DUNE multiplies x,y by TIFFTAG_?RESOLUTION to convert to pixel locations in image
     - then need to multiply result by max concentration
  - todo: transfer tiff in memory instead of creating a bunch of image files

improve dune visualization
  - resolves #78
  - removed old method of displaying average for each triangle
  - now identify all pixels that belong to each triangle
  - evaluate dune grid function to get concentration at each pixel
     - or optionally just linearly interpolate between corner values
     - (the two methods should be equivalent for first order FEM)
  - set any negative concentrations to zero