### PR TITLE
divide membrane reactions by area

### DIFF
--- a/inc/simulate.hpp
+++ b/inc/simulate.hpp
@@ -44,7 +44,9 @@ class ReacEval {
   ReacEval() = default;
   ReacEval(sbml::SbmlDocWrapper *doc_ptr,
            const std::vector<std::string> &speciesID,
-           const std::vector<std::string> &reactionID, BACKEND mathBackend);
+           const std::vector<std::string> &reactionID,
+           const std::vector<std::string> &reactionScaleFactors,
+           BACKEND mathBackend);
   void evaluate();
   const std::vector<double> &getResult() const { return result; }
 };

--- a/test/inc/sbml_test_data/very_simple_model.hpp
+++ b/test/inc/sbml_test_data/very_simple_model.hpp
@@ -5,8 +5,35 @@ namespace sbml_test_data {
 struct very_simple_model {
   const char* xml =
       R"=====(<?xml version="1.0" encoding="UTF-8"?>
-    <sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
-      <model metaid="COPASI0" id="New_Model" name="New Model">
+    <sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+      <model metaid="COPASI0" id="New_Model" name="New Model" substanceUnits="substance" timeUnits="unit_of_time" volumeUnits="unit_of_volume" areaUnits="area" lengthUnits="unit_of_length" extentUnits="substance">
+      <listOfUnitDefinitions>
+        <unitDefinition id="area" name="metre squared">
+          <listOfUnits>
+            <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+          </listOfUnits>
+        </unitDefinition>
+        <unitDefinition id="substance" name="mole">
+          <listOfUnits>
+            <unit kind="mole" exponent="1" scale="0" multiplier="1"/>
+          </listOfUnits>
+        </unitDefinition>
+        <unitDefinition id="unit_of_time" name="second">
+          <listOfUnits>
+            <unit kind="second" exponent="1" scale="0" multiplier="1"/>
+          </listOfUnits>
+        </unitDefinition>
+        <unitDefinition id="unit_of_length" name="metre">
+          <listOfUnits>
+            <unit kind="metre" exponent="1" scale="0" multiplier="1"/>
+          </listOfUnits>
+        </unitDefinition>
+        <unitDefinition id="unit_of_volume" name="metre cubed">
+          <listOfUnits>
+            <unit kind="metre" exponent="3" scale="0" multiplier="1"/>
+          </listOfUnits>
+        </unitDefinition>
+      </listOfUnitDefinitions>
         <listOfCompartments>
           <compartment metaid="COPASI1" id="c1" name="c1" spatialDimensions="3" size="10" constant="true">
           </compartment>
@@ -16,26 +43,26 @@ struct very_simple_model {
           </compartment>
         </listOfCompartments>
         <listOfSpecies>
-          <species metaid="COPASI4" id="A_c1" name="A" compartment="c1" initialConcentration="1" boundaryCondition="true" constant="true">
+          <species metaid="COPASI4" id="A_c1" name="A" compartment="c1" substanceUnits="substance" hasOnlySubstanceUnits="false"  initialConcentration="1" boundaryCondition="true" constant="true">
           </species>
-          <species metaid="COPASI5" id="A_c2" name="A" compartment="c2" initialConcentration="0" boundaryCondition="false" constant="false">
+          <species metaid="COPASI5" id="A_c2" name="A" compartment="c2" substanceUnits="substance" hasOnlySubstanceUnits="false" initialConcentration="0" boundaryCondition="false" constant="false">
           </species>
-          <species metaid="COPASI6" id="A_c3" name="A" compartment="c3" initialConcentration="0" boundaryCondition="false" constant="false">
+          <species metaid="COPASI6" id="A_c3" name="A" compartment="c3" substanceUnits="substance" hasOnlySubstanceUnits="false" initialConcentration="0" boundaryCondition="false" constant="false">
           </species>
-          <species metaid="COPASI7" id="B_c3" name="B" compartment="c3" initialConcentration="0" boundaryCondition="false" constant="false">
+          <species metaid="COPASI7" id="B_c3" name="B" compartment="c3" substanceUnits="substance" hasOnlySubstanceUnits="false" initialConcentration="0" boundaryCondition="false" constant="false">
           </species>
-          <species metaid="COPASI8" id="B_c2" name="B" compartment="c2" initialConcentration="0" boundaryCondition="false" constant="false">
+          <species metaid="COPASI8" id="B_c2" name="B" compartment="c2" substanceUnits="substance" hasOnlySubstanceUnits="false" initialConcentration="0" boundaryCondition="false" constant="false">
           </species>
-          <species metaid="COPASI9" id="B_c1" name="B" compartment="c1" initialConcentration="0" boundaryCondition="false" constant="false">
+          <species metaid="COPASI9" id="B_c1" name="B" compartment="c1" substanceUnits="substance" hasOnlySubstanceUnits="false" initialConcentration="0" boundaryCondition="false" constant="false">
           </species>
         </listOfSpecies>
         <listOfReactions>
           <reaction metaid="COPASI10" id="A_uptake" name="A_uptake" reversible="false">
             <listOfReactants>
-              <speciesReference species="A_c1" stoichiometry="1"/>
+              <speciesReference species="A_c1" stoichiometry="1" constant="true"/>
             </listOfReactants>
             <listOfProducts>
-              <speciesReference species="A_c2" stoichiometry="1"/>
+              <speciesReference species="A_c2" stoichiometry="1" constant="true"/>
             </listOfProducts>
             <kineticLaw>
               <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -45,17 +72,17 @@ struct very_simple_model {
                   <ci> A_c1 </ci>
                 </apply>
               </math>
-              <listOfParameters>
-                <parameter id="k1" name="k1" value="0.1"/>
-              </listOfParameters>
+              <listOfLocalParameters>
+                <localParameter id="k1" name="k1" value="0.1"/>
+              </listOfLocalParameters>
             </kineticLaw>
           </reaction>
           <reaction metaid="COPASI11" id="A_transport" name="A_transport" reversible="true">
             <listOfReactants>
-              <speciesReference species="A_c2" stoichiometry="1"/>
+              <speciesReference species="A_c2" stoichiometry="1" constant="true"/>
             </listOfReactants>
             <listOfProducts>
-              <speciesReference species="A_c3" stoichiometry="1"/>
+              <speciesReference species="A_c3" stoichiometry="1" constant="true"/>
             </listOfProducts>
             <kineticLaw>
               <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -73,18 +100,18 @@ struct very_simple_model {
                   </apply>
                 </apply>
               </math>
-              <listOfParameters>
-                <parameter id="k1" name="k1" value="0.1"/>
-                <parameter id="k2" name="k2" value="0.1"/>
-              </listOfParameters>
+              <listOfLocalParameters>
+                <localParameter id="k1" name="k1" value="0.1"/>
+                <localParameter id="k2" name="k2" value="0.1"/>
+              </listOfLocalParameters>
             </kineticLaw>
           </reaction>
           <reaction metaid="COPASI12" id="A_B_conversion" name="A_B_conversion" reversible="false">
             <listOfReactants>
-              <speciesReference species="A_c3" stoichiometry="1"/>
+              <speciesReference species="A_c3" stoichiometry="1" constant="true"/>
             </listOfReactants>
             <listOfProducts>
-              <speciesReference species="B_c3" stoichiometry="1"/>
+              <speciesReference species="B_c3" stoichiometry="1" constant="true"/>
             </listOfProducts>
             <kineticLaw>
               <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -95,17 +122,17 @@ struct very_simple_model {
                   <ci> A_c3 </ci>
                 </apply>
               </math>
-              <listOfParameters>
-                <parameter id="k1" name="k1" value="0.3"/>
-              </listOfParameters>
+              <listOfLocalParameters>
+                <localParameter id="k1" name="k1" value="0.3"/>
+              </listOfLocalParameters>
             </kineticLaw>
           </reaction>
           <reaction metaid="COPASI13" id="B_transport" name="B_transport" reversible="false">
             <listOfReactants>
-              <speciesReference species="B_c3" stoichiometry="1"/>
+              <speciesReference species="B_c3" stoichiometry="1" constant="true"/>
             </listOfReactants>
             <listOfProducts>
-              <speciesReference species="B_c2" stoichiometry="1"/>
+              <speciesReference species="B_c2" stoichiometry="1" constant="true"/>
             </listOfProducts>
             <kineticLaw>
               <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -115,17 +142,17 @@ struct very_simple_model {
                   <ci> B_c3 </ci>
                 </apply>
               </math>
-              <listOfParameters>
-                <parameter id="k1" name="k1" value="0.1"/>
-              </listOfParameters>
+              <listOfLocalParameters>
+                <localParameter id="k1" name="k1" value="0.1"/>
+              </listOfLocalParameters>
             </kineticLaw>
           </reaction>
           <reaction metaid="COPASI14" id="B_excretion" name="B_excretion" reversible="false">
             <listOfReactants>
-              <speciesReference species="B_c2" stoichiometry="1"/>
+              <speciesReference species="B_c2" stoichiometry="1" constant="true"/>
             </listOfReactants>
             <listOfProducts>
-              <speciesReference species="B_c1" stoichiometry="1"/>
+              <speciesReference species="B_c1" stoichiometry="1" constant="true"/>
             </listOfProducts>
             <kineticLaw>
               <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -135,9 +162,9 @@ struct very_simple_model {
                   <ci> B_c2 </ci>
                 </apply>
               </math>
-              <listOfParameters>
-                <parameter id="k1" name="k1" value="0.2"/>
-              </listOfParameters>
+              <listOfLocalParameters>
+                <localParameter id="k1" name="k1" value="0.2"/>
+              </listOfLocalParameters>
             </kineticLaw>
           </reaction>
         </listOfReactions>

--- a/test/src/test_simulate.cpp
+++ b/test/src/test_simulate.cpp
@@ -27,6 +27,7 @@ SCENARIO("simulate very_simple_model: single pixel geometry",
   img.setPixel(0, 2, col3);
   img.save("tmp.bmp");
   s.importGeometryFromImage("tmp.bmp");
+  s.setPixelWidth(1.0);
   s.setCompartmentColour("c1", col1);
   s.setCompartmentColour("c2", col2);
   s.setCompartmentColour("c3", col3);
@@ -102,7 +103,6 @@ SCENARIO("simulate very_simple_model: single pixel geometry",
 
   double dt = 0.134521234;
   double volC1 = 10.0;
-  double volC3 = 0.2;
   WHEN("single Euler step") {
     sim.integrateForwardsEuler(dt);
     // A_c1 = 1 = const

--- a/test/src/test_symbolic.cpp
+++ b/test/src/test_symbolic.cpp
@@ -192,7 +192,16 @@ TEST_CASE("invalid variable relabeling is a no-op", "[symbolic][non-gui]") {
   REQUIRE(sym.simplify() == expr);
 }
 
-TEST_CASE("divide expression", "[symbolic][non-gui][QQ]") {
+TEST_CASE("divide expression with number", "[symbolic][non-gui][QQ]") {
+  REQUIRE(symbolic::divide("x", "1.3") == "x/1.3");
+  REQUIRE(symbolic::divide("1", "2") == "2**(-1)");
+  REQUIRE(symbolic::divide("10*x", "5") == "10*x/5");
+  REQUIRE(symbolic::divide("(cos(x))^2+3", "3.14") == "(3 + cos(x)**2)/3.14");
+  REQUIRE(symbolic::divide("2*unknown_function(a,b,c)", "2") ==
+          "2*unknown_function(a, b, c)/2");
+}
+
+TEST_CASE("divide expression with symbol", "[symbolic][non-gui][QQ]") {
   REQUIRE(symbolic::divide("x", "x") == "1");
   REQUIRE(symbolic::divide("1", "x") == "x**(-1)");
   REQUIRE(symbolic::divide("0", "x") == "0");


### PR DESCRIPTION
  - for reactions that involve species from two compartments
  - these have units amount/time in non-spatial sbml
  - in spatial sbml have flux: amount/membrane area/time
  - once membrane geometry is known
    - set isSpatial true for such reactions
    - divide equation by area of membrane
  - resolves #102 

fix pde / simulation of membranes
  - convert flux to concentration by
    - dividing by LENGTH^3/VOLUME units factor
    - dividing by membrane width