### PR TITLE
minor symbolic fixes

### DIFF
--- a/src/dialoganalytic.cpp
+++ b/src/dialoganalytic.cpp
@@ -137,7 +137,7 @@ void DialogAnalytic::txtExpression_textChanged() {
     }
     // construct image of concentration
     if (expressionIsValid) {
-      expression = ui->txtExpression->toPlainText().toStdString();
+      expression = sym.simplify();
       // normalise intensity to max concentration
       double maxConc =
           *std::max_element(concentration.cbegin(), concentration.cend());

--- a/src/symbolic.cpp
+++ b/src/symbolic.cpp
@@ -52,8 +52,7 @@ void muPrinter::_print_pow(std::ostringstream &o, const RCP<const Basic> &a,
 namespace symbolic {
 
 static std::string toString(const SymEngine::RCP<const SymEngine::Basic> &e) {
-  SymEngine::muPrinter p;
-  return p.apply(e);
+  return SymEngine::muPrinter().apply(e);
 }
 
 class Symbolic::SymEngineImpl {
@@ -131,7 +130,7 @@ void Symbolic::SymEngineImpl::relabel(
 }
 
 std::string divide(const std::string &expr, const std::string &var) {
-  return SymEngine::StrPrinter().apply(
+  return SymEngine::muPrinter().apply(
       SymEngine::div(SymEngine::parse(expr), SymEngine::symbol(var)));
 }
 

--- a/test/src/test_symbolic.cpp
+++ b/test/src/test_symbolic.cpp
@@ -194,16 +194,16 @@ TEST_CASE("invalid variable relabeling is a no-op", "[symbolic][non-gui]") {
 
 TEST_CASE("divide expression with number", "[symbolic][non-gui][QQ]") {
   REQUIRE(symbolic::divide("x", "1.3") == "x/1.3");
-  REQUIRE(symbolic::divide("1", "2") == "2**(-1)");
+  REQUIRE(symbolic::divide("1", "2") == "2^(-1)");
   REQUIRE(symbolic::divide("10*x", "5") == "10*x/5");
-  REQUIRE(symbolic::divide("(cos(x))^2+3", "3.14") == "(3 + cos(x)**2)/3.14");
+  REQUIRE(symbolic::divide("(cos(x))^2+3", "3.14") == "(3 + cos(x)^2)/3.14");
   REQUIRE(symbolic::divide("2*unknown_function(a,b,c)", "2") ==
           "2*unknown_function(a, b, c)/2");
 }
 
 TEST_CASE("divide expression with symbol", "[symbolic][non-gui][QQ]") {
   REQUIRE(symbolic::divide("x", "x") == "1");
-  REQUIRE(symbolic::divide("1", "x") == "x**(-1)");
+  REQUIRE(symbolic::divide("1", "x") == "x^(-1)");
   REQUIRE(symbolic::divide("0", "x") == "0");
   REQUIRE(symbolic::divide("x^2", "x") == "x");
   REQUIRE(symbolic::divide("x+3*x", "x") == "4");


### PR DESCRIPTION
      - return parsed&simplified expression from analytic concentration dialog instead of string directly provided by user
      - use same math printer for divide function as for the rest of the symbolic routines, for muParser/SBML compatibility