### PR TITLE
allow user to change species Compartment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ matrix:
         - ls
         - cd ../
         # upload coverage report to codecov.io
-        - bash <(curl -s https://codecov.io/bash) -X gcov -F unit
+        - bash <(curl --connect-timeout 10 --retry 5 -v -s https://codecov.io/bash) -X gcov -F unit
 
         # integration tests (i.e. mainwindow)
         - rm src/*.gcda
@@ -144,7 +144,7 @@ matrix:
         - ls
         - cd ../
         # upload coverage report to codecov.io
-        - bash <(curl -s https://codecov.io/bash) -X gcov -f '!*/gcov-unit/*' -F integration
+        - bash <(curl --connect-timeout 10 --retry 5 -v https://codecov.io/bash) -X gcov -f '!*/gcov-unit/*' -F integration
 
         # run all tests again for sonarsource
         # inefficient but haven't found a way to combine previous coverage data such that sonarsource can read it

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.6.3
+        VERSION 0.6.5
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 

--- a/inc/geometry.hpp
+++ b/inc/geometry.hpp
@@ -74,6 +74,7 @@ class Field {
   bool isSpatial;
   // field.dcdt = result of the diffusion operator acting on field.conc
   void applyDiffusionOperator();
+  void setCompartment(const Compartment *compartment);
 };
 
 }  // namespace geometry

--- a/inc/mainwindow.hpp
+++ b/inc/mainwindow.hpp
@@ -117,6 +117,10 @@ class MainWindow : public QMainWindow {
   void listSpecies_currentItemChanged(QTreeWidgetItem *current,
                                       QTreeWidgetItem *previous);
 
+  void txtSpeciesName_editingFinished();
+
+  void cmbSpeciesCompartment_activated(int index);
+
   void chkSpeciesIsSpatial_toggled(bool enabled);
 
   void chkSpeciesIsConstant_toggled(bool enabled);

--- a/inc/sbml.hpp
+++ b/inc/sbml.hpp
@@ -140,8 +140,6 @@ class SbmlDocWrapper {
 
   void writeGeometryImageToSBML();
 
-  void setSBMLCompartmentSizeUnit(int metreExponent);
-
   // return supplied math expression as string with any Function calls inlined
   // e.g. given mathExpression = "z*f(x,y)"
   // where the SBML model contains a function "f(a,b) = a*b-2"
@@ -207,6 +205,10 @@ class SbmlDocWrapper {
   SpeciesGeometry getSpeciesGeometry(const QString &speciesID) const;
   QString getCompartmentSizeUnits(const QString &compartmentID) const;
 
+  QString getSpeciesCompartment(const QString &speciesID) const;
+  void setSpeciesCompartment(const QString &speciesID,
+                             const QString &compartmentID);
+
   // compartment geometry: interiorPoints - used for mesh generation
   std::optional<QPointF> getCompartmentInteriorPoint(
       const QString &compartmentID) const;
@@ -250,6 +252,7 @@ class SbmlDocWrapper {
   void setIsSpeciesConstant(const std::string &speciesID, bool constant);
   bool getIsSpeciesConstant(const std::string &speciesID) const;
 
+  void setSpeciesName(const QString &speciesID, const QString &name);
   QString getSpeciesName(const QString &speciesID) const;
   QString getReactionName(const QString &reactionID) const;
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -169,4 +169,15 @@ double Field::getMeanConcentration() const {
          static_cast<double>(conc.size());
 }
 
+void Field::setCompartment(const Compartment *compartment) {
+  if (geometry == compartment) {
+    return;
+  }
+  SPDLOG_DEBUG("Changing compartment to {}", compartment->compartmentID);
+  geometry = compartment;
+  conc.assign(geometry->ix.size(), 0.0);
+  dcdt = conc;
+  init = conc;
+}
+
 }  // namespace geometry

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.6.4";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.6.5";

--- a/test/src/test_symbolic.cpp
+++ b/test/src/test_symbolic.cpp
@@ -192,7 +192,7 @@ TEST_CASE("invalid variable relabeling is a no-op", "[symbolic][non-gui]") {
   REQUIRE(sym.simplify() == expr);
 }
 
-TEST_CASE("divide expression with number", "[symbolic][non-gui][QQ]") {
+TEST_CASE("divide expression with number", "[symbolic][non-gui]") {
   REQUIRE(symbolic::divide("x", "1.3") == "x/1.3");
   REQUIRE(symbolic::divide("1", "2") == "2^(-1)");
   REQUIRE(symbolic::divide("10*x", "5") == "10*x/5");
@@ -201,7 +201,7 @@ TEST_CASE("divide expression with number", "[symbolic][non-gui][QQ]") {
           "2*unknown_function(a, b, c)/2");
 }
 
-TEST_CASE("divide expression with symbol", "[symbolic][non-gui][QQ]") {
+TEST_CASE("divide expression with symbol", "[symbolic][non-gui]") {
   REQUIRE(symbolic::divide("x", "x") == "1");
   REQUIRE(symbolic::divide("1", "x") == "x^(-1)");
   REQUIRE(symbolic::divide("0", "x") == "0");
@@ -209,7 +209,7 @@ TEST_CASE("divide expression with symbol", "[symbolic][non-gui][QQ]") {
   REQUIRE(symbolic::divide("x+3*x", "x") == "4");
 }
 
-TEST_CASE("divide expression with other symbols", "[symbolic][non-gui][QQ]") {
+TEST_CASE("divide expression with other symbols", "[symbolic][non-gui]") {
   REQUIRE(symbolic::divide("x+a", "x") == "(a + x)/x");
   REQUIRE(symbolic::divide("x+y", "x") == "(x + y)/x");
   REQUIRE(symbolic::divide("y*x", "x") == "y");
@@ -217,7 +217,7 @@ TEST_CASE("divide expression with other symbols", "[symbolic][non-gui][QQ]") {
 }
 
 TEST_CASE("divide expression with other symbols & functions",
-          "[symbolic][non-gui][QQ]") {
+          "[symbolic][non-gui]") {
   REQUIRE(symbolic::divide("sin(x+a)", "x") == "sin(a + x)/x");
   REQUIRE(symbolic::divide("x*sin(x+a)", "x") == "sin(a + x)");
   REQUIRE(symbolic::divide("x*unknown(z)", "x") == "unknown(z)");

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -16,6 +16,11 @@ TEST_CASE("QStringList <-> std::vector<std::string>", "[utils]") {
   REQUIRE(q2s == s);
   REQUIRE(utils::toQString(q2s) == q);
   REQUIRE(utils::toStdString(s2q) == s);
+
+  QStringList qEmpty;
+  std::vector<std::string> sEmpty;
+  REQUIRE(utils::toStdString(qEmpty) == sEmpty);
+  REQUIRE(utils::toQString(sEmpty) == qEmpty);
 }
 
 TEST_CASE("vector <-> string: int", "[utils]") {

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -28,26 +28,6 @@
       </property>
       <widget class="QWidget" name="gridLayoutWidget">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="lblGeometryStatus">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QPushButton" name="btnSpeciesDisplaySelect">
-          <property name="text">
-           <string>Species</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0" colspan="2">
          <widget class="QLabelMouseTracker" name="lblGeometry" native="true">
           <property name="sizePolicy">
@@ -78,6 +58,19 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QLabel" name="lblGeometryStatus">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QTabWidget" name="tabMain">
@@ -94,7 +87,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>5</number>
        </property>
        <widget class="QWidget" name="tabGeometry">
         <property name="whatsThis">
@@ -759,90 +752,14 @@
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
               <layout class="QGridLayout" name="gridSpeciesSettings">
-               <item row="2" column="0" rowspan="3">
-                <widget class="QLabel" name="lblInitConc">
+               <item row="4" column="8">
+                <widget class="QLabel" name="lblInitialConcentrationUnits">
                  <property name="text">
-                  <string>Initial Concentration:</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  <string/>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="2">
-                <widget class="QRadioButton" name="radInitialConcentrationUniform">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Spatially uniform initial concentration: no spatial dependence</string>
-                 </property>
-                 <property name="statusTip">
-                  <string>Spatially uniform initial concentration: no spatial dependence</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;h4&gt;Spatially uniform initial concentration&lt;/h4&gt;
-&lt;p&gt;The initial concentration of the species is the same everywhere in the compartment.&lt;/p&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>Spatially uniform</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="lblSpeciesColourLabel">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>The colour that is used to display the concentration of this species</string>
-                 </property>
-                 <property name="statusTip">
-                  <string>The colour that is used to display the concentration of this species</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>The colour that is used to display the concentration of this species</string>
-                 </property>
-                 <property name="text">
-                  <string>Colour:</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2" colspan="7">
-                <widget class="QCheckBox" name="chkSpeciesIsConstant">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
-                 </property>
-                 <property name="statusTip">
-                  <string>'Constant': species concentration cannot be altered by the simulation</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>species concentration is fixed throughout the whole simulation</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
+               <item row="3" column="0">
                 <widget class="QLabel" name="lblSpeciesIsConstant">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -867,55 +784,10 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="lblSpeciesIsSpacial">
-                 <property name="toolTip">
-                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-                 </property>
-                 <property name="statusTip">
-                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>Spatial:</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="2" colspan="7">
-                <widget class="QCheckBox" name="chkSpeciesIsSpatial">
-                 <property name="toolTip">
-                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-                 </property>
-                 <property name="statusTip">
-                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>species concentration has a spatial dependence</string>
-                 </property>
-                </widget>
+                <widget class="QLineEdit" name="txtSpeciesName"/>
                </item>
-               <item row="3" column="3" colspan="6">
-                <widget class="QPushButton" name="btnEditAnalyticConcentration">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>edit expression...</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
+               <item row="9" column="0">
                 <widget class="QLabel" name="lblDiffConst">
                  <property name="toolTip">
                   <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
@@ -935,7 +807,74 @@
                  </property>
                 </widget>
                </item>
-               <item row="3" column="2">
+               <item row="3" column="2" colspan="7">
+                <widget class="QCheckBox" name="chkSpeciesIsConstant">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
+                 </property>
+                 <property name="statusTip">
+                  <string>'Constant': species concentration cannot be altered by the simulation</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>species concentration is fixed throughout the whole simulation</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="2" colspan="6">
+                <widget class="QLineEdit" name="txtDiffusionConstant">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                 </property>
+                 <property name="statusTip">
+                  <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
+&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="lblSpeciesColourLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>The colour that is used to display the concentration of this species</string>
+                 </property>
+                 <property name="statusTip">
+                  <string>The colour that is used to display the concentration of this species</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>The colour that is used to display the concentration of this species</string>
+                 </property>
+                 <property name="text">
+                  <string>Colour:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
                 <widget class="QRadioButton" name="radInitialConcentrationAnalytic">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -958,7 +897,53 @@
                  </property>
                 </widget>
                </item>
-               <item row="8" column="8">
+               <item row="9" column="8">
+                <widget class="QLabel" name="lblDiffusionConstantUnits">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="lblSpeciesIsSpacial">
+                 <property name="toolTip">
+                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                 </property>
+                 <property name="statusTip">
+                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Spatial:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0" rowspan="3">
+                <widget class="QLabel" name="lblInitConc">
+                 <property name="text">
+                  <string>Initial Concentration:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="lblSpeciesName">
+                 <property name="text">
+                  <string>Name:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="8">
                 <widget class="QPushButton" name="btnChangeSpeciesColour">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -980,17 +965,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="2" column="3" colspan="5">
-                <widget class="QLineEdit" name="txtInitialConcentration">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="2" colspan="6">
+               <item row="11" column="2" colspan="6">
                 <widget class="QLabel" name="lblSpeciesColour">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -1021,29 +996,24 @@
                  </property>
                 </widget>
                </item>
-               <item row="2" column="8">
-                <widget class="QLabel" name="lblInitialConcentrationUnits">
+               <item row="2" column="2" colspan="7">
+                <widget class="QCheckBox" name="chkSpeciesIsSpatial">
+                 <property name="toolTip">
+                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                 </property>
+                 <property name="statusTip">
+                  <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+                 </property>
                  <property name="text">
-                  <string/>
+                  <string>species concentration has a spatial dependence</string>
                  </property>
                 </widget>
                </item>
                <item row="4" column="2">
-                <widget class="QRadioButton" name="radInitialConcentrationImage">
-                 <property name="text">
-                  <string>Concentration image</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="8">
-                <widget class="QLabel" name="lblDiffusionConstantUnits">
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="2" colspan="6">
-                <widget class="QLineEdit" name="txtDiffusionConstant">
+                <widget class="QRadioButton" name="radInitialConcentrationUniform">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                    <horstretch>0</horstretch>
@@ -1051,18 +1021,24 @@
                   </sizepolicy>
                  </property>
                  <property name="toolTip">
-                  <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                  <string>Spatially uniform initial concentration: no spatial dependence</string>
                  </property>
                  <property name="statusTip">
-                  <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+                  <string>Spatially uniform initial concentration: no spatial dependence</string>
                  </property>
                  <property name="whatsThis">
-                  <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
-&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
+                  <string>&lt;h4&gt;Spatially uniform initial concentration&lt;/h4&gt;
+&lt;p&gt;The initial concentration of the species is the same everywhere in the compartment.&lt;/p&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Spatially uniform</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="3" colspan="6">
+               <item row="6" column="3" colspan="6">
                 <widget class="QPushButton" name="btnEditImageConcentration">
                  <property name="enabled">
                   <bool>true</bool>
@@ -1086,6 +1062,49 @@
                   <string>edit image...</string>
                  </property>
                 </widget>
+               </item>
+               <item row="4" column="3" colspan="5">
+                <widget class="QLineEdit" name="txtInitialConcentration">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="3" colspan="6">
+                <widget class="QPushButton" name="btnEditAnalyticConcentration">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>edit expression...</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="2">
+                <widget class="QRadioButton" name="radInitialConcentrationImage">
+                 <property name="text">
+                  <string>Concentration image</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="lblSpeciesCompartment">
+                 <property name="text">
+                  <string>Compartment:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2" colspan="7">
+                <widget class="QComboBox" name="cmbSpeciesCompartment"/>
                </item>
               </layout>
              </item>
@@ -1886,6 +1905,47 @@
    <header>qlabelmousetracker.hpp</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabMain</tabstop>
+  <tabstop>listCompartments</tabstop>
+  <tabstop>txtCompartmentSize</tabstop>
+  <tabstop>btnSetCompartmentSizeFromImage</tabstop>
+  <tabstop>tabCompartmentGeometry</tabstop>
+  <tabstop>btnChangeCompartment</tabstop>
+  <tabstop>hslideTime</tabstop>
+  <tabstop>spinBoundaryIndex</tabstop>
+  <tabstop>spinMaxBoundaryPoints</tabstop>
+  <tabstop>spinBoundaryWidth</tabstop>
+  <tabstop>spinMaxTriangleArea</tabstop>
+  <tabstop>listMembranes</tabstop>
+  <tabstop>listSpecies</tabstop>
+  <tabstop>btnEditImageConcentration</tabstop>
+  <tabstop>btnChangeSpeciesColour</tabstop>
+  <tabstop>btnEditAnalyticConcentration</tabstop>
+  <tabstop>txtInitialConcentration</tabstop>
+  <tabstop>chkSpeciesIsConstant</tabstop>
+  <tabstop>radInitialConcentrationUniform</tabstop>
+  <tabstop>radInitialConcentrationAnalytic</tabstop>
+  <tabstop>txtDiffusionConstant</tabstop>
+  <tabstop>radInitialConcentrationImage</tabstop>
+  <tabstop>chkSpeciesIsSpatial</tabstop>
+  <tabstop>cmbSpeciesCompartment</tabstop>
+  <tabstop>listReactions</tabstop>
+  <tabstop>listReactionParams</tabstop>
+  <tabstop>listReactants</tabstop>
+  <tabstop>listProducts</tabstop>
+  <tabstop>listFunctions</tabstop>
+  <tabstop>listFunctionParams</tabstop>
+  <tabstop>txtSimLength</tabstop>
+  <tabstop>btnSimulate</tabstop>
+  <tabstop>txtSimDt</tabstop>
+  <tabstop>btnResetSimulation</tabstop>
+  <tabstop>txtSimInterval</tabstop>
+  <tabstop>txtSBML</tabstop>
+  <tabstop>txtDUNE</tabstop>
+  <tabstop>txtGMSH</tabstop>
+  <tabstop>txtSpeciesName</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
  - when compartment of a species is changed
     - field updated with new compartment geometry
     - initial condition for concentration set to uniform
     - SBML updated
     - species list updated
     - reactions list updated
        - note that some reactions may change from compartment to membrane reactions and vice versa

also
  - allow user to change species Name
  - display species Name instead of Id in simulation results plot
  - don't simulate empty membranes with Pixel simulation