### PR TITLE
improve simulation results graph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ jobs:
         - source /opt/qt512/bin/qt512-env.sh
       script:
         # build tests & compile executable using sonar-source build wrapper
-        - ccache --show-stats
+        - ccache --zero-stats
         - mkdir build
         - cd build
         - /usr/bin/cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;`pwd`/../ext/dune" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.7.0
+        VERSION 0.7.1
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.7.0";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.7.1";

--- a/src/gui/tabs/qtabsimulate.hpp
+++ b/src/gui/tabs/qtabsimulate.hpp
@@ -9,6 +9,7 @@ namespace Ui {
 class QTabSimulate;
 }
 class QCustomPlot;
+class QCPItemStraightLine;
 class QCPAbstractPlottable;
 class QLabelMouseTracker;
 namespace sbml {
@@ -33,13 +34,15 @@ class QTabSimulate : public QWidget {
   sbml::SbmlDocWrapper &sbmlDoc;
   QLabelMouseTracker *lblGeometry;
   QCustomPlot *pltPlot;
+  QCPItemStraightLine *pltTimeLine;
+  QVector<double> time;
   QVector<QImage> images;
   bool isSimulationRunning = false;
   bool useDuneSimulator = true;
 
   void btnSimulate_clicked();
 
-  void graphClicked(QCPAbstractPlottable *plottable, int dataIndex);
+  void graphClicked(const QMouseEvent *event);
 
   void hslideTime_valueChanged(int value);
 };

--- a/src/gui/tabs/qtabsimulate.ui
+++ b/src/gui/tabs/qtabsimulate.ui
@@ -22,7 +22,7 @@
         <string>Reset all concentrations to their initial values, clear all simulation data.</string>
        </property>
        <property name="text">
-        <string>Reset Simulation</string>
+        <string>Reset</string>
        </property>
       </widget>
      </item>
@@ -111,7 +111,7 @@
      <item row="0" column="7">
       <widget class="QPushButton" name="btnStopSimulation">
        <property name="text">
-        <string>Stop Simulation</string>
+        <string>Stop</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
  - for Pixel sim, plot every time point, not just ones which have images
  - time points with an image get a circle on plot, otherwise just a line
  - vertical line shows current image time point, controlled by slider below plot
  - Dune sim is now only initialized when simulate clicked if chosen simulator is Dune