### PR TITLE
add optional TBB support to Pixel simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         # run tests
         - ./build/test/test -as 2>&1 | tail -n 100
         # run benchmarks (~1 sec per benchmark, ~20secs total)
-        - ./build/benchmark/benchmark 1
+        - time ./build/benchmark/benchmark 1
         # check dependencies of resulting executable
         - cd build/src
         - ldd spatial-model-editor
@@ -67,7 +67,7 @@ jobs:
         # run tests
         - ./build/test/test.app/Contents/MacOS/test -as "~[gui]" 2>&1 | tail -n 100
         # run benchmarks (~1 sec per benchmark, ~20secs total)
-        - ./build/benchmark/benchmark.app/Contents/MacOS/benchmark 1
+        - time ./build/benchmark/benchmark.app/Contents/MacOS/benchmark 1
         # check dependencies of resulting executable
         - cd build/src
         - otool -L spatial-model-editor.app/Contents/MacOS/spatial-model-editor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,15 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.8.0
+        VERSION 0.8.1
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 # find required Qt5 modules
 
@@ -30,12 +34,18 @@ add_subdirectory(ext/triangle)
 add_subdirectory(ext/qcustomplot)
 
 # compile spatial model editor
+set(WITH_TBB yes CACHE BOOL "Build with TBB support (multithreading)")
 add_subdirectory(src)
 
 # compile tests
 include(CTest)
 include(Catch)
-add_subdirectory(test)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 # compile benchmarks
-add_subdirectory(benchmark)
+set(BUILD_BENCHMARKS yes CACHE BOOL "Build benchmarks")
+if(BUILD_BENCHMARKS)
+  add_subdirectory(benchmark)
+endif()

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 A GUI editor to convert non-spatial SBML models of bio-chemical reactions into 2d spatial models and simulate them using the [dune-copasi](https://gitlab.dune-project.org/copasi/dune-copasi) solver for reaction-diffusion systems.
 
-[<img src="docs/img/icon-linux.png" width="32"> linux executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor) |
-[<img src="docs/img/icon-osx.png" width="32"> mac executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor.dmg) |
-[<img src="docs/img/icon-windows.png" width="32"> windows executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor.exe) |
-[<img src="docs/img/icon-docs.png" width="32"> documentation](https://spatial-model-editor.readthedocs.io/en/latest/)
+[<img src="docs/quickstart/img/icon-linux.png" width="32"> linux executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor) |
+[<img src="docs/quickstart/img/icon-osx.png" width="32"> mac executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor.dmg) |
+[<img src="docs/quickstart/img/icon-windows.png" width="32"> windows executable](https://github.com/lkeegan/spatial-model-editor/releases/latest/download/spatial-model-editor.exe) |
+[<img src="docs/quickstart/img/icon-docs.png" width="32"> documentation](https://spatial-model-editor.readthedocs.io/en/latest/)
 ---|---|---|---
 
-![screenshot](docs/img/geometry.png)
+![screenshot](docs/quickstart/img/geometry.png)
 
 ## Project status
 
@@ -105,6 +105,11 @@ Translate the spatial model to a system of PDEs and simulate it: generate 2d tri
     -   Expat XML library <https://github.com/libexpat/libexpat>
 
         -   license: [MIT](https://github.com/libexpat/libexpat/blob/master/expat/COPYING)
+        -   using pre-compiled binaries from <https://github.com/lkeegan/libsbml-static>
+
+    -   Threading Building Blocks (TBB): <https://github.com/intel/tbb>
+
+        -   license: [Apache-2.0](https://github.com/intel/tbb/blob/tbb_2020/LICENSE)
         -   using pre-compiled binaries from <https://github.com/lkeegan/libsbml-static>
 
     -   Catch2 testing framework: <https://github.com/catchorg/Catch2>

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -128,6 +128,7 @@ static void printSimulatorBenchmarks(const BenchmarkParams &params) {
   spdlog::set_level(spdlog::level::off);
   // symengine assumes C locale
   std::locale::global(std::locale::classic());
+
   double dt = params.simulator_timestep;
 
   for (auto simulator : params.simulators) {

--- a/cmake/Findtbb.cmake
+++ b/cmake/Findtbb.cmake
@@ -1,0 +1,17 @@
+find_path(tbb_INCLUDE_DIR tbb/tbb.h)
+find_library(tbb_LIBRARY tbb)
+mark_as_advanced(tbb_INCLUDE_DIR tbb_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(tbb
+                                  REQUIRED_VARS
+                                  tbb_LIBRARY
+                                  tbb_INCLUDE_DIR)
+if(tbb_FOUND AND NOT TARGET tbb::tbb)
+  add_library(tbb::tbb UNKNOWN IMPORTED)
+  set_target_properties(tbb::tbb
+                        PROPERTIES IMPORTED_LOCATION
+                                   ${tbb_LIBRARY}
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   ${tbb_INCLUDE_DIR})
+endif()

--- a/common.pri
+++ b/common.pri
@@ -2,6 +2,9 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 CONFIG += c++17
 
+# enable use of TBB
+DEFINES += SPATIAL_MODEL_EDITOR_USE_TBB
+
 # set logging level (at compile time)
 CONFIG(release, debug|release):DEFINES += SPDLOG_ACTIVE_LEVEL="SPDLOG_LEVEL_INFO"
 CONFIG(debug, debug|release):DEFINES += SPDLOG_ACTIVE_LEVEL="SPDLOG_LEVEL_DEBUG"

--- a/ext/ext.pri
+++ b/ext/ext.pri
@@ -36,6 +36,7 @@ LIBS += \
     $${TOPDIR}/ext/lib/libfmt.a \
     $${TOPDIR}/ext/lib/libtiff.a \
     $${TOPDIR}/ext/lib/libmuparser.a \
+    $${TOPDIR}/ext/lib/libtbb.a \
 
 # these LLVM core static libraries are available pre-compiled from
 # https://github.com/lkeegan/llvm-static

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,13 @@ target_compile_definitions(
   SPDLOG_ACTIVE_LEVEL=$<$<CONFIG:Debug>:SPDLOG_LEVEL_TRACE>$<$<CONFIG:Release>:SPDLOG_LEVEL_INFO>
   )
 
+# use TBB
+if(WITH_TBB)
+  find_package(tbb REQUIRED)
+  target_compile_definitions(core PUBLIC SPATIAL_MODEL_EDITOR_USE_TBB)
+  target_link_libraries(core PUBLIC tbb::tbb)
+endif()
+
 # set Compile options and warnings
 
 set_target_properties(core PROPERTIES CXX_STANDARD 17)

--- a/src/core/pixelsim.hpp
+++ b/src/core/pixelsim.hpp
@@ -30,16 +30,13 @@ class ReacEval {
   std::vector<double> result;
 
  public:
-  // vector of species concentrations that Reaction expressions will use
-  std::vector<double> species_values;
   std::size_t nSpecies = 0;
   ReacEval() = default;
   ReacEval(const sbml::SbmlDocWrapper &doc,
            const std::vector<std::string> &speciesID,
            const std::vector<std::string> &reactionID,
            const std::vector<std::string> &reactionScaleFactors);
-  void evaluate();
-  const std::vector<double> &getResult() const { return result; }
+  void evaluate(double *output, const double *input) const;
 };
 
 class SimCompartment {

--- a/src/core/symbolic.cpp
+++ b/src/core/symbolic.cpp
@@ -187,4 +187,8 @@ void Symbolic::eval(std::vector<double> &results,
   pSymEngineImpl->lambdaLLVM.call(results.data(), vars.data());
 }
 
+void Symbolic::eval(double *results, const double *vars) const {
+  pSymEngineImpl->lambdaLLVM.call(results, vars);
+}
+
 }  // namespace symbolic

--- a/src/core/symbolic.hpp
+++ b/src/core/symbolic.hpp
@@ -56,6 +56,7 @@ class Symbolic {
   // evaluate compiled expressions
   void eval(std::vector<double> &results,
             const std::vector<double> &vars = {}) const;
+  void eval(double *results, const double *vars) const;
 };
 
 }  // namespace symbolic

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.0";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.1";

--- a/src/gui/dialogs/dialogabout.cpp
+++ b/src/gui/dialogs/dialogabout.cpp
@@ -7,6 +7,9 @@
 #include <sbml/common/libsbml-version.h>
 #include <spdlog/version.h>
 #include <symengine/symengine_config.h>
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+#include <tbb/tbb_stddef.h>
+#endif
 #include <tiffvers.h>
 
 #include "symbolic.hpp"
@@ -16,6 +19,13 @@
 static QString dep(const QString& name, const QString& url,
                    const QString& version) {
   return QString("<li><a href=\"%2\">%1</a>: %3</li>").arg(name, url, version);
+}
+
+static QString dep(const QString& name, const QString& url, int major,
+                   int minor) {
+  auto version =
+      QString("%1.%2</li>").arg(QString::number(major), QString::number(minor));
+  return dep(name, url, version);
 }
 
 static QString dep(const QString& name, const QString& url, int major,
@@ -66,6 +76,10 @@ DialogAbout::DialogAbout(QWidget* parent)
   libraries.append(dep("expat", "https://libexpat.github.io/",
                        XML_MAJOR_VERSION, XML_MINOR_VERSION,
                        XML_MICRO_VERSION));
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  libraries.append(dep("TBB", "https://github.com/intel/tbb", TBB_VERSION_MAJOR,
+                       TBB_VERSION_MINOR));
+#endif
   libraries.append("</ul>");
   ui->lblLibraries->setText(libraries);
 }


### PR DESCRIPTION
  - enabled if USE_TBB is defined at compile time
  - tbb::parallel_for is then used to parallelise
    - reactions within a compartment
    - diffusion within a compartment
    - note: not used for membrane reactions
  - use case: large models, multi-core cpu
  - non-use case: small models and/or single-core cpu
  - hopefully overall overhead in latter case will be small, so we can eventually enable it by default, but this needs testing

also
  - only redraw plot every 1s while running simulation
  - otherwise most of simulation time is spent plotting