### PR TITLE
minor Pixel simulator improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.8.1
+        VERSION 0.8.2
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.1";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.2";


### PR DESCRIPTION
  - reactions now write directly to dcdt, no temporaries
  - diffusion operator now adds to existing dcdt
  - use simpler form of tbb::parallel_for