### PR TITLE
enforce unique Names for species and compartments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.8.2
+        VERSION 0.8.3
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   # compile
   - bash -l ci-build.sh "release optimize_full" mingw32-make
   # run non-gui tests
-  - C:\msys64\home\appveyor\build\test\test.exe -as "~[gui]" > test.txt 2>&1
+  - C:\msys64\home\appveyor\build\test\test.exe -as "~[gui]" > test.txt 2>&1 & exit 0
   - ps: Get-Content test.txt -Tail 100
   - rm test.txt
   # run benchmarks (~1 sec per benchmark, ~20secs total)

--- a/src/core/dunesim.hpp
+++ b/src/core/dunesim.hpp
@@ -61,7 +61,11 @@ class DuneSim : public BaseSim {
   std::size_t integratorOrder = 1;
 
  public:
-  explicit DuneSim(const sbml::SbmlDocWrapper &sbmlDoc, std::size_t order = 1);
+  explicit DuneSim(
+      const sbml::SbmlDocWrapper &sbmlDoc,
+      const std::vector<std::string> &compartmentIds,
+      const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
+      std::size_t order = 1);
   ~DuneSim() override;
   virtual void setIntegrationOrder(std::size_t order) override;
   virtual std::size_t getIntegrationOrder() const override;

--- a/src/core/pixelsim.hpp
+++ b/src/core/pixelsim.hpp
@@ -58,7 +58,8 @@ class SimCompartment {
 
  public:
   explicit SimCompartment(const sbml::SbmlDocWrapper &doc,
-                          const geometry::Compartment &compartment);
+                          const geometry::Compartment &compartment,
+                          const std::vector<std::string> &sIds);
   // dcdt = result of applying diffusion operator to conc
   void evaluateDiffusionOperator();
   // dcdt += result of applying reaction expressions to conc
@@ -117,7 +118,11 @@ class PixelSim : public BaseSim {
   double epsilon = 1e-14;
 
  public:
-  explicit PixelSim(const sbml::SbmlDocWrapper &sbmlDoc, std::size_t order = 2);
+  explicit PixelSim(
+      const sbml::SbmlDocWrapper &sbmlDoc,
+      const std::vector<std::string> &compartmentIds,
+      const std::vector<std::vector<std::string>> &compartmentSpeciesIds,
+      std::size_t order = 2);
   ~PixelSim() override;
   virtual void setIntegrationOrder(std::size_t order) override;
   virtual std::size_t getIntegrationOrder() const override;

--- a/src/core/sbml.hpp
+++ b/src/core/sbml.hpp
@@ -232,7 +232,7 @@ class SbmlDocWrapper {
   void setCompartmentColour(const QString &compartmentID, QRgb colour,
                             bool updateSBML = true);
   const QImage &getCompartmentImage() const;
-  void addCompartment(const QString &compartmentName);
+  QString addCompartment(const QString &compartmentName);
   void removeCompartment(const QString &compartmentID);
 
   double getCompartmentSize(const QString &compartmentID) const;
@@ -242,7 +242,7 @@ class SbmlDocWrapper {
   QString getSpeciesCompartment(const QString &speciesID) const;
   void setSpeciesCompartment(const QString &speciesID,
                              const QString &compartmentID);
-  void addSpecies(const QString &speciesName, const QString &compartmentID);
+  QString addSpecies(const QString &speciesName, const QString &compartmentID);
   void removeSpecies(const QString &speciesID);
 
   // compartment geometry: interiorPoints - used for mesh generation

--- a/src/core/simulate.cpp
+++ b/src/core/simulate.cpp
@@ -13,12 +13,6 @@ namespace simulate {
 Simulation::Simulation(const sbml::SbmlDocWrapper &sbmlDoc,
                        SimulatorType simType, std::size_t integratorOrder)
     : simulatorType(simType), imageSize(sbmlDoc.getCompartmentImage().size()) {
-  // init simulator
-  if (simulatorType == SimulatorType::DUNE) {
-    simulator = std::make_unique<sim::DuneSim>(sbmlDoc, integratorOrder);
-  } else {
-    simulator = std::make_unique<sim::PixelSim>(sbmlDoc);
-  }
   // get compartments with interacting species, name & colour of each species
   for (const auto &compartmentId : sbmlDoc.compartments) {
     std::vector<std::string> sIds;
@@ -42,6 +36,14 @@ Simulation::Simulation(const sbml::SbmlDocWrapper &sbmlDoc,
       compartmentSpeciesColors.push_back(std::move(cols));
       compartments.push_back(comp);
     }
+  }
+  // init simulator
+  if (simulatorType == SimulatorType::DUNE) {
+    simulator = std::make_unique<sim::DuneSim>(
+        sbmlDoc, compartmentIds, compartmentSpeciesIds, integratorOrder);
+  } else {
+    simulator = std::make_unique<sim::PixelSim>(
+        sbmlDoc, compartmentIds, compartmentSpeciesIds, integratorOrder);
   }
   updateConcentrations(0);
 }

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.2";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.3";

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -198,8 +198,8 @@ void TabSpecies::btnAddSpecies_clicked() {
   auto speciesName = QInputDialog::getText(
       this, "Add species", "New species name:", QLineEdit::Normal, {}, &ok);
   if (ok && !speciesName.isEmpty()) {
-    sbmlDoc.addSpecies(speciesName, compartmentID);
-    loadModelData(speciesName);
+    auto newName = sbmlDoc.addSpecies(speciesName, compartmentID);
+    loadModelData(newName);
   }
 }
 

--- a/src/gui/widgets/qlabelmousetracker.cpp
+++ b/src/gui/widgets/qlabelmousetracker.cpp
@@ -78,6 +78,7 @@ bool QLabelMouseTracker::setCurrentPixel(const QMouseEvent *ev) {
 
 void QLabelMouseTracker::resizeImage(const QSize &size) {
   if (image.isNull()) {
+    this->clear();
     return;
   }
   pixmap = QPixmap::fromImage(


### PR DESCRIPTION
  - two species cannot have the same Name
  - two compartments cannot have the same Name
  - this is to avoid confusion where these names are used in reaction rate equations
  - on import:
    - "_" is appended to duplicated compartment Names
    - "_compartmentName" is appended to duplicated species Names
  - within GUI:
    TODO: automatically do the above in case of new name which clashes?
    - "_compartmentName" is appended to new species Name if it clashes
  - resolves #132

also

TODO: fix bug: old compartment image still shown when new model loaded without geometry

  - fix bug with compartment ordering in simulations
    - simulations ignore compartments if they contain no non-constant species
    - but the indexing was not fixed accordingly
    - so compartments following an ignored compartment had the wrong index