### PR TITLE
remove geometry from SBML model on new geometry image import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(SpatialModelEditor
-        VERSION 0.8.3
+        VERSION 0.8.4
         DESCRIPTION "Spatial Model Editor"
         LANGUAGES CXX)
 

--- a/src/core/sbml.hpp
+++ b/src/core/sbml.hpp
@@ -156,6 +156,7 @@ class SbmlDocWrapper {
   // update SBML doc with mesh
   libsbml::ParametricObject *getParametricObject(
       const std::string &compartmentID) const;
+  void removeMeshParamsAnnotation();
   void writeMeshParamsAnnotation(libsbml::ParametricGeometry *parageom);
   void writeGeometryMeshToSBML();
   void writeGeometryImageToSBML();
@@ -211,9 +212,9 @@ class SbmlDocWrapper {
 
   explicit SbmlDocWrapper();
   ~SbmlDocWrapper();
-  SbmlDocWrapper(SbmlDocWrapper &&);
+  SbmlDocWrapper(SbmlDocWrapper &&) noexcept;
   SbmlDocWrapper(const SbmlDocWrapper &) = delete;
-  SbmlDocWrapper &operator=(SbmlDocWrapper &&);
+  SbmlDocWrapper &operator=(SbmlDocWrapper &&) noexcept;
   SbmlDocWrapper &operator=(const SbmlDocWrapper &) = delete;
 
   void createSBMLFile(const std::string &name);
@@ -228,6 +229,7 @@ class SbmlDocWrapper {
 
   QString getCompartmentID(QRgb colour) const;
   QString getCompartmentName(const QString &compartmentID) const;
+  QString setCompartmentName(const QString &compartmentId, const QString &name);
   QRgb getCompartmentColour(const QString &compartmentID) const;
   void setCompartmentColour(const QString &compartmentID, QRgb colour,
                             bool updateSBML = true);
@@ -288,7 +290,7 @@ class SbmlDocWrapper {
   void setIsSpeciesConstant(const std::string &speciesID, bool constant);
   bool getIsSpeciesConstant(const std::string &speciesID) const;
 
-  void setSpeciesName(const QString &speciesID, const QString &name);
+  QString setSpeciesName(const QString &speciesID, const QString &name);
   QString getSpeciesName(const QString &speciesID) const;
   QString getReactionName(const QString &reactionID) const;
 

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.3";
+const char *SPATIAL_MODEL_EDITOR_VERSION = "0.8.4";

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -56,6 +56,11 @@ MainWindow::MainWindow(QWidget *parent)
   // set initial splitter position: 1/4 for image, 3/4 for tabs
   ui->splitter->setSizes({1000, 3000});
 
+  // load empty model by default
+  sbmlDoc.createSBMLFile("untitled-model");
+  this->setWindowTitle(
+      QString("Spatial Model Editor [%1]").arg(sbmlDoc.currentFilename));
+
   enableTabs();
   ui->tabMain->setCurrentIndex(0);
   tabMain_currentChanged(0);
@@ -173,7 +178,8 @@ void MainWindow::tabMain_currentChanged(int index) {
       ui->txtDUNE->setText(dune::DuneConverter(sbmlDoc).getIniFile());
       break;
     case TabIndex::GMSH:
-      ui->txtGMSH->setText(sbmlDoc.mesh->getGMSH());
+      ui->txtGMSH->setText(sbmlDoc.mesh == nullptr ? ""
+                                                   : sbmlDoc.mesh->getGMSH());
       break;
     default:
       SPDLOG_ERROR("Tab index {} not valid", index);

--- a/src/gui/tabs/tabgeometry.hpp
+++ b/src/gui/tabs/tabgeometry.hpp
@@ -44,7 +44,7 @@ class TabGeometry : public QWidget {
   void btnAddCompartment_clicked();
   void btnRemoveCompartment_clicked();
   void btnChangeCompartment_clicked();
-  void btnSetCompartmentSizeFromImage_clicked();
+  void txtCompartmentName_editingFinished();
   void tabCompartmentGeometry_currentChanged(int index);
   void lblCompBoundary_mouseClicked(QRgb col, QPoint point);
   void spinBoundaryIndex_valueChanged(int value);

--- a/src/gui/tabs/tabgeometry.ui
+++ b/src/gui/tabs/tabgeometry.ui
@@ -104,10 +104,35 @@
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <layout class="QGridLayout" name="gridCompartmentSettings">
-         <item row="0" column="5">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblCompartmentNameLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>The size of the compartment</string>
+           </property>
+           <property name="statusTip">
+            <string>The size of the compartment</string>
+           </property>
+           <property name="whatsThis">
+            <string>The size of the compartment</string>
+           </property>
+           <property name="text">
+            <string>Name:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
           <widget class="QLabel" name="lblCompartmentColour">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -143,37 +168,14 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="3">
-          <widget class="QPushButton" name="btnSetCompartmentSizeFromImage">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>set size from image</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="txtCompartmentSize">
+         <item row="0" column="2">
+          <widget class="QLabel" name="lblCompColourLabel">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="toolTip">
-            <string>The size of the compartment</string>
-           </property>
-           <property name="statusTip">
-            <string>The size of the compartment</string>
-           </property>
-           <property name="whatsThis">
-            <string>The size of the compartment</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <widget class="QLabel" name="lblCompColourLabel">
            <property name="font">
             <font>
              <weight>50</weight>
@@ -194,8 +196,8 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblCompartmentSize">
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtCompartmentName">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -210,19 +212,6 @@
            </property>
            <property name="whatsThis">
             <string>The size of the compartment</string>
-           </property>
-           <property name="text">
-            <string>Size:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="lblCompartmentSizeUnits">
-           <property name="text">
-            <string/>
            </property>
           </widget>
          </item>

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -229,8 +229,12 @@ void TabSpecies::btnRemoveSpecies_clicked() {
 
 void TabSpecies::txtSpeciesName_editingFinished() {
   const QString &name = ui->txtSpeciesName->text();
-  sbmlDoc.setSpeciesName(currentSpeciesId, name);
-  loadModelData(name);
+  if (name == sbmlDoc.getSpeciesName(currentSpeciesId)) {
+    return;
+  }
+  QString newName = sbmlDoc.setSpeciesName(currentSpeciesId, name);
+  ui->txtSpeciesName->setText(newName);
+  loadModelData(newName);
 }
 
 void TabSpecies::cmbSpeciesCompartment_activated(int index) {

--- a/test/core/test_sbml.cpp
+++ b/test/core/test_sbml.cpp
@@ -81,23 +81,7 @@ SCENARIO("SBML: import SBML doc without geometry", "[core][sbml]") {
     REQUIRE(geom->getCoordinateComponent(1)->getType() ==
             libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_Y);
 
-    REQUIRE(geom->getNumGeometryDefinitions() == 1);
-    REQUIRE(geom->getGeometryDefinition(0)->isSampledFieldGeometry() == true);
-    REQUIRE(geom->getGeometryDefinition(0)->getIsActive() == true);
-    auto *sfgeom = dynamic_cast<libsbml::SampledFieldGeometry *>(
-        geom->getGeometryDefinition(0));
-    REQUIRE(sfgeom != nullptr);
-    for (unsigned i = 0; i < model->getNumCompartments(); ++i) {
-      auto *comp = model->getCompartment(i);
-      auto *scp = dynamic_cast<libsbml::SpatialCompartmentPlugin *>(
-          comp->getPlugin("spatial"));
-      REQUIRE(scp->isSetCompartmentMapping() == true);
-      std::string domainTypeID = scp->getCompartmentMapping()->getDomainType();
-      REQUIRE(geom->getDomainByDomainType(domainTypeID) ==
-              geom->getDomain(comp->getId() + "_domain"));
-      REQUIRE(sfgeom->getSampledVolumeByDomainType(domainTypeID)->getId() ==
-              comp->getId() + "_sampledVolume");
-    }
+    REQUIRE(geom->getNumGeometryDefinitions() == 0);
   }
   WHEN("import geometry & assign compartments") {
     // import geometry image & assign compartments to colours

--- a/test/gui/tabs/test_tabgeometry.cpp
+++ b/test/gui/tabs/test_tabgeometry.cpp
@@ -28,9 +28,7 @@ SCENARIO("Geometry Tab", "[gui][tabs][geometry]") {
   auto *btnAddCompartment = tab.findChild<QPushButton *>("btnAddCompartment");
   auto *btnRemoveCompartment =
       tab.findChild<QPushButton *>("btnRemoveCompartment");
-  auto *txtCompartmentSize = tab.findChild<QLineEdit *>("txtCompartmentSize");
-  auto *btnSetCompartmentSizeFromImage =
-      tab.findChild<QPushButton *>("btnSetCompartmentSizeFromImage");
+  auto *txtCompartmentName = tab.findChild<QLineEdit *>("txtCompartmentName");
   auto *tabCompartmentGeometry =
       tab.findChild<QTabWidget *>("tabCompartmentGeometry");
   auto *lblCompShape = tab.findChild<QLabelMouseTracker *>("lblCompShape");
@@ -55,19 +53,26 @@ SCENARIO("Geometry Tab", "[gui][tabs][geometry]") {
       // select compartments
       REQUIRE(listCompartments->count() == 3);
       REQUIRE(listCompartments->currentItem()->text() == "Outside");
-      REQUIRE(txtCompartmentSize->text() == "10");
+      REQUIRE(txtCompartmentName->text() == "Outside");
       REQUIRE(tabCompartmentGeometry->currentIndex() == 0);
       REQUIRE(lblCompShape->getImage().pixel(1, 1) == 0xff000200);
-      sendMouseClick(btnSetCompartmentSizeFromImage);
-      REQUIRE(txtCompartmentSize->text() != "10");
+      // change compartment name
+      txtCompartmentName->setFocus();
+      sendKeyEvents(txtCompartmentName, {"X", "Enter"});
+      REQUIRE(txtCompartmentName->text() == "OutsideX");
+      REQUIRE(listCompartments->currentItem()->text() == "OutsideX");
+      txtCompartmentName->setFocus();
+      sendKeyEvents(txtCompartmentName, {"Backspace", "Enter"});
+      REQUIRE(txtCompartmentName->text() == "Outside");
+      REQUIRE(listCompartments->currentItem()->text() == "Outside");
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Cell");
       REQUIRE(lblCompShape->getImage().pixel(20, 20) == 0xff9061c1);
-      REQUIRE(txtCompartmentSize->text() == "1");
+      REQUIRE(txtCompartmentName->text() == "Cell");
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Nucleus");
-      REQUIRE(txtCompartmentSize->text() == "0.2");
+      REQUIRE(txtCompartmentName->text() == "Nucleus");
       REQUIRE(lblCompShape->getImage().pixel(50, 50) == 0xffc58560);
 
       // boundary tab

--- a/test/gui/test_mainwindow.cpp
+++ b/test/gui/test_mainwindow.cpp
@@ -52,7 +52,7 @@ SCENARIO("Mainwindow: shortcut keys", "[gui][mainwindow][shortcuts]") {
       mwt.addUserAction({"Esc"});
       mwt.start();
       sendKeyEvents(&w, {"Ctrl+N"});
-      REQUIRE(w.windowTitle().right(6) == "Editor");
+      REQUIRE(w.windowTitle().right(20) == "[untitled-model.xml]");
       mwt.addUserAction({"n", "e", "w"});
       mwt.start();
       sendKeyEvents(&w, {"Ctrl+N"});
@@ -67,12 +67,12 @@ SCENARIO("Mainwindow: shortcut keys", "[gui][mainwindow][shortcuts]") {
       REQUIRE(mwt.getResult() == "QFileDialog::AcceptOpen");
     }
   }
-  WHEN("user presses ctrl+s (no SBML model loaded)") {
-    THEN("offer to import an SBML model") {
+  WHEN("user presses ctrl+s (SBML model but no geometry loaded)") {
+    THEN("offer to import a geometry image") {
       sendKeyEvents(&w, {"Ctrl+S"});
-      // press no when asked to import model
+      // press no when asked to import image
       auto title = sendKeyEventsToNextQDialog({"Esc"});
-      REQUIRE(title == "No SBML model");
+      REQUIRE(title == "No compartment geometry image");
     }
   }
   WHEN("user presses ctrl+s (with valid SBML model)") {
@@ -84,12 +84,12 @@ SCENARIO("Mainwindow: shortcut keys", "[gui][mainwindow][shortcuts]") {
       REQUIRE(mwt.getResult() == "QFileDialog::AcceptSave");
     }
   }
-  WHEN("user presses ctrl+d (no SBML model loaded)") {
-    THEN("offer to import an SBML model") {
+  WHEN("user presses ctrl+d (SBML model but no geometry loaded)") {
+    THEN("offer to import a geometry image") {
       sendKeyEvents(&w, {"Ctrl+D"});
-      // press no when asked to import model
+      // press no when asked to import image
       auto title = sendKeyEventsToNextQDialog({"Esc"});
-      REQUIRE(title == "No SBML model");
+      REQUIRE(title == "No compartment geometry image");
     }
   }
   WHEN("user presses ctrl+d (with valid SBML model)") {
@@ -101,41 +101,23 @@ SCENARIO("Mainwindow: shortcut keys", "[gui][mainwindow][shortcuts]") {
       REQUIRE(mwt.getResult() == "QFileDialog::AcceptSave");
     }
   }
-  WHEN("user presses ctrl+I to import image (no SBML model)") {
+  WHEN("user presses ctrl+I to import image (default empty SBML model)") {
     THEN("offer to import SBML model") {
-      sendKeyEvents(&w, {"Ctrl+I"});
-      // press no when asked to import model
-      sendKeyEventsToNextQDialog({"Esc"});
-
-      // repeat, this time say yes, but then escape on SBML file open dialog
-      sendKeyEvents(&w, {"Ctrl+I"});
+      // escape on SBML file open dialog
       mwt.addUserAction({"Esc"}, false);
       mwt.start();
-      // press yes when asked to import model
-      // NB: don't send release event, as dialog will be deleted by the
-      // time it is sent, since the modal QFileDialog opens in between the press
-      // & release events
-      sendKeyEventsToNextQDialog({"Enter"}, false);
+      sendKeyEvents(&w, {"Ctrl+I"});
       REQUIRE(mwt.getResult() == "QFileDialog::AcceptOpen");
     }
   }
-  WHEN("menu: Import->Example geometry image->Empty donut (no SBML model)") {
-    THEN("offer to import SBML model") {
-      sendKeyEvents(&w, {"Alt+I"});
-      sendKeyEvents(menuImport, {"E"});
-      sendKeyEvents(menuExample_geometry_image, {"E"});
-      // press no when asked to import model
-      sendKeyEventsToNextQDialog({"Esc"});
-    }
-  }
-  WHEN("user presses ctrl+tab (no SBML & compartment image loaded)") {
+  WHEN("user presses ctrl+tab (default SBML model loaded)") {
     THEN("remain on Geometry tab: all others disabled") {
       REQUIRE(tabMain->currentIndex() == 0);
       sendKeyEvents(tabMain, {"Ctrl+Tab"});
       REQUIRE(tabMain->currentIndex() == 0);
     }
   }
-  WHEN("user presses ctrl+shift+tab (no SBML & compartment image loaded)") {
+  WHEN("user presses ctrl+shift+tab (default SBML model loaded)") {
     THEN("remain on Geometry tab: all others disabled") {
       REQUIRE(tabMain->currentIndex() == 0);
       sendKeyEvents(tabMain, {"Ctrl+Shift+Tab"});
@@ -172,20 +154,23 @@ SCENARIO("Mainwindow: shortcut keys", "[gui][mainwindow][shortcuts]") {
       REQUIRE(tabMain->currentIndex() == 8);
     }
   }
-  WHEN("menu: Tools->Set model units (no SBML model)") {
+  WHEN("menu: Tools->Set model units (default SBML model)") {
     THEN("offer to import SBML model") {
+      mwt.addUserAction({"Esc"}, false);
+      mwt.start();
       sendKeyEvents(&w, {"Alt+T"});
       sendKeyEvents(menu_Tools, {"U"});
-      // press no when asked to import model
-      sendKeyEventsToNextQDialog({"Esc"});
+      // press esc to close dialog
+      REQUIRE(mwt.getResult() == "");
     }
   }
-  WHEN("menu: Tools->Set image size (no SBML model)") {
-    THEN("offer to import SBML model") {
+  WHEN("menu: Tools->Set image size (default SBML model, no image)") {
+    THEN("offer to import geometry image") {
       sendKeyEvents(&w, {"Alt+T"});
       sendKeyEvents(menu_Tools, {"I"});
-      // press no when asked to import model
-      sendKeyEventsToNextQDialog({"Esc"});
+      // press no when asked to import image
+      auto title = sendKeyEventsToNextQDialog({"Esc"});
+      REQUIRE(title == "No compartment geometry image");
     }
   }
   WHEN("menu: Tools->Set simulation type") {


### PR DESCRIPTION
  - resolves #159

user can edit compartment name in tabCompartment
  - resolves #158

also
  - create empty model by default on startup: resolves #163
  - remove button to set size of compartment from image: not useful
  - check for name clash when compartment or species name is edited
  - bugfix: previous model geometry images no longer visible in tabGeometry when new model without geometry loaded
  - bugfix: change geometry sub-tab to Image on load of new model / import of new geometry image