### PR TITLE
fix pixel sim of membranes with an empty compartment

### DIFF
--- a/src/core/pixelsim.hpp
+++ b/src/core/pixelsim.hpp
@@ -86,13 +86,13 @@ class SimMembrane {
  private:
   ReacEval reacEval;
   const geometry::Membrane &membrane;
-  SimCompartment &compA;
-  SimCompartment &compB;
+  SimCompartment *compA;
+  SimCompartment *compB;
 
  public:
   SimMembrane(const sbml::SbmlDocWrapper &doc,
-              const geometry::Membrane &membrane_ptr, SimCompartment &simCompA,
-              SimCompartment &simCompB);
+              const geometry::Membrane &membrane_ptr, SimCompartment *simCompA,
+              SimCompartment *simCompB);
   void evaluateReactions();
 };
 


### PR DESCRIPTION
  - SimMembrane now takes the two compartments as optional parameters
  - If a compartment is not supplied, it is not referenced by SimMembrane
  - resolves #166