### PR TITLE
improve math support

### DIFF
--- a/src/core/common/inc/symbolic.hpp
+++ b/src/core/common/inc/symbolic.hpp
@@ -22,7 +22,7 @@ const char *getLLVMVersion();
 
 class Symbolic {
 private:
-  class SymEngineImpl;
+  struct SymEngineImpl;
   std::unique_ptr<SymEngineImpl> pSymEngineImpl;
 
 public:
@@ -57,6 +57,8 @@ public:
   void eval(std::vector<double> &results,
             const std::vector<double> &vars = {}) const;
   void eval(double *results, const double *vars) const;
+  bool isValid() const;
+  const std::string &getErrorMessage() const;
 };
 
 } // namespace symbolic

--- a/src/core/common/src/symbolic_t.cpp
+++ b/src/core/common/src/symbolic_t.cpp
@@ -23,8 +23,10 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   }
   GIVEN("3*x + 7*x: one var, no constants") {
     std::string expr = "3*x + 7 * x";
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {}, {}), "Unknown symbol: x");
-    symbolic::Symbolic sym(expr, {"x"}, {});
+    auto sym = symbolic::Symbolic(expr, {}, {});
+    REQUIRE(!sym.isValid());
+    REQUIRE(sym.getErrorMessage() == "Unknown symbol: x");
+    sym = symbolic::Symbolic(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(sym.simplify() == "10*x");
     REQUIRE(sym.diff("x") == "10");
@@ -83,10 +85,10 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   }
   GIVEN("3*x + 4/y - 1.0*x + 0.2*x*y - 0.1: two vars, no constants") {
     std::string expr = "3*x + 4/y - 1.0*x + 0.2*x*y - 0.1";
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"x"}, {}),
-                        "Unknown symbol: y");
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"y"}, {}),
-                        "Unknown symbol: x");
+    REQUIRE(symbolic::Symbolic(expr, {"x"}, {}).getErrorMessage() ==
+            "Unknown symbol: y");
+    REQUIRE(symbolic::Symbolic(expr, {"y"}, {}).getErrorMessage() ==
+            "Unknown symbol: x");
     symbolic::Symbolic sym(expr, {"x", "y", "z"}, {});
     CAPTURE(expr);
     REQUIRE(sym.simplify() == "-0.1 + 2.0*x + 0.2*x*y + 4*y^(-1)");
@@ -105,12 +107,12 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   GIVEN("two expressions, three vars, no constants") {
     std::vector<std::string> expr = {"3*x + 4/y - 1.0*x + 0.2*x*y - 0.1",
                                      "z - cos(x)*sin(y) - x*y"};
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"z", "x"}, {}),
-                        "Unknown symbol: y");
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"x", "y"}, {}),
-                        "Unknown symbol: z");
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"z", "y"}, {}),
-                        "Unknown symbol: x");
+    REQUIRE(symbolic::Symbolic(expr, {"z", "x"}, {}).getErrorMessage() ==
+            "Unknown symbol: y");
+    REQUIRE(symbolic::Symbolic(expr, {"x", "y"}, {}).getErrorMessage() ==
+            "Unknown symbol: z");
+    REQUIRE(symbolic::Symbolic(expr, {"z", "y"}, {}).getErrorMessage() ==
+            "Unknown symbol: x");
     symbolic::Symbolic sym(expr, {"x", "y", "z"}, {});
     CAPTURE(expr);
     REQUIRE(sym.simplify(0) == "-0.1 + 2.0*x + 0.2*x*y + 4*y^(-1)");
@@ -135,7 +137,8 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
   }
   GIVEN("e^(4*x): print exponential function") {
     std::string expr = "e^(4*x)";
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {}, {}), "Unknown symbol: x");
+    REQUIRE(symbolic::Symbolic(expr, {}, {}).getErrorMessage() ==
+            "Unknown symbol: x");
     symbolic::Symbolic sym(expr, {"x"}, {});
     CAPTURE(expr);
     REQUIRE(sym.simplify() == "exp(4*x)");
@@ -165,10 +168,10 @@ SCENARIO("Symbolic", "[core/common/symbolic][core/common][core][symbolic]") {
     constants.push_back({"n", -23});
     constants.push_back({"Unused", -99});
     std::string expr = "3*x + alpha*x - a*n*x";
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {}, constants),
-                        "Unknown symbol: x");
-    REQUIRE_THROWS_WITH(symbolic::Symbolic(expr, {"x"}, {{"a", 1}, {"n", 2}}),
-                        "Unknown symbol: alpha");
+    REQUIRE(symbolic::Symbolic(expr, {}, constants).getErrorMessage() ==
+            "Unknown symbol: x");
+    REQUIRE(symbolic::Symbolic(expr, {"x"}, {{"a", 1}, {"n", 2}})
+                .getErrorMessage() == "Unknown symbol: alpha");
     symbolic::Symbolic sym(expr, {"x", "y"}, constants);
     CAPTURE(expr);
     REQUIRE(sym.simplify() == "21.90000000023*x");

--- a/src/core/mesh/src/boundary_pixels.cpp
+++ b/src/core/mesh/src/boundary_pixels.cpp
@@ -198,9 +198,13 @@ static std::size_t getColourIndex(QRgb col, const QImage &img) {
 static std::vector<std::size_t> getColourIndexToCompartmentIndex(
     const std::vector<QRgb> &compartmentColours, const QImage &img) {
   auto nImgColours = static_cast<std::size_t>(img.colorCount());
-  SPDLOG_TRACE("{}-colour image", nImgColours);
+  SPDLOG_TRACE("{}-colour image:", nImgColours);
   for (int i = 0; i < img.colorCount(); ++i) {
     SPDLOG_TRACE("  - {:x}", img.color(i));
+  }
+  SPDLOG_TRACE("{} compartment colours:", compartmentColours.size());
+  for (auto c : compartmentColours) {
+    SPDLOG_TRACE("  - {:x}", c);
   }
   std::vector<std::size_t> vec(nImgColours, nullIndex);
   std::size_t compIndex = 0;
@@ -208,10 +212,11 @@ static std::vector<std::size_t> getColourIndexToCompartmentIndex(
     auto colIndex = getColourIndex(compColour, img);
     if (colIndex == nullIndex) {
       SPDLOG_ERROR("compColour {:x} gave null index in image", compColour);
+    } else {
+      vec[colIndex] = compIndex;
+      SPDLOG_TRACE("comp[{}] : colour {:x}, index {}", compIndex, compColour,
+                   colIndex);
     }
-    vec[colIndex] = compIndex;
-    SPDLOG_TRACE("comp[{}] : colour {:x}, index {}", compIndex, compColour,
-                 colIndex);
     ++compIndex;
   }
   return vec;

--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -93,7 +93,7 @@ public:
   void setDiffusionConstant(double diffConst);
   const Compartment *getCompartment() const;
   const std::vector<double> &getConcentration() const;
-  std::vector<double> &getConcentration();
+  void setConcentration(std::size_t index, double concentration);
 
   void setUniformConcentration(double concentration);
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);

--- a/src/core/model/inc/model.hpp
+++ b/src/core/model/inc/model.hpp
@@ -15,6 +15,7 @@
 #include "model_compartments.hpp"
 #include "model_functions.hpp"
 #include "model_geometry.hpp"
+#include "model_math.hpp"
 #include "model_membranes.hpp"
 #include "model_parameters.hpp"
 #include "model_reactions.hpp"
@@ -41,8 +42,6 @@ class Mesh;
 
 namespace model {
 
-class Model;
-
 struct SpeciesGeometry {
   QSize compartmentImageSize;
   const std::vector<QPoint> &compartmentPoints;
@@ -65,6 +64,7 @@ private:
   ModelFunctions modelFunctions;
   ModelParameters modelParameters;
   ModelUnits modelUnits;
+  ModelMath modelMath;
 
   void initModelData();
 
@@ -91,6 +91,8 @@ public:
   const ModelParameters &getParameters() const;
   ModelUnits &getUnits();
   const ModelUnits &getUnits() const;
+  ModelMath &getMath();
+  const ModelMath &getMath() const;
 
   explicit Model();
   Model(Model &&) noexcept = default;
@@ -112,5 +114,4 @@ public:
 
   std::string getRateRule(const std::string &speciesID) const;
 };
-
 } // namespace model

--- a/src/core/model/inc/model_functions.hpp
+++ b/src/core/model/inc/model_functions.hpp
@@ -14,13 +14,6 @@ class Model;
 
 namespace model {
 
-struct Func {
-  std::string id;
-  std::string name;
-  std::string expression;
-  std::vector<std::string> arguments;
-};
-
 class ModelFunctions {
 private:
   QStringList ids;
@@ -31,11 +24,15 @@ public:
   ModelFunctions();
   explicit ModelFunctions(libsbml::Model *model);
   const QStringList &getIds() const;
+  QString setName(const QString &id, const QString &name);
   QString getName(const QString &id) const;
-  Func getDefinition(const QString &id) const;
-  void setDefinition(const Func &func);
+  void setExpression(const QString &id, const QString &name);
+  QString getExpression(const QString &id) const;
+  void addArgument(const QString &functionId, const QString &argumentId);
+  void removeArgument(const QString &functionId, const QString &argumentId);
+  QStringList getArguments(const QString &id) const;
   void add(const QString &functionName);
   void remove(const QString &functionID);
 };
 
-} // namespace sbml
+} // namespace model

--- a/src/core/model/inc/model_math.hpp
+++ b/src/core/model/inc/model_math.hpp
@@ -1,0 +1,39 @@
+// SBML math
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace libsbml {
+class Model;
+class ASTNode;
+} // namespace libsbml
+
+namespace model {
+
+class ModelMath {
+private:
+  const libsbml::Model *sbmlModel{nullptr};
+  std::unique_ptr<const libsbml::ASTNode> astNode;
+  bool valid{false};
+  std::string errorMessage{"Empty expression"};
+
+public:
+  ModelMath();
+  explicit ModelMath(const libsbml::Model *model);
+  void parse(const std::string &expr);
+  double eval(const std::map<const std::string, std::pair<double, bool>> &vars =
+                  {}) const;
+  bool isValid() const;
+  const std::string &getErrorMessage() const;
+  ModelMath(ModelMath &&) noexcept;
+  ModelMath &operator=(ModelMath &&) noexcept;
+  ModelMath &operator=(const ModelMath &) = delete;
+  ModelMath(const ModelMath &) = delete;
+  ~ModelMath();
+};
+
+} // namespace model

--- a/src/core/model/src/CMakeLists.txt
+++ b/src/core/model/src/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
           model_compartments.cpp
           model_functions.cpp
           model_geometry.cpp
+          model_math.cpp
           model_membranes.cpp
           model_membranes_util.cpp
           model_parameters.cpp
@@ -23,6 +24,8 @@ target_sources(
   core_tests
   PUBLIC geometry_t.cpp
          model_t.cpp
+         model_functions_t.cpp
+         model_math_t.cpp
          model_membranes_t.cpp
          model_membranes_util_t.cpp
          model_units_t.cpp)

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -147,7 +147,9 @@ const Compartment *Field::getCompartment() const { return comp; }
 
 const std::vector<double> &Field::getConcentration() const { return conc; }
 
-std::vector<double> &Field::getConcentration() { return conc; }
+void Field::setConcentration(std::size_t index, double concentration) {
+  conc[index] = concentration;
+}
 
 void Field::importConcentration(
     const std::vector<double> &sbmlConcentrationArray) {

--- a/src/core/model/src/math.hpp
+++ b/src/core/model/src/math.hpp
@@ -2,7 +2,12 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
 #include <string>
+#include <utility>
+
+#include <sbml/SBMLTypes.h>
 
 namespace libsbml {
 class Model;
@@ -14,14 +19,36 @@ namespace model {
 // return supplied math expression as string with any Function calls and/or
 // Assignment rules inlined e.g. given mathExpression = "z*f(x,y)" where the
 // SBML model contains a function "f(a,b) = a*b-2" it returns "z*(x*y-2)"
+// todo: replace with libSBML equivalent
 std::string inlineFunctions(const std::string &mathExpression,
                             const libsbml::Model *model);
 
 // return supplied math expression as string with any Assignment rules
 // inlined
+// todo: replace with libSBML equivalent
 std::string inlineAssignments(const std::string &mathExpression,
                               const libsbml::Model *model);
 
-std::string ASTtoString(const libsbml::ASTNode *node);
+std::string mathASTtoString(const libsbml::ASTNode *node);
 
-} // namespace sbml
+std::unique_ptr<libsbml::ASTNode>
+mathStringToAST(const std::string &mathExpression,
+                const libsbml::Model *model = nullptr);
+
+std::string getUnknownFunctionName(const libsbml::ASTNode *node,
+                                   const libsbml::Model *model);
+
+std::string getUnknownVariableName(const libsbml::ASTNode *node,
+                                   const libsbml::Model *model);
+
+double evaluateMathAST(
+    const libsbml::ASTNode *node,
+    const std::map<const std::string, std::pair<double, bool>> &vars = {},
+    const libsbml::Model *model = nullptr);
+
+double evaluateMathString(
+    const std::string &mathExpression,
+    const std::map<const std::string, std::pair<double, bool>> &vars = {},
+    const libsbml::Model *model = nullptr);
+
+} // namespace model

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -1,14 +1,5 @@
 #include "model.hpp"
 
-#include <sbml/SBMLTypes.h>
-#include <sbml/extension/SBMLDocumentPlugin.h>
-#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
-#include <sbml/packages/spatial/extension/SpatialExtension.h>
-
-#include <algorithm>
-#include <stdexcept>
-#include <utility>
-
 #include "id.hpp"
 #include "logger.hpp"
 #include "math.hpp"
@@ -16,6 +7,14 @@
 #include "utils.hpp"
 #include "validation.hpp"
 #include "xml_annotation.hpp"
+#include <algorithm>
+#include <sbml/SBMLTransforms.h>
+#include <sbml/SBMLTypes.h>
+#include <sbml/extension/SBMLDocumentPlugin.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+#include <sbml/packages/spatial/extension/SpatialExtension.h>
+#include <stdexcept>
+#include <utility>
 
 namespace model {
 
@@ -56,6 +55,7 @@ void Model::initModelData() {
     return;
   }
   auto *model = doc->getModel();
+  modelMath = ModelMath(model);
   modelParameters = ModelParameters(model);
   modelFunctions = ModelFunctions(model);
   modelMembranes.clear();
@@ -143,6 +143,10 @@ ModelUnits &Model::getUnits() { return modelUnits; }
 
 const ModelUnits &Model::getUnits() const { return modelUnits; }
 
+ModelMath &Model::getMath() { return modelMath; }
+
+const ModelMath &Model::getMath() const { return modelMath; }
+
 void Model::clear() {
   doc.reset();
   isValid = false;
@@ -155,6 +159,7 @@ void Model::clear() {
   modelFunctions = ModelFunctions{};
   modelParameters = ModelParameters{};
   modelUnits = ModelUnits{};
+  modelMath = ModelMath{};
 }
 
 SpeciesGeometry Model::getSpeciesGeometry(const QString &speciesID) const {

--- a/src/core/model/src/model_functions_t.cpp
+++ b/src/core/model/src/model_functions_t.cpp
@@ -1,0 +1,80 @@
+#include "catch_wrapper.hpp"
+#include "model.hpp"
+#include "model_functions.hpp"
+#include "sbml_test_data/yeast_glycolysis.hpp"
+#include <QFile>
+#include <QImage>
+#include <sbml/SBMLTypes.h>
+#include <sbml/extension/SBMLDocumentPlugin.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+#include <sbml/packages/spatial/extension/SpatialExtension.h>
+
+SCENARIO("SBML functions",
+         "[core/model/functions][core/model][core][model][functions]") {
+  GIVEN("SBML: yeast-glycolysis.xml") {
+    std::unique_ptr<libsbml::SBMLDocument> doc(
+        libsbml::readSBMLFromString(sbml_test_data::yeast_glycolysis().xml));
+    // write SBML document to file
+    libsbml::SBMLWriter().writeSBML(doc.get(), "tmp.xml");
+
+    model::Model s;
+    s.importSBMLFile("tmp.xml");
+    REQUIRE(s.getCompartments().getIds().size() == 1);
+    REQUIRE(s.getCompartments().getIds()[0] == "compartment");
+    REQUIRE(s.getSpecies().getIds("compartment").size() == 25);
+    auto &funcs = s.getFunctions();
+    REQUIRE(funcs.getIds().size() == 17);
+    REQUIRE(funcs.getIds()[0] == "HK_kinetics");
+    REQUIRE(funcs.getName("HK_kinetics") == "HK kinetics");
+    REQUIRE(funcs.getArguments("HK_kinetics").size() == 10);
+    REQUIRE(funcs.getArguments("HK_kinetics")[0] == "A");
+    REQUIRE(funcs.getExpression("HK_kinetics") ==
+            "Vmax * (A * B / (Kglc * Katp) - P * Q / (Kglc * Katp * Keq)) "
+            "/ ((1 + A / Kglc + P / Kg6p) * (1 + B / Katp + Q / Kadp))");
+    WHEN("inline fn: Glycogen_synthesis_kinetics") {
+      std::string expr = "Glycogen_synthesis_kinetics(abc)";
+      std::string inlined = "(abc)";
+      REQUIRE(s.inlineExpr(expr) == inlined);
+    }
+    WHEN("inline fn: ATPase_0") {
+      std::string expr = "ATPase_0( a,b)";
+      std::string inlined = "(b * a)";
+      REQUIRE(s.inlineExpr(expr) == inlined);
+    }
+    WHEN("inline fn: PDC_kinetics") {
+      std::string expr = "PDC_kinetics(a,V,k,n)";
+      std::string inlined = "(V * (a / k)^n / (1 + (a / k)^n))";
+      REQUIRE(s.inlineExpr(expr) == inlined);
+    }
+    WHEN("edit function: PDC_kinetics") {
+      REQUIRE(funcs.getArguments("PDC_kinetics").size() == 4);
+      REQUIRE(funcs.getArguments("PDC_kinetics")[0] == "A");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[1] == "Vmax");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[2] == "Kpyr");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[3] == "nH");
+      funcs.addArgument("PDC_kinetics", "x");
+      funcs.setName("PDC_kinetics", "newName!");
+      funcs.setExpression("PDC_kinetics", "(V*(x/k)^n/(1+(a/k)^n))");
+      REQUIRE(funcs.getName("PDC_kinetics") == "newName!");
+      REQUIRE(funcs.getArguments("PDC_kinetics").size() == 5);
+      REQUIRE(funcs.getArguments("PDC_kinetics")[0] == "A");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[1] == "Vmax");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[2] == "Kpyr");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[3] == "nH");
+      REQUIRE(funcs.getArguments("PDC_kinetics")[4] == "x");
+      REQUIRE(funcs.getExpression("PDC_kinetics") ==
+              "V * (x / k)^n / (1 + (a / k)^n)");
+      std::string expr = "PDC_kinetics(a,V,k,n,Q)";
+      std::string inlined = "(V * (Q / k)^n / (1 + (a / k)^n))";
+      REQUIRE(s.inlineExpr(expr) == inlined);
+      funcs.remove("PDC_kinetics");
+      REQUIRE(funcs.getIds().size() == 16);
+    }
+    WHEN("add function") {
+      funcs.add("func N~!me");
+      REQUIRE(funcs.getName("func_Nme") == "func N~!me");
+      REQUIRE(funcs.getArguments("func_Nme").isEmpty());
+      REQUIRE(funcs.getExpression("func_Nme") == "0");
+    }
+  }
+}

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -345,4 +345,5 @@ bool ModelGeometry::getHasImage() const { return hasImage; }
 void ModelGeometry::writeGeometryToSBML() const {
   writeGeometryMeshToSBML(sbmlModel, mesh.get(), *modelCompartments);
 }
+
 } // namespace model

--- a/src/core/model/src/model_math.cpp
+++ b/src/core/model/src/model_math.cpp
@@ -1,0 +1,61 @@
+#include "model_math.hpp"
+
+#include "math.hpp"
+#include <memory>
+#include <sbml/SBMLTypes.h>
+#include <sbml/extension/SBMLDocumentPlugin.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+#include <sbml/packages/spatial/extension/SpatialExtension.h>
+
+namespace model {
+
+ModelMath::ModelMath() = default;
+
+ModelMath::ModelMath(const libsbml::Model *model) : sbmlModel{model} {};
+
+void ModelMath::parse(const std::string &expr) {
+  if (expr.empty()) {
+    valid = false;
+    errorMessage = "Empty expression";
+    return;
+  }
+  astNode = mathStringToAST(expr, sbmlModel);
+  if (astNode == nullptr) {
+    valid = false;
+    std::unique_ptr<char, decltype(&std::free)> err(
+        libsbml::SBML_getLastParseL3Error(), &std::free);
+    errorMessage = err.get();
+    return;
+  }
+  if (auto unknownFunc = getUnknownFunctionName(astNode.get(), sbmlModel);
+      !unknownFunc.empty()) {
+    valid = false;
+    errorMessage = "Unknown function: " + unknownFunc;
+    return;
+  }
+  if (auto unknownVar = getUnknownVariableName(astNode.get(), sbmlModel);
+      !unknownVar.empty()) {
+    valid = false;
+    errorMessage = "Unknown variable: " + unknownVar;
+    return;
+  }
+  valid = true;
+  errorMessage.clear();
+}
+
+double ModelMath::eval(
+    const std::map<const std::string, std::pair<double, bool>> &vars) const {
+  return evaluateMathAST(astNode.get(), vars, sbmlModel);
+}
+
+bool ModelMath::isValid() const { return valid; }
+
+const std::string &ModelMath::getErrorMessage() const { return errorMessage; }
+
+ModelMath::ModelMath(ModelMath &&) noexcept = default;
+
+ModelMath &ModelMath::operator=(ModelMath &&) noexcept = default;
+
+ModelMath::~ModelMath() = default;
+
+}; // namespace model

--- a/src/core/model/src/model_math_t.cpp
+++ b/src/core/model/src/model_math_t.cpp
@@ -1,0 +1,107 @@
+#include <QFile>
+#include <QImage>
+
+#include "catch_wrapper.hpp"
+#include "model.hpp"
+#include "model_math.hpp"
+
+SCENARIO("SBML math", "[core/model/math][core/model][core][model][math]") {
+  GIVEN("No SBML model, valid expressions") {
+    model::ModelMath math;
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() == "Empty expression");
+    math.parse("");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() == "Empty expression");
+    math.parse("2");
+    REQUIRE(math.isValid() == true);
+    REQUIRE(math.getErrorMessage().empty());
+    REQUIRE(math.eval() == dbl_approx(2));
+    math.parse("1.1+2.4");
+    REQUIRE(math.isValid() == true);
+    REQUIRE(math.getErrorMessage().empty());
+    REQUIRE(math.eval() == dbl_approx(3.5));
+    math.parse("cos(0)");
+    REQUIRE(math.isValid() == true);
+    REQUIRE(math.getErrorMessage().empty());
+    REQUIRE(math.eval() == dbl_approx(1));
+    math.parse("(-2)^2");
+    REQUIRE(math.isValid() == true);
+    REQUIRE(math.getErrorMessage().empty());
+    REQUIRE(math.eval() == dbl_approx(4));
+    math.parse("(-2)^2");
+    REQUIRE(math.isValid() == true);
+    REQUIRE(math.getErrorMessage().empty());
+    REQUIRE(math.eval() == dbl_approx(4));
+    model::ModelMath math2;
+    math2 = std::move(math);
+    math2.parse("(-2)^2");
+    REQUIRE(math.isValid() == true);
+  }
+  GIVEN("No SBML model, invalid expressions") {
+    model::ModelMath math;
+    math.parse("(");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() ==
+            "Error when parsing input '(' at position 1:  syntax error, "
+            "unexpected end of string");
+    math.parse("x");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() == "Unknown variable: x");
+    math.parse("sillyfunction(x)");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() == "Unknown function: sillyfunction");
+    math.parse("cos(sin(yy))");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() == "Unknown variable: yy");
+    math.parse("cos(sin(yy)");
+    REQUIRE(math.isValid() == false);
+    REQUIRE(math.getErrorMessage() ==
+            "Error when parsing input 'cos(sin(yy)' at position 11:  syntax "
+            "error, unexpected end of string, expecting ')' or ','");
+  }
+  GIVEN("SBML model") {
+    model::Model model;
+    QFile f(":/models/ABtoC.xml");
+    f.open(QIODevice::ReadOnly);
+    model.importSBMLString(f.readAll().toStdString());
+    auto &funcs = model.getFunctions();
+    funcs.add("f1");
+    funcs.addArgument("f1", "x");
+    funcs.setExpression("f1", "2*x");
+    model.getFunctions().add("my_func");
+    funcs.setExpression("my_func", "42");
+    model.getFunctions().add("my Func!");
+    auto &math = model.getMath();
+    std::map<const std::string, std::pair<double, bool>> map;
+    map["x"] = {1.345, false};
+    map["y"] = {-0.9, false};
+    WHEN("Valid expressions") {
+      math.parse("x");
+      REQUIRE(math.isValid() == true);
+      REQUIRE(math.eval(map) == dbl_approx(1.345));
+      math.parse("x^2 + cos(x)");
+      REQUIRE(math.isValid() == true);
+      REQUIRE(math.eval(map) == dbl_approx(1.345 * 1.345 + std::cos(1.345)));
+      math.parse("x+y");
+      REQUIRE(math.isValid() == true);
+      REQUIRE(math.eval(map) == dbl_approx(0.445));
+      math.parse("f1(x+y)");
+      REQUIRE(math.isValid() == true);
+      REQUIRE(math.eval(map) == dbl_approx(0.89));
+    }
+    WHEN("Invalid expressions") {
+      math.parse("x(");
+      REQUIRE(math.isValid() == false);
+      REQUIRE(math.getErrorMessage() ==
+              "Error when parsing input 'x(' at position 2:  syntax error, "
+              "unexpected end of string");
+      math.parse("z");
+      REQUIRE(math.isValid() == false);
+      REQUIRE(math.getErrorMessage() == "Unknown variable: z");
+      math.parse("z(y)");
+      REQUIRE(math.isValid() == false);
+      REQUIRE(math.getErrorMessage() == "Unknown function: z");
+    }
+  }
+}

--- a/src/core/model/src/model_reactions.cpp
+++ b/src/core/model/src/model_reactions.cpp
@@ -58,8 +58,9 @@ static QVector<QStringList> importParameterIds(const libsbml::Model *model) {
   return paramIds;
 }
 
-static void makeReactionSpatial(
-    libsbml::Reaction *reac, const std::vector<geometry::Membrane> &membranes) {
+static void
+makeReactionSpatial(libsbml::Reaction *reac,
+                    const std::vector<geometry::Membrane> &membranes) {
   const auto *model = reac->getModel();
   utils::SmallStackSet<std::string, 3> compSet;
   if (reac->isSetCompartment()) {
@@ -94,7 +95,7 @@ static void makeReactionSpatial(
     SPDLOG_INFO("  - original rate units: d[amount]/dt");
     SPDLOG_INFO("  -> want spatial compartment reaction: d[concentration]/dt");
     SPDLOG_INFO("  -> dividing rate by compartment size");
-    auto expr = ASTtoString(kin->getMath());
+    auto expr = mathASTtoString(kin->getMath());
     SPDLOG_INFO("  - {}", expr);
     auto newExpr = symbolic::divide(expr, compSet[0]);
     SPDLOG_INFO("  --> {}", newExpr);
@@ -103,7 +104,7 @@ static void makeReactionSpatial(
     if (argAST != nullptr) {
       reac->getKineticLaw()->setMath(argAST.get());
       SPDLOG_INFO("  - new math: {}",
-                  ASTtoString(reac->getKineticLaw()->getMath()));
+                  mathASTtoString(reac->getKineticLaw()->getMath()));
     } else {
       SPDLOG_ERROR("  - libSBML failed to parse expression");
     }
@@ -132,8 +133,9 @@ static void makeReactionSpatial(
   }
 }
 
-static void makeReactionsSpatial(
-    libsbml::Model *model, const std::vector<geometry::Membrane> &membranes) {
+static void
+makeReactionsSpatial(libsbml::Model *model,
+                     const std::vector<geometry::Membrane> &membranes) {
   for (unsigned int i = 0; i < model->getNumReactions(); ++i) {
     auto *reac = model->getReaction(i);
     reac->setFast(false);
@@ -174,10 +176,8 @@ ModelReactions::ModelReactions() = default;
 
 ModelReactions::ModelReactions(libsbml::Model *model,
                                const std::vector<geometry::Membrane> &membranes)
-    : ids{importIds(model)},
-      names{importNamesAndMakeUnique(model)},
-      parameterIds{importParameterIds(model)},
-      sbmlModel{model} {
+    : ids{importIds(model)}, names{importNamesAndMakeUnique(model)},
+      parameterIds{importParameterIds(model)}, sbmlModel{model} {
   makeReactionsSpatial(model, membranes);
 }
 
@@ -461,4 +461,4 @@ void ModelReactions::removeParameter(const QString &reactionId,
                 rmParam->getId(), reac->getId());
   }
 }
-}  // namespace model
+} // namespace model

--- a/src/core/resources/models/liver-simplified.xml
+++ b/src/core/resources/models/liver-simplified.xml
@@ -360,7 +360,7 @@
       </unitDefinition>
     </listOfUnitDefinitions>
     <listOfCompartments>
-      <compartment metaid="COPASI1" id="cytoplasm" name="cytoplasm" spatialDimensions="3" size="1" units="volume" constant="true">
+      <compartment metaid="COPASI1" id="cytoplasm" name="cytoplasm" spatialDimensions="2" size="1" units="volume" constant="true">
         <annotation>
           <COPASI xmlns="http://www.copasi.org/static/sbml">
             <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -376,7 +376,7 @@
         </annotation>
         <spatial:compartmentMapping spatial:id="cytoplasm_compartmentMapping" spatial:domainType="cytoplasm_domainType" spatial:unitSize="1"/>
       </compartment>
-      <compartment metaid="COPASI2" id="nucleus" name="nucleus" spatialDimensions="3" size="1" units="volume" constant="true">
+      <compartment metaid="COPASI2" id="nucleus" name="nucleus" spatialDimensions="2" size="1" units="volume" constant="true">
         <annotation>
           <COPASI xmlns="http://www.copasi.org/static/sbml">
             <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -359,7 +359,7 @@ SCENARIO(
     double dt = std::numeric_limits<double>::max();
     if (simType == simulate::SimulatorType::DUNE) {
       initialRelativeError = 0.05;
-      evolvedRelativeError = 0.2;
+      evolvedRelativeError = 0.5;
       simRelErr = std::numeric_limits<double>::max();
       dt = 1.0;
     }
@@ -492,8 +492,8 @@ SCENARIO("Pixel simulator: brusselator model, RK2, RK3, RK4",
     sim2.doTimestep(time);
     auto conc = sim2.getConc(sim.getTimePoints().size() - 1, 0, 0);
     for (std::size_t i = 0; i < conc.size(); ++i) {
-      maxRelDiff = std::max(maxRelDiff, (conc[i] - c4_accurate[i]) /
-                                            (c4_accurate[i] + eps));
+      maxRelDiff = std::max(
+          maxRelDiff, (conc[i] - c4_accurate[i]) / (c4_accurate[i] + eps));
     }
     CAPTURE(order);
     REQUIRE(maxRelDiff < relErr);

--- a/src/gui/dialogs/dialoganalytic.hpp
+++ b/src/gui/dialogs/dialoganalytic.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <QDialog>
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "model.hpp"
 #include "utils.hpp"
@@ -17,25 +20,25 @@ class ModelUnits;
 class DialogAnalytic : public QDialog {
   Q_OBJECT
 
- public:
-  explicit DialogAnalytic(const QString& analyticExpression,
-                          const model::SpeciesGeometry& speciesGeometry,
-                          const std::vector<model::IdNameValue>& constants = {},
-                          QWidget* parent = nullptr);
+public:
+  explicit DialogAnalytic(const QString &analyticExpression,
+                          const model::SpeciesGeometry &speciesGeometry,
+                          model::ModelMath &modelMath,
+                          QWidget *parent = nullptr);
   ~DialogAnalytic();
-  const std::string& getExpression() const;
+  const std::string &getExpression() const;
   bool isExpressionValid() const;
 
- private:
+private:
   std::unique_ptr<Ui::DialogAnalytic> ui;
+  std::map<const std::string, std::pair<double, bool>> sbmlVars;
 
   // user supplied data
-  const std::vector<QPoint>& points;
+  const std::vector<QPoint> &points;
   double width;
   QPointF origin;
   QString lengthUnit;
   QString concentrationUnit;
-  std::vector<double> vars;
 
   QImage img;
   utils::QPointIndexer qpi;
@@ -44,9 +47,9 @@ class DialogAnalytic : public QDialog {
   std::string variableExpression;
   bool expressionIsValid = false;
 
-  QPointF physicalPoint(const QPoint& pixelPoint) const;
-  void txtExpression_mathChanged(const QString& math, bool valid,
-                                 const QString& errorMessage);
+  QPointF physicalPoint(const QPoint &pixelPoint) const;
+  void txtExpression_mathChanged(const QString &math, bool valid,
+                                 const QString &errorMessage);
   void lblImage_mouseOver(QPoint point);
   void btnExportImage_clicked();
 };

--- a/src/gui/dialogs/dialoganalytic_t.cpp
+++ b/src/gui/dialogs/dialoganalytic_t.cpp
@@ -14,8 +14,10 @@ SCENARIO("DialogAnalytic",
     doc.importSBMLString(f.readAll().toStdString());
     auto compartmentPoints = std::vector<QPoint>{
         QPoint(5, 5), QPoint(5, 6), QPoint(5, 7), QPoint(6, 6), QPoint(6, 7)};
-    DialogAnalytic dia("x", {QSize(10, 10), compartmentPoints,
-                             QPointF(0.0, 0.0), 1, doc.getUnits()});
+    DialogAnalytic dia("x",
+                       {QSize(10, 10), compartmentPoints, QPointF(0.0, 0.0), 1,
+                        doc.getUnits()},
+                       doc.getMath());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10") {
@@ -25,22 +27,30 @@ SCENARIO("DialogAnalytic",
       REQUIRE(dia.isExpressionValid() == true);
       REQUIRE(dia.getExpression() == "10");
     }
-    WHEN("invalid expr: (") {
+    WHEN("invalid syntax: (") {
       mwt.addUserAction({"Delete", "(", "Left"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.isExpressionValid() == false);
       REQUIRE(dia.getExpression().empty() == true);
     }
-    WHEN("illegal char: &") {
+    WHEN("illegal syntax: &") {
       mwt.addUserAction({"Delete", "&"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.isExpressionValid() == false);
       REQUIRE(dia.getExpression().empty() == true);
     }
-    WHEN("invalid expr: q") {
+    WHEN("unknown variable: q") {
       mwt.addUserAction({"Delete", "q"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.isExpressionValid() == false);
+      REQUIRE(dia.getExpression().empty() == true);
+    }
+    WHEN("unknown function: sillyfunc") {
+      mwt.addUserAction({"Delete", "s", "i", "l", "l", "y", "f", "u", "n", "c",
+                         "(", "x", ")"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.isExpressionValid() == false);
@@ -82,7 +92,7 @@ SCENARIO("DialogAnalytic",
     QFile f(":/models/ABtoC.xml");
     f.open(QIODevice::ReadOnly);
     doc.importSBMLString(f.readAll().toStdString());
-    DialogAnalytic dia("x", doc.getSpeciesGeometry("B"));
+    DialogAnalytic dia("x", doc.getSpeciesGeometry("B"), doc.getMath());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10") {

--- a/src/gui/tabs/tabfunctions.hpp
+++ b/src/gui/tabs/tabfunctions.hpp
@@ -16,12 +16,12 @@ class Model;
 class TabFunctions : public QWidget {
   Q_OBJECT
 
- public:
+public:
   explicit TabFunctions(model::Model &doc, QWidget *parent = nullptr);
   ~TabFunctions();
   void loadModelData(const QString &selection = {});
 
- private:
+private:
   std::unique_ptr<Ui::TabFunctions> ui;
   model::Model &sbmlDoc;
   void listFunctions_currentRowChanged(int row);
@@ -32,5 +32,4 @@ class TabFunctions : public QWidget {
   void btnRemoveFunctionParam_clicked();
   void txtFunctionDef_mathChanged(const QString &math, bool valid,
                                   const QString &errorMessage);
-  void btnSaveFunctionChanges_clicked();
 };

--- a/src/gui/tabs/tabfunctions.ui
+++ b/src/gui/tabs/tabfunctions.ui
@@ -85,22 +85,6 @@
       <layout class="QHBoxLayout" name="horizontalLayout_8">
        <item>
         <layout class="QGridLayout" name="gridFunction">
-         <item row="4" column="1">
-          <widget class="QPushButton" name="btnSaveFunctionChanges">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Save changes</string>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="0">
           <widget class="QLabel" name="lblFunctionLabel">
            <property name="sizePolicy">
@@ -195,7 +179,14 @@
          <item row="0" column="1" colspan="3">
           <widget class="QLineEdit" name="txtFunctionName"/>
          </item>
-         <item row="4" column="2" colspan="2">
+         <item row="3" column="1" colspan="3">
+          <widget class="QPlainTextMathEdit" name="txtFunctionDef">
+           <property name="tabChangesFocus">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1" colspan="3">
           <widget class="QLabel" name="lblFunctionDefStatus">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -329,13 +320,6 @@
            </property>
            <property name="text">
             <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1" colspan="3">
-          <widget class="QPlainTextMathEdit" name="txtFunctionDef">
-           <property name="tabChangesFocus">
-            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/gui/tabs/tabfunctions_t.cpp
+++ b/src/gui/tabs/tabfunctions_t.cpp
@@ -13,8 +13,8 @@
 #include "tabfunctions.hpp"
 
 SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
-  model::Model smblDoc;
-  auto tab = TabFunctions(smblDoc);
+  model::Model model;
+  auto tab = TabFunctions(model);
   ModalWidgetTimer mwt;
   // get pointers to widgets within tab
   auto *listFunctions = tab.findChild<QListWidget *>("listFunctions");
@@ -28,12 +28,10 @@ SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
       tab.findChild<QPushButton *>("btnRemoveFunctionParam");
   auto *txtFunctionDef = tab.findChild<QPlainTextMathEdit *>("txtFunctionDef");
   REQUIRE(txtFunctionDef != nullptr);
-  auto *btnSaveFunctionChanges =
-      tab.findChild<QPushButton *>("btnSaveFunctionChanges");
   GIVEN("model with no functions") {
     if (QFile f(":/models/very-simple-model.xml");
         f.open(QIODevice::ReadOnly)) {
-      smblDoc.importSBMLString(f.readAll().toStdString());
+      model.importSBMLString(f.readAll().toStdString());
     }
     tab.loadModelData();
     REQUIRE(listFunctions->count() == 0);
@@ -44,7 +42,7 @@ SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
     REQUIRE(btnAddFunctionParam->isEnabled() == false);
     REQUIRE(btnRemoveFunctionParam->isEnabled() == false);
     REQUIRE(txtFunctionDef->getMath() == "");
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == false);
+    REQUIRE(model.getFunctions().getIds().isEmpty());
 
     // add a function
     mwt.addUserAction({"f", "u", "n", "c", " ", "1"});
@@ -53,6 +51,10 @@ SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
     REQUIRE(listFunctions->count() == 1);
     REQUIRE(listFunctions->item(0)->text().toStdString() == "func 1");
     REQUIRE(btnRemoveFunction->isEnabled() == true);
+    REQUIRE(model.getFunctions().getIds().size() == 1);
+    REQUIRE(model.getFunctions().getIds()[0] == "func_1");
+    REQUIRE(model.getFunctions().getArguments("func_1").isEmpty());
+    REQUIRE(model.getFunctions().getExpression("func_1") == "0");
 
     // add two function params
     mwt.addUserAction({"y"});
@@ -61,6 +63,8 @@ SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
     REQUIRE(listFunctionParams->count() == 1);
     REQUIRE(listFunctionParams->item(0)->text().toStdString() == "y");
     REQUIRE(btnRemoveFunctionParam->isEnabled() == true);
+    REQUIRE(model.getFunctions().getArguments("func_1").size() == 1);
+    REQUIRE(model.getFunctions().getArguments("func_1")[0] == "y");
     mwt.addUserAction({"q", "q", " ", "Q", "A"});
     mwt.start();
     sendMouseClick(btnAddFunctionParam);
@@ -68,47 +72,53 @@ SCENARIO("Functions Tab", "[gui/tabs/functions][gui/tabs][gui][functions]") {
     REQUIRE(listFunctionParams->item(0)->text().toStdString() == "y");
     REQUIRE(listFunctionParams->item(1)->text().toStdString() == "qq QA");
     REQUIRE(btnRemoveFunctionParam->isEnabled() == true);
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == true);
+    REQUIRE(model.getFunctions().getArguments("func_1").size() == 2);
+    REQUIRE(model.getFunctions().getArguments("func_1")[0] == "y");
+    REQUIRE(model.getFunctions().getArguments("func_1")[1] == "qq QA");
 
     // click remove param, then press escape at confirmation dialog to cancel
     sendMouseClick(btnRemoveFunctionParam);
     sendKeyEventsToNextQDialog({"Esc"});
     REQUIRE(listFunctionParams->count() == 2);
+    REQUIRE(model.getFunctions().getArguments("func_1").size() == 2);
+    REQUIRE(model.getFunctions().getArguments("func_1")[0] == "y");
+    REQUIRE(model.getFunctions().getArguments("func_1")[1] == "qq QA");
 
     // this time press spacebar to press default 'yes' button to confirm
     sendMouseClick(btnRemoveFunctionParam);
     sendKeyEventsToNextQDialog({"Enter"});
     REQUIRE(listFunctionParams->count() == 1);
     REQUIRE(listFunctionParams->item(0)->text().toStdString() == "y");
+    REQUIRE(model.getFunctions().getArguments("func_1").size() == 1);
+    REQUIRE(model.getFunctions().getArguments("func_1")[0] == "y");
 
-    // edit math expression
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == true);
     // delete existing "0" to have empty expression
-    sendKeyEvents(txtFunctionDef, {"Delete"});
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == false);
-    // edit expression: x is not a parameter
+    // expression invalid so model not changed:
+    REQUIRE(model.getFunctions().getExpression("func_1") == "0");
+    // edit expression: x is not a parameter, model still not changed
     sendKeyEvents(txtFunctionDef, {"x"});
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == false);
-    // edit expression: but y is
-    sendKeyEvents(txtFunctionDef, {"Backspace", "y"});
-    REQUIRE(btnSaveFunctionChanges->isEnabled() == true);
-    // save changes
-    sendMouseClick(btnSaveFunctionChanges);
+    REQUIRE(model.getFunctions().getExpression("func_1") == "0");
+    // edit expression: but y is, so model updated
+    sendKeyEvents(txtFunctionDef, {"Delete", "Backspace", "y"});
+    REQUIRE(model.getFunctions().getExpression("func_1") == "y");
 
     // click remove function, then cancel
     sendMouseClick(btnRemoveFunction);
     sendKeyEventsToNextQDialog({"Esc"});
     REQUIRE(listFunctions->count() == 1);
+    REQUIRE(model.getFunctions().getIds().size() == 1);
+    REQUIRE(model.getFunctions().getIds()[0] == "func_1");
 
     // click remove function, and confirm
     sendMouseClick(btnRemoveFunction);
     sendKeyEventsToNextQDialog({"Enter"});
     REQUIRE(listFunctions->count() == 0);
     REQUIRE(listFunctionParams->count() == 0);
+    REQUIRE(model.getFunctions().getIds().isEmpty());
   }
   GIVEN("circadian clock model") {
     if (QFile f(":/models/circadian-clock.xml"); f.open(QIODevice::ReadOnly)) {
-      smblDoc.importSBMLString(f.readAll().toStdString());
+      model.importSBMLString(f.readAll().toStdString());
     }
     tab.loadModelData();
     REQUIRE(listFunctions->count() == 3);

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -281,8 +281,7 @@ void TabSpecies::btnEditAnalyticConcentration_clicked() {
                currentSpeciesId.toStdString());
   DialogAnalytic dialog(
       sbmlDoc.getSpecies().getAnalyticConcentration(currentSpeciesId),
-      sbmlDoc.getSpeciesGeometry(currentSpeciesId),
-      sbmlDoc.getParameters().getGlobalConstants());
+      sbmlDoc.getSpeciesGeometry(currentSpeciesId), sbmlDoc.getMath());
   if (dialog.exec() == QDialog::Accepted) {
     const std::string &expr = dialog.getExpression();
     SPDLOG_DEBUG("  - set expr: {}", expr);

--- a/src/gui/widgets/qplaintextmathedit.hpp
+++ b/src/gui/widgets/qplaintextmathedit.hpp
@@ -11,16 +11,27 @@
 
 #include "symbolic.hpp"
 
+namespace libsbml {
+class Model;
+}
+
+namespace model {
+class ModelMath;
+}
+
 class QPlainTextMathEdit : public QPlainTextEdit {
   Q_OBJECT
- public:
+public:
   explicit QPlainTextMathEdit(QWidget *parent = nullptr);
+  void enableLibSbmlBackend(model::ModelMath *math);
   bool mathIsValid() const;
   const QString &getMath() const;
   const std::string &getVariableMath() const;
   void importVariableMath(const std::string &expr);
   void compileMath();
   double evaluateMath(const std::vector<double> &variables = {});
+  double evaluateMath(
+      const std::map<const std::string, std::pair<double, bool>> &variables);
   const QString &getErrorMessage() const;
   const std::vector<std::string> &getVariables() const;
   void clearVariables();
@@ -29,11 +40,15 @@ class QPlainTextMathEdit : public QPlainTextEdit {
                    const std::string &displayName = {});
   void removeVariable(const std::string &variable);
 
- signals:
+signals:
   void mathChanged(const QString &math, bool valid,
                    const QString &errorMessage);
 
- private:
+private:
+  model::ModelMath *modelMath{nullptr};
+  bool useLibSbmlBackend{false};
+  bool allowImplicitNames{false};
+  bool allowIllegalChars{false};
   symbolic::Symbolic sym;
   std::vector<double> result{0.0};
   const QColor colourValid = QColor(200, 255, 200);
@@ -46,8 +61,8 @@ class QPlainTextMathEdit : public QPlainTextEdit {
   std::string currentVariableMath;
   QString currentErrorMessage;
   bool expressionIsValid = false;
-  std::pair<std::string, QString> displayNamesToVariables(
-      const std::string &expr) const;
+  std::pair<std::string, QString>
+  displayNamesToVariables(const std::string &expr) const;
   std::string variablesToDisplayNames(const std::string &expr) const;
   void qPlainTextEdit_textChanged();
   void qPlainTextEdit_cursorPositionChanged();

--- a/src/gui/widgets/qplaintextmathedit_t.cpp
+++ b/src/gui/widgets/qplaintextmathedit_t.cpp
@@ -1,10 +1,12 @@
 #include "catch_wrapper.hpp"
 #include "logger.hpp"
+#include "model.hpp"
 #include "qplaintextmathedit.hpp"
 #include "qt_test_utils.hpp"
 
-SCENARIO("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
-                               "widgets][gui][qplaintextmathedit][symbolic]") {
+SCENARIO("QPlainTextMathEdit",
+         "[gui/widgets/qplaintextmathedit][gui/"
+         "widgets][gui][qplaintextmathedit][symbolic]") {
   QPlainTextMathEdit mathEdit;
   struct Signal {
     QString math;
@@ -20,199 +22,326 @@ SCENARIO("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
   REQUIRE(mathEdit.getMath() == "");
   REQUIRE(mathEdit.mathIsValid() == false);
   REQUIRE(mathEdit.getErrorMessage() == "");
-  GIVEN("expression and/or variables") {
-    mathEdit.show();
-    // "1"
-    sendKeyEvents(&mathEdit, {"1"});
-    REQUIRE(mathEdit.getMath() == "1");
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.compileMath();
-    REQUIRE(mathEdit.evaluateMath() == dbl_approx(1.0));
+  WHEN("SymEngine backend") {
+    GIVEN("expression and/or variables") {
+      mathEdit.show();
+      // "1"
+      sendKeyEvents(&mathEdit, {"1"});
+      REQUIRE(mathEdit.getMath() == "1");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(1.0));
 
-    // "1*"
-    sendKeyEvents(&mathEdit, {"*"});
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "syntax error");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
+      // "1*"
+      sendKeyEvents(&mathEdit, {"*"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "syntax error");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
 
-    // "1*2"
-    sendKeyEvents(&mathEdit, {"2"});
-    REQUIRE(mathEdit.getMath() == "2");
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.compileMath();
-    REQUIRE(mathEdit.evaluateMath() == dbl_approx(2.0));
+      // "1*2"
+      sendKeyEvents(&mathEdit, {"2"});
+      REQUIRE(mathEdit.getMath() == "2");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(2.0));
 
-    // "1*2+x" (x not a variable)
-    sendKeyEvents(&mathEdit, {"+", "x"});
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: x");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.addVariable("x");
-    REQUIRE(mathEdit.getMath() == "2 + x");
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.addVariable("y");
-    // removing non-existent variable is a no-op
-    mathEdit.removeVariable("notfound");
-    mathEdit.removeVariable("x");
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'x' not found");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
+      // "1*2+x" (x not a variable)
+      sendKeyEvents(&mathEdit, {"+", "x"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: x");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.addVariable("x");
+      REQUIRE(mathEdit.getMath() == "2 + x");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.addVariable("y");
+      // removing non-existent variable is a no-op
+      mathEdit.removeVariable("notfound");
+      mathEdit.removeVariable("x");
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'x' not found");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
 
-    // "1*2+x&" (& not a valid character)
-    sendKeyEvents(&mathEdit, {"&"});
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'x&' not found");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
+      // "1*2+x&" (& not a valid character)
+      sendKeyEvents(&mathEdit, {"&"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'x&' not found");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
 
-    // "1*2+x!" (! not a valid character)
-    sendKeyEvents(&mathEdit, {"Backspace", "!"});
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'x!' not found");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
+      // "1*2+x!" (! not a valid character)
+      sendKeyEvents(&mathEdit, {"Backspace", "!"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'x!' not found");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
 
-    // "1*2+5*(1+3)"
-    sendKeyEvents(&mathEdit, {"Backspace", "Backspace", "5", "*", "(", "1", "+",
-                              "3", ")"});
-    REQUIRE(mathEdit.getMath() == "22");
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.compileMath();
-    REQUIRE(mathEdit.evaluateMath() == dbl_approx(22.0));
+      // "1*2+5*(1+3)"
+      sendKeyEvents(&mathEdit, {"Backspace", "Backspace", "5", "*", "(", "1",
+                                "+", "3", ")"});
+      REQUIRE(mathEdit.getMath() == "22");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(22.0));
+    }
+    GIVEN("expression with variables") {
+      mathEdit.show();
+      REQUIRE(mathEdit.getVariables().empty() == true);
+      mathEdit.setVariables({"x", "y"});
+      REQUIRE(mathEdit.getVariables().size() == 2);
+      REQUIRE(mathEdit.getVariables()[0] == "x");
+      REQUIRE(mathEdit.getVariables()[1] == "y");
+      mathEdit.addVariable("z");
+      mathEdit.removeVariable("x");
+      REQUIRE(mathEdit.getVariables().size() == 2);
+      REQUIRE(mathEdit.getVariables()[0] == "y");
+      REQUIRE(mathEdit.getVariables()[1] == "z");
+      mathEdit.addVariable("x");
+      REQUIRE(mathEdit.getVariables().size() == 3);
+      REQUIRE(mathEdit.getVariables()[0] == "y");
+      REQUIRE(mathEdit.getVariables()[1] == "z");
+      REQUIRE(mathEdit.getVariables()[2] == "x");
+      mathEdit.removeVariable("y");
+      mathEdit.removeVariable("z");
+      mathEdit.addVariable("y");
+      REQUIRE(mathEdit.getVariables().size() == 2);
+      REQUIRE(mathEdit.getVariables()[0] == "x");
+      REQUIRE(mathEdit.getVariables()[1] == "y");
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Empty expression");
+      // x+2*y
+      sendKeyEvents(&mathEdit, {"x", "+", "2", "*", "y"});
+      REQUIRE(mathEdit.getMath() == "x + 2*y");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath(std::vector<double>{0.0, 0.0}) ==
+              dbl_approx(0.0));
+      REQUIRE(mathEdit.evaluateMath(std::vector<double>{1.0, 0.0}) ==
+              dbl_approx(1.0));
+      REQUIRE(mathEdit.evaluateMath(std::vector<double>{0.0, 1.0}) ==
+              dbl_approx(2.0));
+      REQUIRE(mathEdit.evaluateMath(std::vector<double>{1.0, 1.0}) ==
+              dbl_approx(3.0));
+      // using libSBML map interface works but gives logger warning about
+      // inefficiency
+      std::map<const std::string, std::pair<double, bool>> vars;
+      vars["x"] = {1.0, false};
+      vars["y"] = {1.0, false};
+      REQUIRE(mathEdit.evaluateMath(vars) == dbl_approx(3.0));
+      mathEdit.clearVariables();
+      REQUIRE(mathEdit.getVariables().empty() == true);
+    }
+    GIVEN("expression with unquoted display names") {
+      mathEdit.show();
+      mathEdit.clearVariables();
+      REQUIRE(mathEdit.getVariables().empty() == true);
+      // "X + y_var"
+      sendKeyEvents(&mathEdit, {"X", "+", "y", "_", "v", "a", "r"});
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
+      mathEdit.addVariable("x", "X");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'y_var' not found");
+      mathEdit.addVariable("y", "y_var");
+      REQUIRE(mathEdit.getVariables().size() == 2);
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(signal.math == "X + y_var");
+      REQUIRE(mathEdit.getVariableMath() == "x + y");
+      // "X + y_var + 3*X"
+      sendKeyEvents(&mathEdit, {"+", "3", "*", "X"});
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(signal.math == "4*X + y_var");
+      REQUIRE(mathEdit.getVariableMath() == "4*x + y");
+      mathEdit.removeVariable("y");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'y_var' not found");
+      mathEdit.removeVariable("x");
+      REQUIRE(mathEdit.getVariableMath().empty() == true);
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
+    }
+    GIVEN("expression with quoted display names") {
+      mathEdit.show();
+      REQUIRE(mathEdit.getVariables().empty() == true);
+      mathEdit.addVariable("x", "X var!");
+      REQUIRE(mathEdit.getVariables().size() == 1);
+      // "X var!"
+      sendKeyEvents(&mathEdit, {"\"", "X", " ", "v", "a", "r", "!", "\""});
+      REQUIRE(signal.math == "\"X var!\"");
+      REQUIRE(mathEdit.getVariableMath() == "x");
+      // "X var!" + "X var!"
+      sendKeyEvents(&mathEdit, {"+", "\"", "X", " ", "v", "a", "r", "!", "\""});
+      REQUIRE(signal.math == "2*\"X var!\"");
+      REQUIRE(mathEdit.getVariableMath() == "2*x");
+      mathEdit.removeVariable("x");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Illegal character: !");
+    }
+    GIVEN("expression with user-defined function") {
+      mathEdit.show();
+      REQUIRE(mathEdit.getVariables().empty() == true);
+      mathEdit.addVariable("x", "X");
+      REQUIRE(mathEdit.getVariables().size() == 1);
+      // "cos(X)"
+      sendKeyEvents(&mathEdit, {"c", "o", "s", "(", "X", ")"});
+      REQUIRE(signal.math == "");
+      REQUIRE(mathEdit.getVariableMath().empty() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "name 'cos' not found");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      mathEdit.addVariable("cos");
+      REQUIRE(mathEdit.getVariables().size() == 2);
+      REQUIRE(signal.math == "cos(X)");
+      REQUIRE(mathEdit.getVariableMath() == "cos(x)");
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(mathEdit.mathIsValid() == true);
+    }
   }
-  GIVEN("expression with variables") {
-    mathEdit.show();
-    REQUIRE(mathEdit.getVariables().empty() == true);
-    mathEdit.setVariables({"x", "y"});
-    REQUIRE(mathEdit.getVariables().size() == 2);
-    REQUIRE(mathEdit.getVariables()[0] == "x");
-    REQUIRE(mathEdit.getVariables()[1] == "y");
-    mathEdit.addVariable("z");
-    mathEdit.removeVariable("x");
-    REQUIRE(mathEdit.getVariables().size() == 2);
-    REQUIRE(mathEdit.getVariables()[0] == "y");
-    REQUIRE(mathEdit.getVariables()[1] == "z");
-    mathEdit.addVariable("x");
-    REQUIRE(mathEdit.getVariables().size() == 3);
-    REQUIRE(mathEdit.getVariables()[0] == "y");
-    REQUIRE(mathEdit.getVariables()[1] == "z");
-    REQUIRE(mathEdit.getVariables()[2] == "x");
-    mathEdit.removeVariable("y");
-    mathEdit.removeVariable("z");
-    mathEdit.addVariable("y");
-    REQUIRE(mathEdit.getVariables().size() == 2);
-    REQUIRE(mathEdit.getVariables()[0] == "x");
-    REQUIRE(mathEdit.getVariables()[1] == "y");
-    REQUIRE(mathEdit.getMath() == "");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Empty expression");
-    // x+2*y
-    sendKeyEvents(&mathEdit, {"x", "+", "2", "*", "y"});
-    REQUIRE(mathEdit.getMath() == "x + 2*y");
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(signal.math == mathEdit.getMath());
-    REQUIRE(signal.valid == mathEdit.mathIsValid());
-    REQUIRE(signal.error == mathEdit.getErrorMessage());
-    mathEdit.compileMath();
-    REQUIRE(mathEdit.evaluateMath({0.0, 0.0}) == dbl_approx(0.0));
-    REQUIRE(mathEdit.evaluateMath({1.0, 0.0}) == dbl_approx(1.0));
-    REQUIRE(mathEdit.evaluateMath({0.0, 1.0}) == dbl_approx(2.0));
-    REQUIRE(mathEdit.evaluateMath({1.0, 1.0}) == dbl_approx(3.0));
-    mathEdit.clearVariables();
-    REQUIRE(mathEdit.getVariables().empty() == true);
-  }
-  GIVEN("expression with unquoted display names") {
-    mathEdit.show();
-    mathEdit.clearVariables();
-    REQUIRE(mathEdit.getVariables().empty() == true);
-    // "X + y_var"
-    sendKeyEvents(&mathEdit, {"X", "+", "y", "_", "v", "a", "r"});
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
-    mathEdit.addVariable("x", "X");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'y_var' not found");
-    mathEdit.addVariable("y", "y_var");
-    REQUIRE(mathEdit.getVariables().size() == 2);
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(signal.math == "X + y_var");
-    REQUIRE(mathEdit.getVariableMath() == "x + y");
-    // "X + y_var + 3*X"
-    sendKeyEvents(&mathEdit, {"+", "3", "*", "X"});
-    REQUIRE(mathEdit.mathIsValid() == true);
-    REQUIRE(signal.math == "4*X + y_var");
-    REQUIRE(mathEdit.getVariableMath() == "4*x + y");
-    mathEdit.removeVariable("y");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'y_var' not found");
-    mathEdit.removeVariable("x");
-    REQUIRE(mathEdit.getVariableMath().empty() == true);
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Unknown symbol: X");
-  }
-  GIVEN("expression with quoted display names") {
-    mathEdit.show();
-    REQUIRE(mathEdit.getVariables().empty() == true);
-    mathEdit.addVariable("x", "X var!");
-    REQUIRE(mathEdit.getVariables().size() == 1);
-    // "X var!"
-    sendKeyEvents(&mathEdit, {"\"", "X", " ", "v", "a", "r", "!", "\""});
-    REQUIRE(signal.math == "\"X var!\"");
-    REQUIRE(mathEdit.getVariableMath() == "x");
-    // "X var!" + "X var!"
-    sendKeyEvents(&mathEdit, {"+", "\"", "X", " ", "v", "a", "r", "!", "\""});
-    REQUIRE(signal.math == "2*\"X var!\"");
-    REQUIRE(mathEdit.getVariableMath() == "2*x");
-    mathEdit.removeVariable("x");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    REQUIRE(mathEdit.getErrorMessage() == "Illegal character: !");
-  }
-  GIVEN("expression with user-defined function") {
-    mathEdit.show();
-    REQUIRE(mathEdit.getVariables().empty() == true);
-    mathEdit.addVariable("x", "X");
-    REQUIRE(mathEdit.getVariables().size() == 1);
-    // "cos(X)"
-    sendKeyEvents(&mathEdit, {"c", "o", "s", "(", "X", ")"});
-    REQUIRE(signal.math == "");
-    REQUIRE(mathEdit.getVariableMath().empty() == true);
-    REQUIRE(mathEdit.getErrorMessage() == "name 'cos' not found");
-    REQUIRE(mathEdit.mathIsValid() == false);
-    mathEdit.addVariable("cos");
-    REQUIRE(mathEdit.getVariables().size() == 2);
-    REQUIRE(signal.math == "cos(X)");
-    REQUIRE(mathEdit.getVariableMath() == "cos(x)");
-    REQUIRE(mathEdit.getErrorMessage() == "");
-    REQUIRE(mathEdit.mathIsValid() == true);
+  WHEN("libSBML backend") {
+    model::Model model;
+    QFile f(":/models/ABtoC.xml");
+    f.open(QIODevice::ReadOnly);
+    model.importSBMLString(f.readAll().toStdString());
+    mathEdit.enableLibSbmlBackend(&model.getMath());
+    GIVEN("expression without variables") {
+      mathEdit.show();
+      // "1"
+      sendKeyEvents(&mathEdit, {"1"});
+      REQUIRE(mathEdit.getMath() == "1");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(1.0));
+
+      // "1*"
+      sendKeyEvents(&mathEdit, {"*"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() ==
+              "Error when parsing input '1*' at position 2:  syntax error, "
+              "unexpected end of string");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+
+      // "1*2"
+      sendKeyEvents(&mathEdit, {"2"});
+      REQUIRE(mathEdit.getMath() == "1*2");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(2.0));
+
+      // "1*2+cos(0)"
+      sendKeyEvents(&mathEdit, {"+", "c", "o", "s", "(", "0", ")"});
+      REQUIRE(mathEdit.getMath() == "1*2+cos(0)");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      REQUIRE(mathEdit.evaluateMath() == dbl_approx(3.0));
+    }
+    GIVEN("expression with implicit variable (that exists in model)") {
+      mathEdit.show();
+      // "1+cos(x)"
+      sendKeyEvents(&mathEdit, {"1", "+", "c", "o", "s", "(", "x", ")"});
+      REQUIRE(mathEdit.getMath() == "1+cos(x)");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      mathEdit.compileMath();
+      std::map<const std::string, std::pair<double, bool>> vars;
+      // if we don't specify value for x, get nan
+      REQUIRE(std::isnan(mathEdit.evaluateMath(vars)));
+      vars["x"] = {0.0, false};
+      REQUIRE(mathEdit.evaluateMath(vars) == dbl_approx(2.0));
+    }
+    GIVEN("expression with implicit variable (that doesn't exist in model)") {
+      mathEdit.show();
+      // "1+cos(z)"
+      sendKeyEvents(&mathEdit, {"1", "+", "c", "o", "s", "(", "z", ")"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Unknown variable: z");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+    }
+    GIVEN("expression with user defined function (that exists in model)") {
+      model.getFunctions().add("qwq");
+      model.getFunctions().addArgument("qwq", "x");
+      model.getFunctions().setExpression("qwq", "2*x");
+      mathEdit.show();
+      // "1+qwq(x)"
+      sendKeyEvents(&mathEdit, {"1", "+", "q", "w", "q", "(", "x", ")"});
+      REQUIRE(mathEdit.getMath() == "1+qwq(x)");
+      REQUIRE(mathEdit.mathIsValid() == true);
+      REQUIRE(mathEdit.getErrorMessage() == "");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+      std::map<const std::string, std::pair<double, bool>> vars;
+      // if we don't specify value for x, get nan
+      REQUIRE(std::isnan(mathEdit.evaluateMath(vars)));
+      // if we use the wrong interface for evaluate we get nan & logger error
+      REQUIRE(std::isnan(mathEdit.evaluateMath(std::vector<double>{0})));
+      // right interface for libSBML backend is map:
+      vars["x"] = {4.0, false};
+      REQUIRE(mathEdit.evaluateMath(vars) == dbl_approx(9.0));
+    }
+    GIVEN(
+        "expression with user defined function (that doesn't exist in model)") {
+      mathEdit.show();
+      // "1+qwq(x)"
+      sendKeyEvents(&mathEdit, {"1", "+", "q", "w", "q", "(", "x", ")"});
+      REQUIRE(mathEdit.getMath() == "");
+      REQUIRE(mathEdit.mathIsValid() == false);
+      REQUIRE(mathEdit.getErrorMessage() == "Unknown function: qwq");
+      REQUIRE(signal.math == mathEdit.getMath());
+      REQUIRE(signal.valid == mathEdit.mathIsValid());
+      REQUIRE(signal.error == mathEdit.getErrorMessage());
+    }
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ add_custom_target(
           coverage/cov.info
   COMMAND lcov -l coverage/cov.info
   COMMAND genhtml -q coverage/cov.info -o coverage
+  COMMAND xdg-open coverage/index.html
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   COMMENT "Generating coverage report in coverage/index.html"
   VERBATIM)


### PR DESCRIPTION
  - add libSBML math backend wrapper for evaluating math expressions
    - model::ModelMath class
    - libSBML checks that it can parse the expression
    - but parameter/function look-up performed at evaluation time -> get NaNs or infinite recursion for missing parameter/functions
    - add checks that functions and parameters exist in model after successful parse
  - QPlainTextMathEdit can optionally use this ModelMath instead of Symbolic as math backend
    - use it in DialogAnalytic: support full set of allowed SBML math for analytic initial concentration
    - use it to evaluate initial concentration expression for setting field concentration in ModelSpecies
  - use TIFFs for all DUNE initial conditions except uniform
  - resolves #206

also
  - catch SymEngine "Parse Error" exception within Symbolic class
    - add isValid() and getErrorMessage() functions to interface