### PR TITLE
meshing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
 env:
   global:
     # python wheel building can be disabled to speed up CI when working on a PR
-    - BUILD_PYTHON_WHEELS: true
+    - BUILD_PYTHON_WHEELS: false
     # pypi TWINE_PASSWORD
     - secure: "GFBxgbwP75qb0QW3jFO3e3fbfFLpYue+kUZGm3ArNZ9ExeXPGU3fxfxiBolEPnnPK98VlZZ8R0WBQptvWnaBN0tamt5r7OCXljQdpNgRF04MMa1gtbAEnuYjd6dHQ5CbdiEKxK4MnF28jJ+0wnw35E7YPGq357XWKwGFoG0HT9UenFd7HRbzsM0WmO7sog8bZYahYU+nyIDu6AVGlsc1b4XpVEu/pcuY2PexzYpV4wv+qVprRIeTwi2aFb4bmr3XcPZtyps3eiExLISHmz3mAuHIiNEt3wQA7Kjzsz93lm6DlGi3LSEXugfomGzg3oyHQC8oKKky/D6hHqnc9Jfow4Epj3aHvE4LP00TxDiyrjqvVGeCHa/RL/WIGJ/zZA4W7QTr2wvDOhw5EOuSmIW42tmOsOV4Zo/wr5d9A0r0VUfHhrsi1QUHmFFgTJXeTDyHYC32mvXy8EuaxLRFLBUVKE3gPfaYUgRafvx1Kn7H9WUmrpA7JAj2caMYD6UtKly1J6BFyTpPFlGgk3yxzVYgbeToOOrabQzGzYBuaxz6aysbyPra+rYF5SrJ/Dp4TPjfoE/1IIjmrbVpYEQGdfojnxxN6xnW7woPgq8IUDStw7iR83xyluWEtn1i1KlzRA8NMNdBHxgFWQ9rpE/DZikeJ8yb0FoEleMRjaE6G4C33rc="
 
@@ -343,10 +343,9 @@ jobs:
         # core unit core_tests
         - lcov -q -z -d .
         - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./test/tests -as "[core]" 2>&1 | tail -n 100
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*/*.gcno > /dev/null
-        - mv *#spatial-model-editor#src#core*.gcov gcov/
+        - $COV gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
+        - $COV gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
+        - mv *#src#core*.gcov gcov/
         - rm -f *.gcov
         # upload coverage report to codecov.io
         - bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -F core
@@ -355,12 +354,11 @@ jobs:
         - rm -f gcov/*
         - lcov -q -z -d .
         - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./test/tests -as "~[mainwindow][gui]" 2>&1 | tail -n 100
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*/*.gcno > /dev/null
+        - $COV gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
+        - $COV gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
         - $COV gcov -p src/gui/CMakeFiles/gui.dir/*.gcno > /dev/null
         - $COV gcov -p src/gui/CMakeFiles/gui.dir/*/*.gcno > /dev/null
-        - mv *#spatial-model-editor#src#core*.gcov *#spatial-model-editor#src#gui*.gcov gcov/
+        - mv *#src#core*.gcov *#src#gui*.gcov gcov/
         - rm -f *.gcov
         # upload coverage report to codecov.io
         - bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -F gui
@@ -369,12 +367,11 @@ jobs:
         - rm -f gcov/*
         - lcov -q -z -d .
         - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./test/tests -as "[mainwindow][gui]" 2>&1 | tail -n 100
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*/*.gcno > /dev/null
+        - $COV gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
+        - $COV gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
         - $COV gcov -p src/gui/CMakeFiles/gui.dir/*.gcno > /dev/null
         - $COV gcov -p src/gui/CMakeFiles/gui.dir/*/*.gcno > /dev/null
-        - mv *#spatial-model-editor#src#core*.gcov *#spatial-model-editor#src#gui*.gcov gcov/
+        - mv *#src#core*.gcov *#src#gui*.gcov gcov/
         - rm -f *.gcov
         # upload coverage report to codecov.io
         - bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -F mainwindow
@@ -384,13 +381,11 @@ jobs:
         - lcov -q -z -d .
         - cd sme
         - LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$($CC -print-file-name=libclang_rt.asan-x86_64.so) python3 -m unittest discover -v -s ../../test 2>&1 | tail -n 100
-        - $COV gcov -p ../src/core/CMakeFiles/core.dir/*.gcno > /dev/null
-        - $COV gcov -p ../src/core/CMakeFiles/core.dir/*/*.gcno > /dev/null
-        - $COV gcov -p ../src/core/CMakeFiles/core.dir/*/*/*.gcno > /dev/null
-        - $COV gcov -p CMakeFiles/sme.dir/*.gcno > /dev/null
-        - mv *#spatial-model-editor#src#core*.gcov *#spatial-model-editor#sme*.gcov ../gcov/
-        - rm *.gcov
         - cd ..
+        - $COV gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
+        - $COV gcov -p sme/CMakeFiles/sme.dir/*.gcno > /dev/null
+        - mv *#src#core*.gcov *#sme*.gcov gcov/
+        - rm *.gcov
         # upload coverage report to codecov.io
         - bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -X gcov -F sme
 
@@ -398,17 +393,20 @@ jobs:
         - rm -f gcov/*
         - lcov -q -z -d .
         - LSAN_OPTIONS=suppressions=suppr.txt:exitcode=0 ./test/tests -as 2>&1 | tail -n 100
+        - $COV gcov -p src/core/CMakeFiles/core.dir/*/src/*.gcno > /dev/null
+        - $COV gcov -p test/CMakeFiles/tests.dir/__/src/core/*/src/*.gcno > /dev/null
+        - $COV gcov -p src/gui/CMakeFiles/gui.dir/*.gcno > /dev/null
+        - $COV gcov -p src/gui/CMakeFiles/gui.dir/*/*.gcno > /dev/null
+        - mv *#src#core*.gcov *#src#gui*.gcov gcov/
+        - rm -f *.gcov
+        # run python tests, but only copy gcov data for sme files: don't want to overwrite core data from above main test run
+        - lcov -q -z -d .
         - cd sme
         - LSAN_OPTIONS=exitcode=0 LD_PRELOAD=$($CC -print-file-name=libclang_rt.asan-x86_64.so) python3 -m unittest discover -s ../../test 2>&1 | tail -n 100
         - cd ..
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*.gcno > /dev/null
-        - $COV gcov -p src/core/CMakeFiles/core.dir/*/*/*.gcno > /dev/null
-        - $COV gcov -p src/gui/CMakeFiles/gui.dir/*.gcno > /dev/null
-        - $COV gcov -p src/gui/CMakeFiles/gui.dir/*/*.gcno > /dev/null
         - $COV gcov -p sme/CMakeFiles/sme.dir/*.gcno > /dev/null
-        - mv *#spatial-model-editor#src#core*.gcov *#spatial-model-editor#src#gui*.gcov *#spatial-model-editor#sme*.gcov gcov/
-        - rm *.gcov
+        - mv *#sme*.gcov gcov/
+        - rm -f *.gcov
 
         - cd ..
         # upload to sonar-scanner

--- a/src/core/mesh/src/boundary_t.cpp
+++ b/src/core/mesh/src/boundary_t.cpp
@@ -5,7 +5,7 @@
 #include "boundary.hpp"
 #include "catch_wrapper.hpp"
 
-SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][boundary]") {
+SCENARIO("Boundary", "[core/mesh/boundary][core/mesh][core][boundary]") {
   GIVEN("Loop") {
     // points that make up the loop
     std::vector<QPoint> points{{0, 0}, {2, 0},  {3, 1}, {1, 3},

--- a/src/core/mesh/src/line_simplifier.cpp
+++ b/src/core/mesh/src/line_simplifier.cpp
@@ -211,13 +211,20 @@ bool LineSimplifier::isValid() const { return valid; }
 
 LineSimplifier::LineSimplifier(const std::vector<QPoint> &points,
                                bool isClosedLoop)
-    : vertices{removeDegenerateVertices(points, isClosedLoop)},
-      minNumPoints{isClosedLoop ? std::size_t{3} : std::size_t{2}} {
+    : minNumPoints{isClosedLoop ? std::size_t{3} : std::size_t{2}} {
   SPDLOG_DEBUG("Simplifying {} point line - isLoop: {}", points.size(),
                isClosedLoop);
+  if (points.size() < minNumPoints) {
+    SPDLOG_DEBUG("  -> invalid: not enough points");
+    valid = false;
+    return;
+  }
+  vertices = removeDegenerateVertices(points, isClosedLoop);
   SPDLOG_DEBUG("  - {} non-degenerate points", vertices.size());
   if (vertices.size() < minNumPoints) {
+    SPDLOG_DEBUG("  -> invalid: not enough non-degenerate points");
     valid = false;
+    return;
   }
   priorities = getPriorities(vertices, isClosedLoop);
 }

--- a/src/core/mesh/src/line_simplifier.hpp
+++ b/src/core/mesh/src/line_simplifier.hpp
@@ -19,9 +19,9 @@ struct LineError {
 
 class LineSimplifier {
 private:
-  std::vector<QPoint> vertices;
+  std::vector<QPoint> vertices{};
   std::size_t minNumPoints;
-  std::vector<std::size_t> priorities;
+  std::vector<std::size_t> priorities{};
   LineError getLineError(const std::vector<QPoint> &line) const;
   bool valid{true};
 

--- a/src/core/mesh/src/line_simplifier_t.cpp
+++ b/src/core/mesh/src/line_simplifier_t.cpp
@@ -4,15 +4,42 @@
 #include "line_simplifier.hpp"
 
 SCENARIO("Simplify Lines",
-         "[core/mesh/line_simplifier][core/mesh][line_simplifier]") {
+         "[core/mesh/line_simplifier][core/mesh][core][line_simplifier]") {
+  GIVEN("Invalid points") {
+    std::vector<QPoint> points;
+    // 0 points
+    mesh::LineSimplifier ls(points, true);
+    REQUIRE(ls.isValid() == false);
+    ls = mesh::LineSimplifier(points, false);
+    REQUIRE(ls.isValid() == false);
+    // 1 point
+    points.emplace_back(0, 0);
+    ls = mesh::LineSimplifier(points, true);
+    REQUIRE(ls.isValid() == false);
+    ls = mesh::LineSimplifier(points, false);
+    REQUIRE(ls.isValid() == false);
+    // 2 point loop
+    points.emplace_back(0, 1);
+    ls = mesh::LineSimplifier(points, true);
+    REQUIRE(ls.isValid() == false);
+    // 2 point non-loop is valid however
+    ls = mesh::LineSimplifier(points, false);
+    REQUIRE(ls.isValid() == true);
+    // 3 points
+    points.emplace_back(1, 1);
+    ls = mesh::LineSimplifier(points, true);
+    REQUIRE(ls.isValid() == true);
+    ls = mesh::LineSimplifier(points, false);
+    REQUIRE(ls.isValid() == true);
+  }
   GIVEN("Loop") {
     // 9 point loop with 2 degenerate points
     std::vector<QPoint> points;
     points.emplace_back(0, 0);
-    points.emplace_back(1, 0);  // degenerate horizontal
+    points.emplace_back(1, 0); // degenerate horizontal
     points.emplace_back(2, 0);
     points.emplace_back(3, 1);
-    points.emplace_back(2, 2);  // degenerate diagonal
+    points.emplace_back(2, 2); // degenerate diagonal
     points.emplace_back(1, 3);
     points.emplace_back(0, 3);
     points.emplace_back(-1, 2);
@@ -102,7 +129,7 @@ SCENARIO("Simplify Lines",
     // 8 point line with 1 degenerate point
     std::vector<QPoint> points;
     points.emplace_back(0, 0);
-    points.emplace_back(1, 0);  // degenerate horizontal
+    points.emplace_back(1, 0); // degenerate horizontal
     points.emplace_back(2, 0);
     points.emplace_back(3, 1);
     points.emplace_back(4, 1);

--- a/src/core/mesh/src/mesh.cpp
+++ b/src/core/mesh/src/mesh.cpp
@@ -10,8 +10,8 @@
 
 namespace mesh {
 
-QPointF Mesh::pixelPointToPhysicalPoint(
-    const QPointF &pixelPoint) const noexcept {
+QPointF
+Mesh::pixelPointToPhysicalPoint(const QPointF &pixelPoint) const noexcept {
   return pixelPoint * pixel + origin;
 }
 
@@ -24,9 +24,7 @@ Mesh::Mesh(
     const std::vector<std::pair<std::string, ColourPair>> &membraneColourPairs,
     const std::vector<double> &membraneWidths, double pixelWidth,
     const QPointF &originPoint, const std::vector<QRgb> &compartmentColours)
-    : img(image),
-      origin(originPoint),
-      pixel(pixelWidth),
+    : img(image), origin(originPoint), pixel(pixelWidth),
       compartmentInteriorPoints(interiorPoints),
       boundaryMaxPoints(std::move(maxPoints)),
       compartmentMaxTriangleArea(std::move(maxTriangleArea)),
@@ -41,10 +39,9 @@ Mesh::Mesh(
   }
   if (boundaryMaxPoints.size() != boundaries.size()) {
     // if boundary points not correctly specified use automatic values instead
-    SPDLOG_INFO(
-        "boundaryMaxPoints has size {}, but there are {} boundaries - "
-        "using automatic values",
-        boundaryMaxPoints.size(), boundaries.size());
+    SPDLOG_INFO("boundaryMaxPoints has size {}, but there are {} boundaries - "
+                "using automatic values",
+                boundaryMaxPoints.size(), boundaries.size());
     boundaryMaxPoints = imageBoundaries->setAutoMaxPoints();
   } else {
     imageBoundaries->setMaxPoints(boundaryMaxPoints);
@@ -199,8 +196,8 @@ void Mesh::setCompartmentMaxTriangleArea(std::size_t compartmentIndex,
   constructMesh();
 }
 
-std::size_t Mesh::getCompartmentMaxTriangleArea(
-    std::size_t compartmentIndex) const {
+std::size_t
+Mesh::getCompartmentMaxTriangleArea(std::size_t compartmentIndex) const {
   return compartmentMaxTriangleArea.at(compartmentIndex);
 }
 
@@ -241,8 +238,8 @@ const std::vector<std::vector<QTriangleF>> &Mesh::getTriangles() const {
   return triangles;
 }
 
-static TriangulateBoundaries constructTriangulateBoundaries(
-    const ImageBoundaries *imageBoundaries) {
+static TriangulateBoundaries
+constructTriangulateBoundaries(const ImageBoundaries *imageBoundaries) {
   TriangulateBoundaries tid;
   const auto &boundaries = imageBoundaries->getBoundaries();
   std::size_t nPointsUpperBound = 0;
@@ -320,8 +317,8 @@ static TriangulateBoundaries constructTriangulateBoundaries(
   return tid;
 }
 
-static TriangulateFixedPoints constructTriangulateFixedPoints(
-    const ImageBoundaries *imageBoundaries) {
+static TriangulateFixedPoints
+constructTriangulateFixedPoints(const ImageBoundaries *imageBoundaries) {
   TriangulateFixedPoints tfp;
   tfp.nFPs = imageBoundaries->getFixedPoints().size();
   tfp.newFPs = imageBoundaries->getNewFixedPoints();
@@ -382,8 +379,9 @@ const QImage &Mesh::getBoundaryPixelsImage() const {
   return imageBoundaries->getBoundaryPixelsImage();
 }
 
-std::pair<QImage, QImage> Mesh::getBoundariesImages(
-    const QSize &size, std::size_t boldBoundaryIndex) const {
+std::pair<QImage, QImage>
+Mesh::getBoundariesImages(const QSize &size,
+                          std::size_t boldBoundaryIndex) const {
   constexpr int defaultPenSize = 2;
   constexpr int boldPenSize = 5;
   constexpr int maskPenSize = 15;
@@ -452,8 +450,8 @@ std::pair<QImage, QImage> Mesh::getBoundariesImages(
                         maskImage.mirrored(false, true));
 }
 
-std::pair<QImage, QImage> Mesh::getMeshImages(
-    const QSize &size, std::size_t compartmentIndex) const {
+std::pair<QImage, QImage>
+Mesh::getMeshImages(const QSize &size, std::size_t compartmentIndex) const {
   std::pair<QImage, QImage> imgPair;
   auto &[meshImage, maskImage] = imgPair;
   double scaleFactor = getScaleFactor(img, size);
@@ -592,4 +590,4 @@ QString Mesh::getGMSH(const std::unordered_set<int> &gmshCompIndices) const {
   return msh;
 }
 
-}  // namespace mesh
+} // namespace mesh

--- a/src/core/mesh/src/mesh_t.cpp
+++ b/src/core/mesh/src/mesh_t.cpp
@@ -5,7 +5,7 @@
 #include "mesh.hpp"
 #include "utils.hpp"
 
-SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][mesh]") {
+SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][core][mesh]") {
   GIVEN("empty image") {
     QImage img(24, 32, QImage::Format_RGB32);
     QRgb col = QColor(0, 0, 0).rgb();
@@ -24,11 +24,11 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][mesh]") {
     REQUIRE(mesh.getNumBoundaries() == 1);
 
     // check output vertices
-    const auto& vertices = mesh.getVertices();
+    const auto &vertices = mesh.getVertices();
     REQUIRE(vertices.size() == 2 * 4);
 
     // check triangles
-    const auto& triangles = mesh.getTriangles();
+    const auto &triangles = mesh.getTriangles();
     REQUIRE(triangles.size() == 1);
     REQUIRE(triangles[0].size() == 2);
     REQUIRE(triangles[0][0] ==
@@ -135,7 +135,7 @@ SCENARIO("Mesh", "[core/mesh/mesh][core/mesh][mesh]") {
     correctBoundary.emplace_back(5, 7);
     correctBoundary.emplace_back(4, 6);
     QRgb col = QColor(123, 123, 123).rgb();
-    for (const auto& p : correctBoundary) {
+    for (const auto &p : correctBoundary) {
       img.setPixel(p, col);
     }
     // fill in internal compartment pixels

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -185,8 +185,11 @@ void ModelGeometry::importSampledFieldGeometry(libsbml::Model *model) {
 }
 
 void ModelGeometry::importParametricGeometry(libsbml::Model *model) {
-  mesh = importParametricGeometryFromSBML(model, this, modelCompartments,
-                                          modelMembranes);
+  auto importedMesh = importParametricGeometryFromSBML(
+      model, this, modelCompartments, modelMembranes);
+  if (importedMesh != nullptr) {
+    mesh = std::move(importedMesh);
+  }
 }
 
 void ModelGeometry::importSampledFieldGeometry(const QString &filename) {

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -381,7 +381,8 @@ SCENARIO("SBML: create new model, import geometry from image",
   }
 }
 
-SCENARIO("SBML: import uint8 sampled field", "[core][model]") {
+SCENARIO("SBML: import uint8 sampled field",
+         "[core/model/model][core/model][core][model]") {
   model::Model s;
   QFile f(":/test/models/very-simple-model-uint8.xml");
   f.open(QIODevice::ReadOnly);


### PR DESCRIPTION
- GUI boundary lines tab
      - if image has zero boundary lines, disable spin boxes for boundary index, number of points, width
- LineSimplifier
      - previously would crash if initial line had too few points
      - now checks there are enough points in the constructor
      - if not, sets valid=false
- ParametricGeometry import
      - previously would always overwrite any existing mesh
      - now only overwrites if new mesh is not null
      - fixes situation where mesh was created from SampledField geometry import, then immediately overwritten with a null mesh by ParametricGeometry import
