### PR TITLE
allow user to set spatial coordinate names

### DIFF
--- a/src/core/model/inc/model_parameters.hpp
+++ b/src/core/model/inc/model_parameters.hpp
@@ -22,6 +22,11 @@ struct IdName {
   std::string name;
 };
 
+struct SpatialCoordinates {
+  IdName x;
+  IdName y;
+};
+
 struct IdValue {
   std::string id;
   double value;
@@ -34,9 +39,10 @@ struct IdNameExpr {
 };
 
 class ModelParameters {
-public:
+private:
   QStringList ids;
   QStringList names;
+  SpatialCoordinates spatialCoordinates;
   libsbml::Model *sbmlModel = nullptr;
 
 public:
@@ -50,6 +56,8 @@ public:
   QString getExpression(const QString &id) const;
   QString add(const QString &name);
   void remove(const QString &id);
+  const SpatialCoordinates &getSpatialCoordinates() const;
+  void setSpatialCoordinates(SpatialCoordinates coords);
   std::vector<IdName> getSymbols() const;
   std::vector<IdValue> getGlobalConstants() const;
   std::vector<IdNameExpr> getNonConstantParameters() const;

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -56,7 +56,6 @@ void Model::initModelData() {
   }
   auto *model = doc->getModel();
   modelMath = ModelMath(model);
-  modelParameters = ModelParameters(model);
   modelFunctions = ModelFunctions(model);
   modelMembranes.clear();
   // todo: reduce these cyclic dependencies: currently order of initialization
@@ -66,6 +65,7 @@ void Model::initModelData() {
   modelGeometry = ModelGeometry(model, &modelCompartments, &modelMembranes);
   modelGeometry.importSampledFieldGeometry(model);
   modelGeometry.importParametricGeometry(model);
+  modelParameters = ModelParameters(model);
   modelSpecies = ModelSpecies(model, &modelCompartments, &modelGeometry,
                               &modelParameters, &modelReactions);
   modelReactions = ModelReactions(model, modelMembranes.getMembranes());

--- a/src/core/model/src/model_parameters_t.cpp
+++ b/src/core/model/src/model_parameters_t.cpp
@@ -20,6 +20,29 @@ SCENARIO("SBML parameters",
     auto &params = s.getParameters();
     REQUIRE(params.getIds().size() == 0);
     REQUIRE(params.getNames().size() == 0);
+    // default geometry spatial coordinates:
+    const auto &coords = params.getSpatialCoordinates();
+    REQUIRE(coords.x.id == "x");
+    REQUIRE(coords.x.name == "x");
+    REQUIRE(coords.y.id == "y");
+    REQUIRE(coords.y.name == "y");
+    WHEN("change spatial coords") {
+      auto newC = coords;
+      newC.x.name = "x name";
+      newC.y.name = "yY";
+      params.setSpatialCoordinates(std::move(newC));
+      REQUIRE(coords.x.id == "x");
+      REQUIRE(coords.x.name == "x name");
+      REQUIRE(coords.y.id == "y");
+      REQUIRE(coords.y.name == "yY");
+      std::string xml = s.getXml().toStdString();
+      std::unique_ptr<libsbml::SBMLDocument> doc2{
+          libsbml::readSBMLFromString(xml.c_str())};
+      const auto *param = doc2->getModel()->getParameter("x");
+      REQUIRE(param->getName() == "x name");
+      param = doc2->getModel()->getParameter("y");
+      REQUIRE(param->getName() == "yY");
+    }
     WHEN("add double parameter") {
       params.add("p1");
       REQUIRE(params.getIds().size() == 1);

--- a/src/core/model/src/sbml_utils.hpp
+++ b/src/core/model/src/sbml_utils.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <sbml/SBMLTypes.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+
 #include <optional>
 #include <string>
 #include <utility>
@@ -9,10 +12,11 @@ class Geometry;
 class Model;
 class SampledFieldGeometry;
 class Species;
-}  // namespace libsbml
+class Parameter;
+} // namespace libsbml
 
 libsbml::SampledFieldGeometry *getSampledFieldGeometry(libsbml::Geometry *geom);
-const libsbml::Geometry *getOrCreateGeometry(const libsbml::Model *model);
+const libsbml::Geometry *getGeometry(const libsbml::Model *model);
 libsbml::Geometry *getOrCreateGeometry(libsbml::Model *model);
 void createDefaultCompartmentGeometryIfMissing(libsbml::Model *model);
 
@@ -21,7 +25,11 @@ unsigned int getNumSpatialDimensions(const libsbml::Model *model);
 std::string getDomainIdFromCompartmentId(const libsbml::Model *model,
                                          const std::string &compartmentId);
 
-std::optional<std::pair<std::string, std::string>> getAdjacentCompartments(
-    const libsbml::Model *model, const std::string &compartmentId);
+std::optional<std::pair<std::string, std::string>>
+getAdjacentCompartments(const libsbml::Model *model,
+                        const std::string &compartmentId);
 
 bool getIsSpeciesConstant(const libsbml::Species *spec);
+
+libsbml::Parameter *getSpatialCoordinateParam(libsbml::Model *model,
+                                              libsbml::CoordinateKind_t kind);

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   PRIVATE dialogabout.cpp
           dialoganalytic.cpp
           dialogconcentrationimage.cpp
+          dialogcoordinates.cpp
           dialogdisplayoptions.cpp
           dialogimagesize.cpp
           dialogimageslice.cpp
@@ -15,6 +16,7 @@ target_sources(
   PUBLIC dialogabout_t.cpp
          dialoganalytic_t.cpp
          dialogconcentrationimage_t.cpp
+         dialogcoordinates_t.cpp
          dialogdisplayoptions_t.cpp
          dialogimagesize_t.cpp
          dialogimageslice_t.cpp

--- a/src/gui/dialogs/dialoganalytic.hpp
+++ b/src/gui/dialogs/dialoganalytic.hpp
@@ -17,6 +17,10 @@ namespace units {
 class ModelUnits;
 }
 
+namespace Model {
+struct SpatialCoordinates;
+}
+
 class DialogAnalytic : public QDialog {
   Q_OBJECT
 
@@ -24,6 +28,7 @@ public:
   explicit DialogAnalytic(const QString &analyticExpression,
                           const model::SpeciesGeometry &speciesGeometry,
                           model::ModelMath &modelMath,
+                          const model::SpatialCoordinates &spatialCoordinates,
                           QWidget *parent = nullptr);
   ~DialogAnalytic();
   const std::string &getExpression() const;
@@ -32,7 +37,8 @@ public:
 private:
   std::unique_ptr<Ui::DialogAnalytic> ui;
   std::map<const std::string, std::pair<double, bool>> sbmlVars;
-
+  std::string xId{};
+  std::string yId{};
   // user supplied data
   const std::vector<QPoint> &points;
   double width;

--- a/src/gui/dialogs/dialoganalytic_t.cpp
+++ b/src/gui/dialogs/dialoganalytic_t.cpp
@@ -17,7 +17,8 @@ SCENARIO("DialogAnalytic",
     DialogAnalytic dia("x",
                        {QSize(10, 10), compartmentPoints, QPointF(0.0, 0.0), 1,
                         doc.getUnits()},
-                       doc.getMath());
+                       doc.getMath(),
+                       doc.getParameters().getSpatialCoordinates());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10") {
@@ -92,7 +93,8 @@ SCENARIO("DialogAnalytic",
     QFile f(":/models/ABtoC.xml");
     f.open(QIODevice::ReadOnly);
     doc.importSBMLString(f.readAll().toStdString());
-    DialogAnalytic dia("x", doc.getSpeciesGeometry("B"), doc.getMath());
+    DialogAnalytic dia("x", doc.getSpeciesGeometry("B"), doc.getMath(),
+                       doc.getParameters().getSpatialCoordinates());
     REQUIRE(dia.getExpression() == "x");
     ModalWidgetTimer mwt;
     WHEN("valid expr: 10") {

--- a/src/gui/dialogs/dialogcoordinates.cpp
+++ b/src/gui/dialogs/dialogcoordinates.cpp
@@ -1,0 +1,21 @@
+#include "dialogcoordinates.hpp"
+
+#include "ui_dialogcoordinates.h"
+
+DialogCoordinates::DialogCoordinates(const QString &xName, const QString &yName,
+                                     QWidget *parent)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogCoordinates>()} {
+  ui->setupUi(this);
+  ui->txtXName->setText(xName);
+  ui->txtYName->setText(yName);
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+          &DialogCoordinates::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &DialogCoordinates::reject);
+}
+
+DialogCoordinates::~DialogCoordinates() = default;
+
+QString DialogCoordinates::getXName() const { return ui->txtXName->text(); }
+
+QString DialogCoordinates::getYName() const { return ui->txtYName->text(); }

--- a/src/gui/dialogs/dialogcoordinates.hpp
+++ b/src/gui/dialogs/dialogcoordinates.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QDialog>
+#include <memory>
+
+namespace Ui {
+class DialogCoordinates;
+}
+
+class DialogCoordinates : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit DialogCoordinates(const QString &xName, const QString &yName,
+                             QWidget *parent = nullptr);
+  ~DialogCoordinates();
+  QString getXName() const;
+  QString getYName() const;
+
+private:
+  std::unique_ptr<Ui::DialogCoordinates> ui;
+};

--- a/src/gui/dialogs/dialogcoordinates.ui
+++ b/src/gui/dialogs/dialogcoordinates.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogCoordinates</class>
+ <widget class="QDialog" name="DialogCoordinates">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>393</width>
+    <height>133</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Set Model Spatial Coordinates</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblXName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>x coordinate name:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="txtXName"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblYName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>y coordinate name:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="txtYName"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/dialogs/dialogcoordinates_t.cpp
+++ b/src/gui/dialogs/dialogcoordinates_t.cpp
@@ -1,0 +1,19 @@
+#include <QFile>
+
+#include "catch_wrapper.hpp"
+#include "dialogcoordinates.hpp"
+#include "qt_test_utils.hpp"
+
+SCENARIO("DialogCoordinates",
+         "[gui/dialogs/coordinates][gui/dialogs][gui][coordinates]") {
+  DialogCoordinates dia("x", "y");
+  REQUIRE(dia.getXName() == "x");
+  REQUIRE(dia.getYName() == "y");
+  ModalWidgetTimer mwt;
+  mwt.addUserAction({"Delete", "Backspace", "e", "x", "!", "Tab", "Delete",
+                     "Backspace", "y", "y"});
+  mwt.start();
+  dia.exec();
+  REQUIRE(dia.getXName() == "ex!");
+  REQUIRE(dia.getYName() == "yy");
+}

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -29,6 +29,7 @@ private:
   QLabel *statusBarPermanentMessage;
   model::Model sbmlDoc;
 
+  void setupTabs();
   void setupConnections();
 
   // check if SBML model and geometry image are both valid
@@ -66,6 +67,7 @@ private:
   // Tools menu actions
   void actionSet_model_units_triggered();
   void actionSet_image_size_triggered();
+  void actionSet_spatial_coordinates_triggered();
 
   // Advanced menu actions
   void actionIntegrator_options_triggered();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -295,6 +295,7 @@
     </widget>
     <addaction name="actionSet_model_units"/>
     <addaction name="actionSet_image_size"/>
+    <addaction name="actionSet_spatial_coordinates"/>
     <addaction name="menuSimulation_type"/>
    </widget>
    <widget class="QMenu" name="menu_Advanced">
@@ -508,6 +509,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+G</string>
+   </property>
+  </action>
+  <action name="actionSet_spatial_coordinates">
+   <property name="text">
+    <string>Set &amp;spatial coordinates</string>
    </property>
   </action>
   <actiongroup name="actionGroupSimType">

--- a/src/gui/tabs/tabspecies.cpp
+++ b/src/gui/tabs/tabspecies.cpp
@@ -281,7 +281,8 @@ void TabSpecies::btnEditAnalyticConcentration_clicked() {
                currentSpeciesId.toStdString());
   DialogAnalytic dialog(
       sbmlDoc.getSpecies().getAnalyticConcentration(currentSpeciesId),
-      sbmlDoc.getSpeciesGeometry(currentSpeciesId), sbmlDoc.getMath());
+      sbmlDoc.getSpeciesGeometry(currentSpeciesId), sbmlDoc.getMath(),
+      sbmlDoc.getParameters().getSpatialCoordinates());
   if (dialog.exec() == QDialog::Accepted) {
     const std::string &expr = dialog.getExpression();
     SPDLOG_DEBUG("  - set expr: {}", expr);


### PR DESCRIPTION
  - DialogCoordinates
    - dialog box allowing the user to edit names of spatial coordinates
  - ModelParameters
    - now imports existing parameters that are a spatialref to a coordinate component
      - if not found, create them
    - getGlobalConstants() excludes params that are a spatialref to a coordinate component
      - we don't want to substitute for their value, we want them as symbolic variables
    - todo: getSymbols() does include these parameters (?)
      - math parsers should know that they exist
      - but they should also deal with them differently, so maybe not required as they will always import them separately
  - DialogAnalytic
    - now uses model coordinate parameter names in math instead of assuming 'x' and 'y'
  - resolves #215