### PR TITLE
improve units support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "ext/pybind11"]
 	path = ext/pybind11
 	url = git://github.com/pybind/pybind11.git
-	branch = v2.5.0
 [submodule "ext/Catch2"]
 	path = ext/Catch2
 	url = https://github.com/catchorg/Catch2
-	branch = v2.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
 env:
   global:
     # python wheel building can be disabled to speed up CI when working on a PR
-    - BUILD_PYTHON_WHEELS: false
+    - BUILD_PYTHON_WHEELS: true
     # pypi TWINE_PASSWORD
     - secure: "GFBxgbwP75qb0QW3jFO3e3fbfFLpYue+kUZGm3ArNZ9ExeXPGU3fxfxiBolEPnnPK98VlZZ8R0WBQptvWnaBN0tamt5r7OCXljQdpNgRF04MMa1gtbAEnuYjd6dHQ5CbdiEKxK4MnF28jJ+0wnw35E7YPGq357XWKwGFoG0HT9UenFd7HRbzsM0WmO7sog8bZYahYU+nyIDu6AVGlsc1b4XpVEu/pcuY2PexzYpV4wv+qVprRIeTwi2aFb4bmr3XcPZtyps3eiExLISHmz3mAuHIiNEt3wQA7Kjzsz93lm6DlGi3LSEXugfomGzg3oyHQC8oKKky/D6hHqnc9Jfow4Epj3aHvE4LP00TxDiyrjqvVGeCHa/RL/WIGJ/zZA4W7QTr2wvDOhw5EOuSmIW42tmOsOV4Zo/wr5d9A0r0VUfHhrsi1QUHmFFgTJXeTDyHYC32mvXy8EuaxLRFLBUVKE3gPfaYUgRafvx1Kn7H9WUmrpA7JAj2caMYD6UtKly1J6BFyTpPFlGgk3yxzVYgbeToOOrabQzGzYBuaxz6aysbyPra+rYF5SrJ/Dp4TPjfoE/1IIjmrbVpYEQGdfojnxxN6xnW7woPgq8IUDStw7iR83xyluWEtn1i1KlzRA8NMNdBHxgFWQ9rpE/DZikeJ8yb0FoEleMRjaE6G4C33rc="
 
@@ -78,11 +78,11 @@ jobs:
         - ldd spatial-model-editor
         - ldd spatial-cli
     ########################################################
-    # macOS GUI/CLI release build: xcode 10.3, macOS 10.14 #
+    # macOS GUI/CLI release build: xcode 11.3, macOS 10.14 #
     ########################################################
     - name: "macOS GUI/CLI"
       os: osx
-      osx_image: xcode10.3
+      osx_image: xcode11.3
       language: cpp
       compiler: clang
       env:
@@ -195,7 +195,7 @@ jobs:
         - export TWINE_USERNAME="__token__"
         - if [ -n "${TRAVIS_TAG}" ]; then python -m twine upload --verbose --non-interactive --skip-existing dist/* ; fi
     ##############################################################
-    # macOS python wheels release build: xcode 10.3, macOS 10.14 #
+    # macOS python wheels release build: xcode 11.3, macOS 10.14 #
     ##############################################################
     - name: "macOS python wheels"
       if: (env(BUILD_PYTHON_WHEELS) = true) AND (tag != "latest")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 0.8.8
+  VERSION 0.8.9
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="0.8.8",
+    version="0.8.9",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",

--- a/src/core/model/inc/model_units.hpp
+++ b/src/core/model/inc/model_units.hpp
@@ -12,16 +12,17 @@ class Model;
 namespace model {
 
 struct Unit {
-  // UI display name
   QString name;
-  // UI display symbol
-  QString symbol;
-  // SBML unit definition: name == (multiplier * 10^scale * kind)^exponent
+  // SBML unit definition: (multiplier * 10^scale * kind)^exponent
   QString kind;
   int scale{0};
   int exponent{1};
   double multiplier{1.0};
 };
+
+bool operator==(const Unit &, const Unit &);
+
+QString unitInBaseUnits(const Unit &unit);
 
 class UnitVector {
 private:
@@ -32,36 +33,36 @@ public:
   explicit UnitVector(const QVector<Unit> &unitsVec = {}, int defaultIndex = 0);
   const Unit &get() const;
   const QVector<Unit> &getUnits() const;
+  QVector<Unit> &getUnits();
   int getIndex() const;
   void setIndex(int newIndex);
 };
 
 class ModelUnits {
 private:
-  UnitVector time{{{"hour", "h", "second", 0, 1, 3600},
-                   {"minute", "m", "second", 0, 1, 60},
-                   {"second", "s", "second", 0},
-                   {"millisecond", "ms", "second", -3},
-                   {"microsecond", "us", "second", -6}},
+  UnitVector time{{{"hour", "second", 0, 1, 3600},
+                   {"min", "second", 0, 1, 60},
+                   {"s", "second", 0},
+                   {"ms", "second", -3},
+                   {"us", "second", -6}},
                   2};
-  UnitVector length{{{"metre", "m", "metre", 0},
-                     {"decimetre", "dm", "metre", -1},
-                     {"centimetre", "cm", "metre", -2},
-                     {"millimetre", "mm", "metre", -3},
-                     {"micrometre", "um", "metre", -6},
-                     {"nanometre", "nm", "metre", -9}},
+  UnitVector length{{{"m", "metre", 0},
+                     {"dm", "metre", -1},
+                     {"cm", "metre", -2},
+                     {"mm", "metre", -3},
+                     {"um", "metre", -6},
+                     {"nm", "metre", -9}},
                     2};
-  UnitVector volume{{{"litre", "L", "litre", 0},
-                     {"decilitre", "dL", "litre", -1},
-                     {"centilitre", "cL", "litre", -2},
-                     {"millilitre", "mL", "litre", -3},
-                     {"cubic metre", "m^3", "metre", 0, 3},
-                     {"cubic decimetre", "dm^3", "metre", -1, 3},
-                     {"cubic centimetre", "cm^3", "metre", -2, 3},
-                     {"cubic millimetre", "mm^3", "metre", -3, 3}},
+  UnitVector volume{{{"L", "litre", 0},
+                     {"dL", "litre", -1},
+                     {"cL", "litre", -2},
+                     {"mL", "litre", -3},
+                     {"m3", "metre", 0, 3},
+                     {"dm3", "metre", -1, 3},
+                     {"cm3", "metre", -2, 3},
+                     {"mm3", "metre", -3, 3}},
                     3};
-  UnitVector amount{
-      {{"mole", "mol", "mole", 0}, {"millimole", "mmol", "mole", -3}}, 1};
+  UnitVector amount{{{"mol", "mole", 0}, {"mmol", "mole", -3}}, 1};
   QString concentration;
   QString diffusion;
   libsbml::Model *sbmlModel;
@@ -73,18 +74,22 @@ public:
   const Unit &getTime() const;
   int getTimeIndex() const;
   const QVector<Unit> &getTimeUnits() const;
+  QVector<Unit> &getTimeUnits();
   void setTimeIndex(int index);
   const Unit &getLength() const;
   int getLengthIndex() const;
   const QVector<Unit> &getLengthUnits() const;
+  QVector<Unit> &getLengthUnits();
   void setLengthIndex(int index);
   const Unit &getVolume() const;
   int getVolumeIndex() const;
   const QVector<Unit> &getVolumeUnits() const;
+  QVector<Unit> &getVolumeUnits();
   void setVolumeIndex(int index);
   const Unit &getAmount() const;
   int getAmountIndex() const;
   const QVector<Unit> &getAmountUnits() const;
+  QVector<Unit> &getAmountUnits();
   void setAmountIndex(int index);
   const QString &getConcentration() const;
   const QString &getDiffusion() const;

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -55,6 +55,7 @@ void Model::initModelData() {
     return;
   }
   auto *model = doc->getModel();
+  modelUnits = ModelUnits(model);
   modelMath = ModelMath(model);
   modelFunctions = ModelFunctions(model);
   modelMembranes.clear();
@@ -69,7 +70,6 @@ void Model::initModelData() {
   modelSpecies = ModelSpecies(model, &modelCompartments, &modelGeometry,
                               &modelParameters, &modelReactions);
   modelReactions = ModelReactions(model, modelMembranes.getMembranes());
-  modelUnits = ModelUnits(model);
 }
 
 bool Model::getIsValid() const { return isValid; }

--- a/src/core/model/src/model_geometry.cpp
+++ b/src/core/model/src/model_geometry.cpp
@@ -42,6 +42,7 @@ bool ModelGeometry::importDimensions(libsbml::Model *model) {
     SPDLOG_ERROR("No y-coordinate found in SBML model");
     return false;
   }
+
   // import xy coordinates
   double xmin = xcoord->getBoundaryMin()->getValue();
   double xmax = xcoord->getBoundaryMax()->getValue();

--- a/src/core/model/src/model_parameters.cpp
+++ b/src/core/model/src/model_parameters.cpp
@@ -85,7 +85,7 @@ createSpatialCoordParam(const QString &name, libsbml::CoordinateKind_t kind,
 
 static SpatialCoordinates importSpatialCoordinates(libsbml::Model *model) {
   SpatialCoordinates s;
-  const auto *xparam = getSpatialCoordinateParam(
+  auto *xparam = getSpatialCoordinateParam(
       model, libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_X);
   if (xparam == nullptr) {
     SPDLOG_WARN("No x-coord parameter found - creating");
@@ -93,9 +93,11 @@ static SpatialCoordinates importSpatialCoordinates(libsbml::Model *model) {
         "x", libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_X,
         model);
   }
+  xparam->setUnits(model->getLengthUnits());
+  xparam->setValue(0);
   s.x.id = xparam->getId();
   s.x.name = xparam->getName();
-  const auto *yparam = getSpatialCoordinateParam(
+  auto *yparam = getSpatialCoordinateParam(
       model, libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_Y);
   if (yparam == nullptr) {
     SPDLOG_WARN("No y-coord parameter found - creating");
@@ -103,6 +105,8 @@ static SpatialCoordinates importSpatialCoordinates(libsbml::Model *model) {
         "y", libsbml::CoordinateKind_t::SPATIAL_COORDINATEKIND_CARTESIAN_Y,
         model);
   }
+  yparam->setUnits(model->getLengthUnits());
+  yparam->setValue(0);
   s.y.id = yparam->getId();
   s.y.name = yparam->getName();
   return s;
@@ -284,6 +288,10 @@ std::vector<IdName> ModelParameters::getSymbols() const {
   for (unsigned i = 0; i < sbmlModel->getNumSpecies(); ++i) {
     const auto *spec = sbmlModel->getSpecies(i);
     symbols.push_back({spec->getId(), spec->getName()});
+  }
+  for (unsigned i = 0; i < sbmlModel->getNumCompartments(); ++i) {
+    const auto *comp = sbmlModel->getCompartment(i);
+    symbols.push_back({comp->getId(), comp->getName()});
   }
   symbols.push_back({spatialCoordinates.x.id, spatialCoordinates.x.name});
   symbols.push_back({spatialCoordinates.y.id, spatialCoordinates.y.name});

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -420,8 +420,7 @@ SCENARIO("SBML: ABtoC.xml", "[core/model/model][core/model][core][model]") {
       }
       THEN("find species geometry") {
         auto g = s.getSpeciesGeometry("A");
-        REQUIRE(g.modelUnits.getAmount().symbol ==
-                s.getUnits().getAmount().symbol);
+        REQUIRE(g.modelUnits.getAmount().name == s.getUnits().getAmount().name);
         REQUIRE(g.pixelWidth == dbl_approx(1.0));
         REQUIRE(g.physicalOrigin.x() == dbl_approx(0.0));
         REQUIRE(g.physicalOrigin.y() == dbl_approx(0.0));

--- a/src/core/model/src/model_units_t.cpp
+++ b/src/core/model/src/model_units_t.cpp
@@ -1,31 +1,42 @@
 #include "catch_wrapper.hpp"
 #include "model_units.hpp"
+#include <QFile>
+#include <sbml/SBMLTypes.h>
+#include <sbml/extension/SBMLDocumentPlugin.h>
+#include <sbml/packages/spatial/common/SpatialExtensionTypes.h>
+#include <sbml/packages/spatial/extension/SpatialExtension.h>
 
-SCENARIO("Units", "[core/model/model_units][core/model][core][model][units]") {
-  auto timeUnits = model::UnitVector{{{"hour", "h", "second", 0, 1, 3600},
-                                      {"minute", "m", "second", 0, 1, 60},
-                                      {"second", "s", "second", 0},
-                                      {"millisecond", "ms", "second", -3},
-                                      {"microsecond", "us", "second", -6}}};
-  auto lengthUnits = model::UnitVector{{{"metre", "m", "metre", 0},
-                                        {"decimetre", "dm", "metre", -1},
-                                        {"centimetre", "cm", "metre", -2},
-                                        {"millimetre", "mm", "metre", -3},
-                                        {"micrometre", "um", "metre", -6},
-                                        {"nanometre", "nm", "metre", -9}}};
-  auto volumeUnits =
-      model::UnitVector{{{"litre", "L", "litre", 0},
-                         {"decilitre", "dL", "litre", -1},
-                         {"centilitre", "cL", "litre", -2},
-                         {"millilitre", "mL", "litre", -3},
-                         {"cubic metre", "m^3", "metre", 0, 3},
-                         {"cubic decimetre", "dm^3", "metre", -1, 3},
-                         {"cubic centimetre", "cm^3", "metre", -2, 3},
-                         {"cubic millimetre", "mm^3", "metre", -3, 3}}};
-  auto amountUnits = model::UnitVector{
-      {{"mole", "mol", "mole", 0}, {"millimole", "mmol", "mole", -3}}};
-  auto modelUnits = model::ModelUnits();
-  WHEN("default indices") {
+TEST_CASE("Units", "[core/model/model_units][core/model][core][model][units]") {
+  auto timeUnits = model::UnitVector{{{"hour", "second", 0, 1, 3600},
+                                      {"min", "second", 0, 1, 60},
+                                      {"s", "second", 0},
+                                      {"ms", "second", -3},
+                                      {"us", "second", -6}}};
+  auto lengthUnits = model::UnitVector{{{"m", "metre", 0},
+                                        {"dm", "metre", -1},
+                                        {"cm", "metre", -2},
+                                        {"mm", "metre", -3},
+                                        {"um", "metre", -6},
+                                        {"nm", "metre", -9}}};
+  auto volumeUnits = model::UnitVector{{{"L", "litre", 0},
+                                        {"dL", "litre", -1},
+                                        {"cL", "litre", -2},
+                                        {"mL", "litre", -3},
+                                        {"m3", "metre", 0, 3},
+                                        {"dm3", "metre", -1, 3},
+                                        {"cm3", "metre", -2, 3},
+                                        {"mm3", "metre", -3, 3}}};
+  auto amountUnits =
+      model::UnitVector{{{"mol", "mole", 0}, {"mmol", "mole", -3}}};
+  SECTION("unit") {
+    model::Unit u1{"hour", "second", 0, 1, 3600};
+    model::Unit u2{"zzzz", "second", 0, 1, 3600};
+    // units are equal if mathematically equivalent
+    // (so name can be different)
+    REQUIRE(u1 == u2);
+  }
+  SECTION("no model") {
+    auto modelUnits = model::ModelUnits();
     auto units = std::vector<const model::Unit *>{
         &(modelUnits.getTime()), &(modelUnits.getLength()),
         &(modelUnits.getVolume()), &(modelUnits.getAmount())};
@@ -36,47 +47,58 @@ SCENARIO("Units", "[core/model/model_units][core/model][core][model][units]") {
       const auto &unit = units[i];
       const auto &ref = refs[i];
       REQUIRE(unit->name == ref->name);
-      REQUIRE(unit->symbol == ref->symbol);
       REQUIRE(unit->kind == ref->kind);
       REQUIRE(unit->scale == ref->scale);
       REQUIRE(unit->exponent == ref->exponent);
       REQUIRE(unit->multiplier == dbl_approx(ref->multiplier));
     }
-  }
-  WHEN("default indices: derived units correct") {
-    REQUIRE(modelUnits.getLength().symbol.toStdString() == "cm");
-    REQUIRE(modelUnits.getTime().symbol.toStdString() == "s");
-    REQUIRE(modelUnits.getDiffusion().toStdString() == "cm^2/s");
+    SECTION("default indices: derived units correct") {
+      REQUIRE(modelUnits.getLength().name == "cm");
+      REQUIRE(modelUnits.getTime().name == "s");
+      REQUIRE(modelUnits.getDiffusion() == "cm^2/s");
 
-    REQUIRE(modelUnits.getAmount().symbol.toStdString() == "mmol");
-    REQUIRE(modelUnits.getVolume().symbol.toStdString() == "mL");
-    REQUIRE(modelUnits.getConcentration().toStdString() == "mmol/mL");
-  }
-  WHEN("index is set: units updated") {
-    modelUnits.setTimeIndex(2);
-    REQUIRE(modelUnits.getTimeIndex() == 2);
-    REQUIRE(modelUnits.getTime().name == timeUnits.getUnits()[2].name);
-    modelUnits.setLengthIndex(4);
-    REQUIRE(modelUnits.getLengthIndex() == 4);
-    REQUIRE(modelUnits.getLength().name == lengthUnits.getUnits()[4].name);
-    modelUnits.setVolumeIndex(3);
-    REQUIRE(modelUnits.getVolumeIndex() == 3);
-    REQUIRE(modelUnits.getVolume().name == volumeUnits.getUnits()[3].name);
-    modelUnits.setAmountIndex(1);
-    REQUIRE(modelUnits.getAmountIndex() == 1);
-    REQUIRE(modelUnits.getAmount().name == amountUnits.getUnits()[1].name);
-  }
-  WHEN("index is set: derived units updated") {
-    modelUnits.setTimeIndex(2);
-    modelUnits.setLengthIndex(2);
-    REQUIRE(modelUnits.getLength().symbol.toStdString() == "cm");
-    REQUIRE(modelUnits.getTime().symbol.toStdString() == "s");
-    REQUIRE(modelUnits.getDiffusion().toStdString() == "cm^2/s");
+      REQUIRE(modelUnits.getAmount().name == "mmol");
+      REQUIRE(modelUnits.getVolume().name == "mL");
+      REQUIRE(modelUnits.getConcentration() == "mmol/mL");
+    }
+    SECTION("index is set: units updated") {
+      modelUnits.setTimeIndex(2);
+      REQUIRE(modelUnits.getTimeIndex() == 2);
+      REQUIRE(modelUnits.getTime().name == timeUnits.getUnits()[2].name);
+      modelUnits.setLengthIndex(4);
+      REQUIRE(modelUnits.getLengthIndex() == 4);
+      REQUIRE(modelUnits.getLength().name == lengthUnits.getUnits()[4].name);
+      modelUnits.setVolumeIndex(3);
+      REQUIRE(modelUnits.getVolumeIndex() == 3);
+      REQUIRE(modelUnits.getVolume().name == volumeUnits.getUnits()[3].name);
+      modelUnits.setAmountIndex(1);
+      REQUIRE(modelUnits.getAmountIndex() == 1);
+      REQUIRE(modelUnits.getAmount().name == amountUnits.getUnits()[1].name);
+    }
+    SECTION("index is set: derived units updated") {
+      modelUnits.setTimeIndex(2);
+      modelUnits.setLengthIndex(2);
+      REQUIRE(modelUnits.getLength().name == "cm");
+      REQUIRE(modelUnits.getTime().name == "s");
+      REQUIRE(modelUnits.getDiffusion() == "cm^2/s");
 
-    modelUnits.setAmountIndex(1);
-    modelUnits.setVolumeIndex(4);
-    REQUIRE(modelUnits.getAmount().symbol.toStdString() == "mmol");
-    REQUIRE(modelUnits.getVolume().symbol.toStdString() == "m^3");
-    REQUIRE(modelUnits.getConcentration().toStdString() == "mmol/m^3");
+      modelUnits.setAmountIndex(1);
+      modelUnits.setVolumeIndex(4);
+      REQUIRE(modelUnits.getAmount().name == "mmol");
+      REQUIRE(modelUnits.getVolume().name == "m3");
+      REQUIRE(modelUnits.getConcentration() == "mmol/m3");
+    }
+  }
+  SECTION("model with custom units") {
+    QFile f(":/test/models/weird-units.xml");
+    f.open(QIODevice::ReadOnly);
+    std::unique_ptr<libsbml::SBMLDocument> doc(
+        libsbml::readSBMLFromString(f.readAll().toStdString().c_str()));
+    auto modelUnits = model::ModelUnits(doc.get()->getModel());
+    REQUIRE(modelUnits.getTime().name == "megasecond");
+    REQUIRE(modelUnits.getTime().kind == "second");
+    REQUIRE(modelUnits.getTime().exponent == 1);
+    REQUIRE(modelUnits.getTime().scale == 6);
+    REQUIRE(modelUnits.getTime().multiplier == dbl_approx(1.0));
   }
 }

--- a/src/core/resources/models/ABtoC.xml
+++ b/src/core/resources/models/ABtoC.xml
@@ -9,29 +9,35 @@
           <unit kind="second" exponent="-1" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
-      <unitDefinition id="area" name="metre squared">
+      <unitDefinition id="area" name="m_squared">
         <listOfUnits>
           <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
-      <unitDefinition id="unit_of_time" name="second">
+      <unitDefinition id="unit_of_time" name="s">
         <listOfUnits>
           <unit kind="second" exponent="1" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
-      <unitDefinition id="unit_of_length" name="metre">
+      <unitDefinition id="unit_of_length" name="m">
         <listOfUnits>
           <unit kind="metre" exponent="1" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
-      <unitDefinition id="unit_of_volume" name="litre">
+      <unitDefinition id="unit_of_volume" name="L">
         <listOfUnits>
           <unit kind="litre" exponent="1" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
-      <unitDefinition id="units_of_substance" name="mole">
+      <unitDefinition id="units_of_substance" name="mol">
         <listOfUnits>
           <unit kind="mole" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="diffusion_constant_units" name="diffusion_constant_units">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="0" multiplier="1"/>
         </listOfUnits>
       </unitDefinition>
     </listOfUnitDefinitions>
@@ -58,19 +64,19 @@
       </species>
     </listOfSpecies>
     <listOfParameters>
-      <parameter id="B_diffusionConstant" value="0.4" constant="true">
+      <parameter id="B_diffusionConstant" value="0.4" units="diffusion_constant_units" constant="true">
         <spatial:diffusionCoefficient spatial:variable="B" spatial:type="isotropic"/>
       </parameter>
-      <parameter id="A_diffusionConstant" value="0.4" constant="true">
+      <parameter id="A_diffusionConstant" value="0.4" units="diffusion_constant_units" constant="true">
         <spatial:diffusionCoefficient spatial:variable="A" spatial:type="isotropic"/>
       </parameter>
-      <parameter id="C_diffusionConstant" value="25" constant="true">
+      <parameter id="C_diffusionConstant" value="25" units="diffusion_constant_units" constant="true">
         <spatial:diffusionCoefficient spatial:variable="C" spatial:type="isotropic"/>
       </parameter>
-      <parameter id="x" constant="false">
+      <parameter id="x" name="x" value="0" units="unit_of_length" constant="false">
         <spatial:spatialSymbolReference spatial:spatialRef="xCoord"/>
       </parameter>
-      <parameter id="y" constant="false">
+      <parameter id="y" name="y" value="0" units="unit_of_length" constant="false">
         <spatial:spatialSymbolReference spatial:spatialRef="yCoord"/>
       </parameter>
       <parameter id="A_initialConcentration_" units="units_of_substance" constant="true">

--- a/src/core/simulate/src/duneini.cpp
+++ b/src/core/simulate/src/duneini.cpp
@@ -10,8 +10,8 @@
 #include "tiff.hpp"
 #include "utils.hpp"
 
-static std::vector<std::string> makeValidDuneSpeciesNames(
-    const std::vector<std::string> &names) {
+static std::vector<std::string>
+makeValidDuneSpeciesNames(const std::vector<std::string> &names) {
   std::vector<std::string> duneNames = names;
   // muparser reserved words, taken from:
   // https://beltoforion.de/article.php?a=muparser&p=features
@@ -306,7 +306,7 @@ DuneConverter::DuneConverter(const model::Model &SbmlDoc, double dt,
               membraneID.toStdString());
           double scaleFactor = width * lengthCubedToVolFactor;
           SPDLOG_INFO("  - membrane width = {} {}", width,
-                      lengthUnit.symbol.toStdString());
+                      lengthUnit.name.toStdString());
           SPDLOG_INFO("  - [length]^3/[vol] = {}", lengthCubedToVolFactor);
           SPDLOG_INFO("  - dividing flux by {}", scaleFactor);
           reacScaleFactors.push_back(
@@ -374,4 +374,4 @@ bool DuneConverter::hasIndependentCompartments() const {
   return independentCompartments;
 }
 
-}  // namespace dune
+} // namespace dune

--- a/src/core/simulate/src/pixelsim.cpp
+++ b/src/core/simulate/src/pixelsim.cpp
@@ -429,10 +429,10 @@ double PixelSim::doRKAdaptive(double dtMax) {
     double errFactor = std::min(errMax.abs / err.abs, errMax.rel / err.rel);
     errFactor = std::pow(errFactor, 1.0 / static_cast<double>(integratorOrder));
     nextTimestep = std::min(0.95 * dt * errFactor, dtMax);
-    SPDLOG_DEBUG("dt = {} gave rel err = {}, abs err = {} -> new dt = {}", dt,
+    SPDLOG_TRACE("dt = {} gave rel err = {}, abs err = {} -> new dt = {}", dt,
                  err.rel, err.abs, nextTimestep);
     if (err.abs > errMax.abs || err.rel > errMax.rel) {
-      SPDLOG_DEBUG("discarding step");
+      SPDLOG_TRACE("discarding step");
       ++discardedSteps;
       for (auto &sim : simCompartments) {
         sim.undoRKStep();

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(
           dialogconcentrationimage.cpp
           dialogcoordinates.cpp
           dialogdisplayoptions.cpp
+          dialogeditunit.cpp
           dialogimagesize.cpp
           dialogimageslice.cpp
           dialogintegratoroptions.cpp
@@ -18,6 +19,7 @@ target_sources(
          dialogconcentrationimage_t.cpp
          dialogcoordinates_t.cpp
          dialogdisplayoptions_t.cpp
+         dialogeditunit_t.cpp
          dialogimagesize_t.cpp
          dialogimageslice_t.cpp
          dialogintegratoroptions_t.cpp

--- a/src/gui/dialogs/dialogabout_t.cpp
+++ b/src/gui/dialogs/dialogabout_t.cpp
@@ -1,9 +1,14 @@
-#include <QFile>
-
 #include "catch_wrapper.hpp"
 #include "dialogabout.hpp"
-#include "qt_test_utils.hpp"
+#include "version.hpp"
+#include <QLabel>
 
-SCENARIO("DialogAbout", "[gui/dialogs/about][gui/dialogs][gui][about]") {
-  REQUIRE(1 == 1);
+TEST_CASE("DialogAbout", "[gui/dialogs/about][gui/dialogs][gui][about]") {
+  auto dia = DialogAbout();
+  auto *lblAbout = dia.findChild<QLabel *>("lblAbout");
+  auto *lblLibraries = dia.findChild<QLabel *>("lblLibraries");
+  REQUIRE(lblAbout != nullptr);
+  REQUIRE(lblLibraries != nullptr);
+  REQUIRE(lblLibraries->text().contains("dune-copasi"));
+  REQUIRE(lblLibraries->text().contains("libSBML"));
 }

--- a/src/gui/dialogs/dialoganalytic.cpp
+++ b/src/gui/dialogs/dialoganalytic.cpp
@@ -22,10 +22,9 @@ DialogAnalytic::DialogAnalytic(
   ui->txtExpression->enableLibSbmlBackend(&modelMath);
 
   const auto &units = speciesGeometry.modelUnits;
-  lengthUnit = units.getLength().symbol;
-  concentrationUnit = QString("%1/%2")
-                          .arg(units.getAmount().symbol)
-                          .arg(units.getVolume().symbol);
+  lengthUnit = units.getLength().name;
+  concentrationUnit =
+      QString("%1/%2").arg(units.getAmount().name).arg(units.getVolume().name);
   img = QImage(speciesGeometry.compartmentImageSize,
                QImage::Format_ARGB32_Premultiplied);
   img.fill(0);

--- a/src/gui/dialogs/dialogconcentrationimage.cpp
+++ b/src/gui/dialogs/dialogconcentrationimage.cpp
@@ -29,10 +29,9 @@ DialogConcentrationImage::DialogConcentrationImage(
   ui->lblMaxConcColour->setPixmap(QPixmap::fromImage(colourMaxConc));
 
   const auto &units = speciesGeometry.modelUnits;
-  lengthUnit = units.getLength().symbol;
-  concentrationUnit = QString("%1/%2")
-                          .arg(units.getAmount().symbol)
-                          .arg(units.getVolume().symbol);
+  lengthUnit = units.getLength().name;
+  concentrationUnit =
+      QString("%1/%2").arg(units.getAmount().name).arg(units.getVolume().name);
   ui->lblMinConcUnits->setText(concentrationUnit);
   ui->lblMaxConcUnits->setText(concentrationUnit);
   img = QImage(speciesGeometry.compartmentImageSize,

--- a/src/gui/dialogs/dialogeditunit.cpp
+++ b/src/gui/dialogs/dialogeditunit.cpp
@@ -1,0 +1,90 @@
+#include "dialogeditunit.hpp"
+#include "logger.hpp"
+#include "ui_dialogeditunit.h"
+#include <QPushButton>
+
+DialogEditUnit::DialogEditUnit(const model::Unit &unit, const QString &unitType,
+                               QWidget *parent)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogEditUnit>()}, u(unit) {
+  ui->setupUi(this);
+  if (!unitType.isEmpty()) {
+    setWindowTitle(QString("Edit Unit of %1").arg(unitType));
+  }
+  ui->txtName->setText(u.name);
+  ui->txtMultipler->setText(QString::number(u.multiplier));
+  ui->txtScale->setText(QString::number(u.scale));
+  ui->txtExponent->setText(QString::number(u.exponent));
+
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+          &DialogEditUnit::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &DialogEditUnit::reject);
+  connect(ui->txtName, &QLineEdit::textEdited, this,
+          &DialogEditUnit::txtName_textEdited);
+  connect(ui->txtMultipler, &QLineEdit::textEdited, this,
+          &DialogEditUnit::txtMultiplier_textEdited);
+  connect(ui->txtScale, &QLineEdit::textEdited, this,
+          &DialogEditUnit::txtScale_textEdited);
+  connect(ui->txtExponent, &QLineEdit::textEdited, this,
+          &DialogEditUnit::txtExponent_textEdited);
+
+  updateLblBaseUnits();
+}
+
+DialogEditUnit::~DialogEditUnit() = default;
+
+const model::Unit &DialogEditUnit::getUnit() const { return u; }
+
+void DialogEditUnit::updateLblBaseUnits() {
+  if (validScale && validExponent && validMultipler) {
+    ui->lblBaseUnits->setText(
+        QString("1 %1 = %2").arg(u.name).arg(model::unitInBaseUnits(u)));
+  }
+}
+
+void DialogEditUnit::setIsValidState(QWidget *widget, bool valid,
+                                     const QString &errorMessage) {
+  ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)
+      ->setEnabled(valid);
+  if (valid) {
+    widget->setStyleSheet({});
+    return;
+  }
+  widget->setStyleSheet("background-color: red");
+  ui->lblBaseUnits->setText(errorMessage);
+}
+
+void DialogEditUnit::txtName_textEdited(const QString &text) {
+  u.name = text;
+  updateLblBaseUnits();
+}
+
+void DialogEditUnit::txtMultiplier_textEdited(const QString &text) {
+  double newMultiplier = text.toDouble(&validMultipler);
+  if (validMultipler) {
+    u.multiplier = newMultiplier;
+  }
+  setIsValidState(ui->txtMultipler, validMultipler,
+                  "Invalid value: Multiplier must be a double");
+  updateLblBaseUnits();
+}
+
+void DialogEditUnit::txtScale_textEdited(const QString &text) {
+  int newScale = text.toInt(&validScale);
+  if (validScale) {
+    u.scale = newScale;
+  }
+  setIsValidState(ui->txtScale, validScale,
+                  "Invalid value: Scale must be an integer");
+  updateLblBaseUnits();
+}
+
+void DialogEditUnit::txtExponent_textEdited(const QString &text) {
+  int newExponent = text.toInt(&validExponent);
+  if (validExponent) {
+    u.exponent = newExponent;
+  }
+  setIsValidState(ui->txtScale, validExponent,
+                  "Invalid value: Exponent must be an integer");
+  updateLblBaseUnits();
+}

--- a/src/gui/dialogs/dialogeditunit.hpp
+++ b/src/gui/dialogs/dialogeditunit.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QDialog>
+#include <memory>
+
+#include "model_units.hpp"
+
+namespace Ui {
+class DialogEditUnit;
+}
+
+class DialogEditUnit : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit DialogEditUnit(const model::Unit &unit, const QString &unitType = {},
+                          QWidget *parent = nullptr);
+  ~DialogEditUnit();
+  const model::Unit &getUnit() const;
+
+private:
+  std::unique_ptr<Ui::DialogEditUnit> ui;
+  model::Unit u;
+  bool validMultipler{true};
+  bool validScale{true};
+  bool validExponent{true};
+  void updateLblBaseUnits();
+  void setIsValidState(QWidget *widget, bool valid,
+                       const QString &errorMessage = {});
+  void txtName_textEdited(const QString &text);
+  void txtMultiplier_textEdited(const QString &text);
+  void txtScale_textEdited(const QString &text);
+  void txtExponent_textEdited(const QString &text);
+};

--- a/src/gui/dialogs/dialogeditunit.ui
+++ b/src/gui/dialogs/dialogeditunit.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogEditUnit</class>
+ <widget class="QDialog" name="DialogEditUnit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>494</width>
+    <height>339</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Unit</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="txtExponent"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="txtScale"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblLabelName">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblLabelMultiplier">
+       <property name="text">
+        <string>Multiplier:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="txtName"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblLabelScale">
+       <property name="text">
+        <string>Scale:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="txtMultipler"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="lblBaseUnits">
+       <property name="text">
+        <string>unit in base units</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelExponent">
+       <property name="text">
+        <string>Exponent:</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>txtMultipler</tabstop>
+  <tabstop>txtScale</tabstop>
+  <tabstop>txtExponent</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/dialogs/dialogeditunit_t.cpp
+++ b/src/gui/dialogs/dialogeditunit_t.cpp
@@ -1,0 +1,60 @@
+#include "catch_wrapper.hpp"
+#include "dialogeditunit.hpp"
+#include "model.hpp"
+#include "qt_test_utils.hpp"
+#include <QFile>
+#include <QLabel>
+#include <QLineEdit>
+
+TEST_CASE("DialogEditUnit",
+          "[gui/dialogs/editunit][gui/dialogs][gui][editunit][units]") {
+  model::Unit u{"h", "second", 0, 1, 3600};
+  ModalWidgetTimer mwt;
+  DialogEditUnit dia(u);
+  auto *lblBaseUnits = dia.findChild<QLabel *>("lblBaseUnits");
+  REQUIRE(dia.getUnit().kind == u.kind);
+  REQUIRE(dia.getUnit().name == u.name);
+  REQUIRE(dia.getUnit().multiplier == dbl_approx(u.multiplier));
+  REQUIRE(dia.getUnit().scale == u.scale);
+  REQUIRE(dia.getUnit().exponent == u.exponent);
+  REQUIRE(lblBaseUnits->text() == "1 h = 3600 second");
+  SECTION("valid unit") {
+    mwt.addUserAction({"Delete", "Backspace", "H", " ", "!", "Tab", ".", "2",
+                       "Tab", "1", "0", "Tab", "2"});
+    mwt.start();
+    auto result = dia.exec();
+    REQUIRE(dia.getUnit().kind == u.kind);
+    REQUIRE(dia.getUnit().name == "H !");
+    REQUIRE(dia.getUnit().multiplier == dbl_approx(0.2));
+    REQUIRE(dia.getUnit().scale == 10);
+    REQUIRE(dia.getUnit().exponent == 2);
+    REQUIRE(lblBaseUnits->text() == "1 H ! = (0.2 * 10^(10) second)^2");
+    REQUIRE(result == QDialog::Accepted);
+  }
+  SECTION("invalid multiplier") {
+    mwt.addUserAction({"Delete", "Backspace", "q", "Tab", ".", ",", "Tab", "1",
+                       "0", "Tab", "2"});
+    mwt.start();
+    dia.exec();
+    REQUIRE(dia.getUnit().name == "q");
+    // multiplier ".," invalid: unit retains previous valid multiplier value
+    REQUIRE(dia.getUnit().multiplier == dbl_approx(3600));
+    REQUIRE(dia.getUnit().scale == 10);
+    REQUIRE(dia.getUnit().exponent == 2);
+    REQUIRE(lblBaseUnits->text() ==
+            "Invalid value: Multiplier must be a double");
+  }
+  SECTION("invalid scale") {
+    mwt.addUserAction({"Tab", "Tab", "q"});
+    mwt.start();
+    dia.exec();
+    REQUIRE(lblBaseUnits->text() == "Invalid value: Scale must be an integer");
+  }
+  SECTION("invalid exponent") {
+    mwt.addUserAction({"Tab", "Tab", "Tab", "q"});
+    mwt.start();
+    dia.exec();
+    REQUIRE(lblBaseUnits->text() ==
+            "Invalid value: Exponent must be an integer");
+  }
+}

--- a/src/gui/dialogs/dialogimagesize.cpp
+++ b/src/gui/dialogs/dialogimagesize.cpp
@@ -15,7 +15,7 @@ DialogImageSize::DialogImageSize(const QImage &image, double pixelWidth,
 
   for (auto *cmb : {ui->cmbUnitsWidth, ui->cmbUnitsHeight}) {
     for (const auto &u : units.getLengthUnits()) {
-      cmb->addItem(u.symbol);
+      cmb->addItem(u.name);
     }
     cmb->setCurrentIndex(units.getLengthIndex());
   }

--- a/src/gui/dialogs/dialogunits.cpp
+++ b/src/gui/dialogs/dialogunits.cpp
@@ -1,9 +1,9 @@
 #include "dialogunits.hpp"
-
+#include "dialogeditunit.hpp"
 #include "logger.hpp"
 #include "ui_dialogunits.h"
 
-DialogUnits::DialogUnits(const model::ModelUnits &modelUnits, QWidget *parent)
+DialogUnits::DialogUnits(model::ModelUnits &modelUnits, QWidget *parent)
     : QDialog(parent), ui{std::make_unique<Ui::DialogUnits>()},
       units(modelUnits) {
   ui->setupUi(this);
@@ -20,18 +20,25 @@ DialogUnits::DialogUnits(const model::ModelUnits &modelUnits, QWidget *parent)
           &DialogUnits::cmbVolume_currentIndexChanged);
   connect(ui->cmbAmount, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &DialogUnits::cmbAmount_currentIndexChanged);
-
+  connect(ui->btnEditTime, &QPushButton::pressed, this,
+          &DialogUnits::btnEditTime_pressed);
+  connect(ui->btnEditLength, &QPushButton::pressed, this,
+          &DialogUnits::btnEditLength_pressed);
+  connect(ui->btnEditVolume, &QPushButton::pressed, this,
+          &DialogUnits::btnEditVolume_pressed);
+  connect(ui->btnEditAmount, &QPushButton::pressed, this,
+          &DialogUnits::btnEditAmount_pressed);
   for (const auto &u : units.getTimeUnits()) {
-    ui->cmbTime->addItem(u.symbol);
+    ui->cmbTime->addItem(u.name);
   }
   for (const auto &u : units.getLengthUnits()) {
-    ui->cmbLength->addItem(u.symbol);
+    ui->cmbLength->addItem(u.name);
   }
   for (const auto &u : units.getVolumeUnits()) {
-    ui->cmbVolume->addItem(u.symbol);
+    ui->cmbVolume->addItem(u.name);
   }
   for (const auto &u : units.getAmountUnits()) {
-    ui->cmbAmount->addItem(u.symbol);
+    ui->cmbAmount->addItem(u.name);
   }
 
   ui->cmbTime->setCurrentIndex(units.getTimeIndex());
@@ -58,48 +65,74 @@ int DialogUnits::getAmountUnitIndex() const {
   return ui->cmbAmount->currentIndex();
 }
 
-static QString baseUnitString(const model::Unit &unit) {
-  QString s;
-  if (unit.exponent != 1) {
-    s = "(";
-  }
-  if (unit.multiplier != 1.0) {
-    s.append(QString::number(unit.multiplier, 'g', 14));
-    s.append(" ");
-    if (unit.scale != 0) {
-      s.append("* ");
-    }
-  }
-  if (unit.scale != 0) {
-    s.append(QString("10^(%1) ").arg(unit.scale));
-  }
-  s.append(unit.kind);
-  if (unit.exponent != 1) {
-    s.append(QString(")^%1").arg(unit.exponent));
-  }
-  return s;
-}
-
 void DialogUnits::cmbTime_currentIndexChanged(int index) {
   const auto &unit = units.getTimeUnits().at(index);
-  ui->lblTime->setText(unit.name);
-  ui->lblSITime->setText(baseUnitString(unit));
+  ui->lblSITime->setText(model::unitInBaseUnits(unit));
 }
 
 void DialogUnits::cmbLength_currentIndexChanged(int index) {
   const auto &unit = units.getLengthUnits().at(index);
-  ui->lblLength->setText(unit.name);
-  ui->lblSILength->setText(baseUnitString(unit));
+  ui->lblSILength->setText(model::unitInBaseUnits(unit));
 }
 
 void DialogUnits::cmbVolume_currentIndexChanged(int index) {
   const auto &unit = units.getVolumeUnits().at(index);
-  ui->lblVolume->setText(unit.name);
-  ui->lblSIVolume->setText(baseUnitString(unit));
+  ui->lblSIVolume->setText(model::unitInBaseUnits(unit));
 }
 
 void DialogUnits::cmbAmount_currentIndexChanged(int index) {
   const auto &unit = units.getAmountUnits().at(index);
-  ui->lblAmount->setText(unit.name);
-  ui->lblSIAmount->setText(baseUnitString(unit));
+  ui->lblSIAmount->setText(model::unitInBaseUnits(unit));
+}
+
+void DialogUnits::btnEditTime_pressed() {
+  int i{ui->cmbTime->currentIndex()};
+  auto &u = units.getTimeUnits()[i];
+  DialogEditUnit dialog(u, "Time");
+  if (dialog.exec() == QDialog::Accepted) {
+    u = dialog.getUnit();
+    SPDLOG_INFO("New unit of time: {} ({})", u.name.toStdString());
+    SPDLOG_INFO("  = {}", model::unitInBaseUnits(u).toStdString());
+    ui->cmbTime->setItemText(i, u.name);
+    cmbTime_currentIndexChanged(i);
+  }
+}
+
+void DialogUnits::btnEditLength_pressed() {
+  int i{ui->cmbLength->currentIndex()};
+  auto &u = units.getLengthUnits()[i];
+  DialogEditUnit dialog(u, "Length");
+  if (dialog.exec() == QDialog::Accepted) {
+    u = dialog.getUnit();
+    SPDLOG_INFO("New unit of length: {} ({})", u.name.toStdString());
+    SPDLOG_INFO("  = {}", model::unitInBaseUnits(u).toStdString());
+    ui->cmbLength->setItemText(i, u.name);
+    cmbLength_currentIndexChanged(i);
+  }
+}
+
+void DialogUnits::btnEditVolume_pressed() {
+  int i{ui->cmbVolume->currentIndex()};
+  auto &u = units.getVolumeUnits()[i];
+  DialogEditUnit dialog(u, "Volume");
+  if (dialog.exec() == QDialog::Accepted) {
+    u = dialog.getUnit();
+    SPDLOG_INFO("New unit of volume: {} ({})", u.name.toStdString());
+    SPDLOG_INFO("  = {}", model::unitInBaseUnits(u).toStdString());
+    ui->cmbVolume->setItemText(i, u.name);
+    cmbVolume_currentIndexChanged(i);
+  }
+}
+
+void DialogUnits::btnEditAmount_pressed() {
+  int i{ui->cmbAmount->currentIndex()};
+  auto &u = units.getAmountUnits()[i];
+  DialogEditUnit dialog(u, "Amount");
+  if (dialog.exec() == QDialog::Accepted) {
+    u = dialog.getUnit();
+    SPDLOG_INFO("New unit of amount: {} ({})", u.name.toStdString());
+    SPDLOG_INFO("  = {}", model::unitInBaseUnits(u).toStdString());
+    ui->cmbAmount->setItemText(i, u.name);
+    cmbAmount_currentIndexChanged(i);
+  }
 }

--- a/src/gui/dialogs/dialogunits.hpp
+++ b/src/gui/dialogs/dialogunits.hpp
@@ -13,8 +13,7 @@ class DialogUnits : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogUnits(const model::ModelUnits &units,
-                       QWidget *parent = nullptr);
+  explicit DialogUnits(model::ModelUnits &units, QWidget *parent = nullptr);
   ~DialogUnits();
   int getTimeUnitIndex() const;
   int getLengthUnitIndex() const;
@@ -23,9 +22,13 @@ public:
 
 private:
   std::unique_ptr<Ui::DialogUnits> ui;
-  const model::ModelUnits &units;
+  model::ModelUnits &units;
   void cmbTime_currentIndexChanged(int index);
   void cmbLength_currentIndexChanged(int index);
   void cmbVolume_currentIndexChanged(int index);
   void cmbAmount_currentIndexChanged(int index);
+  void btnEditTime_pressed();
+  void btnEditLength_pressed();
+  void btnEditVolume_pressed();
+  void btnEditAmount_pressed();
 };

--- a/src/gui/dialogs/dialogunits.ui
+++ b/src/gui/dialogs/dialogunits.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
-    <height>236</height>
+    <width>718</width>
+    <height>279</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,39 +25,46 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="4">
-      <widget class="QLabel" name="lblTime">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+     <item row="4" column="2">
+      <widget class="QComboBox" name="cmbVolume"/>
      </item>
-     <item row="3" column="6">
-      <widget class="QLabel" name="lblSILength">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="7">
-      <widget class="Line" name="line_2">
+     <item row="2" column="3" rowspan="4">
+      <widget class="Line" name="line_6">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="lblLabelUnits">
+     <item row="2" column="2">
+      <widget class="QComboBox" name="cmbTime"/>
+     </item>
+     <item row="4" column="6">
+      <widget class="QPushButton" name="btnEditVolume">
        <property name="text">
-        <string>Symbol</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <string>edit...</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="cmbLength"/>
+     <item row="0" column="5">
+      <widget class="Line" name="line_9">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="Line" name="line_7">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="6">
+      <widget class="QPushButton" name="btnEditAmount">
+       <property name="text">
+        <string>edit...</string>
+       </property>
+      </widget>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="lblLabelAmount">
@@ -69,8 +76,15 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="4">
-      <widget class="QLabel" name="lblLabelName">
+     <item row="2" column="5" rowspan="4">
+      <widget class="Line" name="line_10">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="lblLabelUnits">
        <property name="text">
         <string>Name</string>
        </property>
@@ -79,39 +93,8 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
-      <widget class="QLabel" name="lblLength">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="4">
-      <widget class="QLabel" name="lblAmount">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="Line" name="line_7">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="lblLabelLength">
-       <property name="text">
-        <string>Length:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="6">
-      <widget class="QLabel" name="lblSITime">
+     <item row="4" column="4">
+      <widget class="QLabel" name="lblSIVolume">
        <property name="text">
         <string/>
        </property>
@@ -120,6 +103,20 @@
      <item row="5" column="2">
       <widget class="QComboBox" name="cmbAmount"/>
      </item>
+     <item row="3" column="6">
+      <widget class="QPushButton" name="btnEditLength">
+       <property name="text">
+        <string>edit...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="4">
+      <widget class="QLabel" name="lblSIAmount">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="lblLabelVolume">
        <property name="text">
@@ -127,64 +124,6 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="6">
-      <widget class="QLabel" name="lblSIAmount">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0" colspan="7">
-      <widget class="Line" name="line_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="cmbVolume"/>
-     </item>
-     <item row="2" column="2">
-      <widget class="QComboBox" name="cmbTime"/>
-     </item>
-     <item row="0" column="6">
-      <widget class="QLabel" name="lblLabelSIEquivalent">
-       <property name="text">
-        <string>Base units</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1" rowspan="4">
-      <widget class="Line" name="line_5">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3" rowspan="4">
-      <widget class="Line" name="line_6">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="5" rowspan="4">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="6">
-      <widget class="QLabel" name="lblSIVolume">
-       <property name="text">
-        <string/>
        </property>
       </widget>
      </item>
@@ -205,15 +144,66 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="4">
-      <widget class="QLabel" name="lblVolume">
+     <item row="1" column="0" colspan="7">
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblLabelLength">
+       <property name="text">
+        <string>Length:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QComboBox" name="cmbLength"/>
+     </item>
+     <item row="2" column="6">
+      <widget class="QPushButton" name="btnEditTime">
+       <property name="text">
+        <string>edit...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="QLabel" name="lblSITime">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="0" column="5">
-      <widget class="Line" name="line_3">
+     <item row="6" column="0" colspan="7">
+      <widget class="Line" name="line_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="QLabel" name="lblLabelSIEquivalent">
+       <property name="text">
+        <string>Equivalent base units</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="QLabel" name="lblSILength">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1" rowspan="4">
+      <widget class="Line" name="line_5">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
@@ -238,6 +228,10 @@
   <tabstop>cmbLength</tabstop>
   <tabstop>cmbVolume</tabstop>
   <tabstop>cmbAmount</tabstop>
+  <tabstop>btnEditTime</tabstop>
+  <tabstop>btnEditLength</tabstop>
+  <tabstop>btnEditVolume</tabstop>
+  <tabstop>btnEditAmount</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -164,37 +164,37 @@ void MainWindow::tabMain_currentChanged(int index) {
   SPDLOG_DEBUG("Tab changed to {} [{}]", index,
                ui->tabMain->tabText(index).toStdString());
   switch (index) {
-    case TabIndex::GEOMETRY:
-      tabGeometry->loadModelData();
-      break;
-    case TabIndex::SPECIES:
-      tabSpecies->loadModelData();
-      break;
-    case TabIndex::REACTIONS:
-      tabReactions->loadModelData();
-      break;
-    case TabIndex::FUNCTIONS:
-      tabFunctions->loadModelData();
-      break;
-    case TabIndex::PARAMETERS:
-      tabParameters->loadModelData();
-      break;
-    case TabIndex::SIMULATE:
-      tabSimulate->loadModelData();
-      break;
-    case TabIndex::SBML:
-      ui->txtSBML->setText(sbmlDoc.getXml());
-      break;
-    case TabIndex::DUNE:
-      ui->txtDUNE->setText(dune::DuneConverter(sbmlDoc).getIniFile());
-      break;
-    case TabIndex::GMSH:
-      ui->txtGMSH->setText(sbmlDoc.getGeometry().getMesh() == nullptr
-                               ? ""
-                               : sbmlDoc.getGeometry().getMesh()->getGMSH());
-      break;
-    default:
-      SPDLOG_ERROR("Tab index {} not valid", index);
+  case TabIndex::GEOMETRY:
+    tabGeometry->loadModelData();
+    break;
+  case TabIndex::SPECIES:
+    tabSpecies->loadModelData();
+    break;
+  case TabIndex::REACTIONS:
+    tabReactions->loadModelData();
+    break;
+  case TabIndex::FUNCTIONS:
+    tabFunctions->loadModelData();
+    break;
+  case TabIndex::PARAMETERS:
+    tabParameters->loadModelData();
+    break;
+  case TabIndex::SIMULATE:
+    tabSimulate->loadModelData();
+    break;
+  case TabIndex::SBML:
+    ui->txtSBML->setText(sbmlDoc.getXml());
+    break;
+  case TabIndex::DUNE:
+    ui->txtDUNE->setText(dune::DuneConverter(sbmlDoc).getIniFile());
+    break;
+  case TabIndex::GMSH:
+    ui->txtGMSH->setText(sbmlDoc.getGeometry().getMesh() == nullptr
+                             ? ""
+                             : sbmlDoc.getGeometry().getMesh()->getGMSH());
+    break;
+  default:
+    SPDLOG_ERROR("Tab index {} not valid", index);
   }
 }
 

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -17,9 +17,7 @@
 
 TabSimulate::TabSimulate(model::Model &doc, QLabelMouseTracker *mouseTracker,
                          QWidget *parent)
-    : QWidget(parent),
-      ui{std::make_unique<Ui::TabSimulate>()},
-      sbmlDoc(doc),
+    : QWidget(parent), ui{std::make_unique<Ui::TabSimulate>()}, sbmlDoc(doc),
       lblGeometry(mouseTracker) {
   ui->setupUi(this);
   pltPlot = new QCustomPlot(this);
@@ -100,18 +98,17 @@ void TabSimulate::loadModelData() {
         sbmlDoc.getCompartments().getNames()[static_cast<int>(ic)]);
     auto &names = speciesNames.emplace_back();
     for (std::size_t is = 0; is < sim->getSpeciesIds(ic).size(); ++is) {
-      names.push_back(sbmlDoc.getSpecies().getName(
-          sim->getSpeciesIds(ic)[is].c_str()));
+      names.push_back(
+          sbmlDoc.getSpecies().getName(sim->getSpeciesIds(ic)[is].c_str()));
       speciesVisible.push_back(true);
     }
   }
   // setup plot
   pltPlot->clearGraphs();
   pltPlot->xAxis->setLabel(
-      QString("time (%1)").arg(sbmlDoc.getUnits().getTime().symbol));
+      QString("time (%1)").arg(sbmlDoc.getUnits().getTime().name));
   pltPlot->yAxis->setLabel(
-      QString("concentration (%1)")
-          .arg(sbmlDoc.getUnits().getConcentration()));
+      QString("concentration (%1)").arg(sbmlDoc.getUnits().getConcentration()));
   pltPlot->xAxis->setRange(0, ui->txtSimLength->text().toDouble());
   // graphs
   for (std::size_t ic = 0; ic < sim->getCompartmentIds().size(); ++ic) {
@@ -395,9 +392,8 @@ void TabSimulate::hslideTime_valueChanged(int value) {
       pltPlot->rescaleAxes(true);
     }
     pltPlot->replot();
-    ui->lblCurrentTime->setText(
-        QString("%1%2")
-            .arg(time[value])
-            .arg(sbmlDoc.getUnits().getTime().symbol));
+    ui->lblCurrentTime->setText(QString("%1%2")
+                                    .arg(time[value])
+                                    .arg(sbmlDoc.getUnits().getTime().name));
   }
 }

--- a/test/resources/models/weird-units.xml
+++ b/test/resources/models/weird-units.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model id="weird_units" name="Weird Units Model" substanceUnits="substance" timeUnits="unit_of_time" volumeUnits="unit_of_volume" areaUnits="area" lengthUnits="unit_of_length" extentUnits="substance">
+    <listOfUnitDefinitions>
+      <unitDefinition id="area" name="kilometre squared">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="3" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance" name="kilomole">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="3" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area_perTime">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="3" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="6" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_time" name="megasecond">
+        <listOfUnits>
+          <unit kind="second" exponent="1" scale="6" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_length" name="kilometre">
+        <listOfUnits>
+          <unit kind="metre" exponent="1" scale="3" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_of_volume" name="picolitre">
+        <listOfUnits>
+          <unit kind="litre" exponent="1" scale="-12" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="c1" name="Outside" spatialDimensions="2" units="area" constant="true">
+      </compartment>
+      <compartment id="c2" name="Cell" spatialDimensions="2" units="area" constant="true">
+      </compartment>
+      <compartment id="c3" name="Nucleus" spatialDimensions="2" units="area" constant="true">
+      </compartment>
+    </listOfCompartments>
+  </model>
+</sbml>

--- a/test/resources/test_resources.qrc
+++ b/test/resources/test_resources.qrc
@@ -5,5 +5,6 @@
         <file>models/very-simple-model-uint8.xml</file>
         <file>models/analytic_2d.xml</file>
         <file>models/analytic_3d.xml</file>
+        <file>models/weird-units.xml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
  - DialogUnits: add button allowing user to edit each unit
  - DialogEditUnit: dialog where user can edit a unit definition
  - on SBML import:
    - first try to find an equivalent built-in GUI unit
    - if none exists, create a new one from the SBML UnitDefinition
  - no longer expose sId in GUI as unit symbol, instead use Name in GUI in line with other SBML objects

also
  - add compartment ids/names to ModelParameters::getSymbols()