### PR TITLE
export any tiff files to same dir as dune ini file

### DIFF
--- a/src/core/simulate/inc/duneconverter.hpp
+++ b/src/core/simulate/inc/duneconverter.hpp
@@ -20,7 +20,7 @@ namespace simulate {
 class DuneConverter {
 public:
   explicit DuneConverter(const model::Model &model, bool forExternalUse = false,
-                         double dt = 1e-2, int doublePrecision = 18);
+                         double dt = 1e-2, const QString& iniFileName={}, int doublePrecision = 18);
   QString getIniFile() const;
   const std::unordered_set<int> &getGMSHCompIndices() const;
   bool hasIndependentCompartments() const;

--- a/src/core/simulate/src/duneconverter_t.cpp
+++ b/src/core/simulate/src/duneconverter_t.cpp
@@ -15,7 +15,7 @@ SCENARIO("DUNE: DuneConverter",
     f.open(QIODevice::ReadOnly);
     s.importSBMLString(f.readAll().toStdString());
 
-    simulate::DuneConverter dc(s, true, 1e-4, 14);
+    simulate::DuneConverter dc(s, true, 1e-4, {}, 14);
     QStringList ini = dc.getIniFile().split("\n");
     auto line = ini.cbegin();
     while (line != ini.cend() && *line != "[model.compartments]") {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -263,28 +263,15 @@ void MainWindow::actionExport_Dune_ini_file_triggered() {
     SPDLOG_DEBUG("invalid geometry and/or model: ignoring");
     return;
   }
-  QString filename = QFileDialog::getSaveFileName(this, "Export DUNE ini file",
-                                                  "", "DUNE ini file (*.ini)");
-  if (!filename.isEmpty()) {
-    if (filename.right(4) != ".ini") {
-      filename.append(".ini");
-    }
-    simulate::DuneConverter dc(sbmlDoc, true);
-    QFile f(filename);
-    if (f.open(QIODevice::ReadWrite | QIODevice::Text)) {
-      f.write(dc.getIniFile().toUtf8());
-    }
-    // also export gmsh file `grid.msh` in the same dir
-    QString dir = QFileInfo(filename).absolutePath();
-    QString meshFilename = QDir(dir).filePath("grid.msh");
-    QFile f2(meshFilename);
-    if (f2.open(QIODevice::ReadWrite | QIODevice::Text)) {
-      f2.write(sbmlDoc.getGeometry()
-                   .getMesh()
-                   ->getGMSH(dc.getGMSHCompIndices())
-                   .toUtf8());
-    }
+  QString iniFilename = QFileDialog::getSaveFileName(
+      this, "Export DUNE ini file", "", "DUNE ini file (*.ini)");
+  if (iniFilename.isEmpty()) {
+    return;
   }
+  if (iniFilename.right(4) != ".ini") {
+    iniFilename.append(".ini");
+  }
+  simulate::DuneConverter dc(sbmlDoc, true, 1e-2, iniFilename);
 }
 
 void MainWindow::actionGeometry_from_model_triggered() {


### PR DESCRIPTION
- DuneConverter now takes iniFilename as parameter
   - If forExternalUse=true, then it creates:
     - dune ini file with supplied filename
     - gmsh file in the same directory
     - tiff initial concentration files in the same directory
   - resolves #238