### PR TITLE
Improve dune initial concentration interpolation

### DIFF
--- a/src/core/model/inc/geometry.hpp
+++ b/src/core/model/inc/geometry.hpp
@@ -102,7 +102,8 @@ public:
   void setUniformConcentration(double concentration);
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);
   QImage getConcentrationImage() const;
-  std::vector<double> getConcentrationImageArray() const;
+  std::vector<double>
+  getConcentrationImageArray(double invalidPixelValue = 0.0) const;
   void setCompartment(const Compartment *comp);
 };
 

--- a/src/core/model/src/geometry.cpp
+++ b/src/core/model/src/geometry.cpp
@@ -209,13 +209,14 @@ QImage Field::getConcentrationImage() const {
   return img;
 }
 
-std::vector<double> Field::getConcentrationImageArray() const {
+std::vector<double>
+Field::getConcentrationImageArray(double invalidPixelValue) const {
   const auto &img = comp->getCompartmentImage();
   int size = img.width() * img.height();
   // NOTE: order of concentration array is [ (x=0,y=0), (x=1,y=0), ... ]
   // NOTE: (0,0) point is at bottom-left
   // NOTE: QImage has (0,0) point at top-left, so flip y-coord here
-  std::vector<double> arr(static_cast<std::size_t>(size), 0.0);
+  std::vector<double> arr(static_cast<std::size_t>(size), invalidPixelValue);
   for (std::size_t i = 0; i < comp->nPixels(); ++i) {
     const auto &point = comp->getPixel(i);
     int arrayIndex = point.x() + img.width() * (img.height() - 1 - point.y());

--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -97,6 +97,7 @@ DuneConverter::DuneConverter(const model::Model &model, bool forExternalUse,
   double end_time = 0.02;
   double time_step = dt;
 
+  constexpr double invalidPixelConc{-999.0};
   // grid
   ini.addSection("grid");
   ini.addValue("file", "grid.msh");
@@ -205,7 +206,7 @@ DuneConverter::DuneConverter(const model::Model &model, bool forExternalUse,
         } else {
           ini.addValue(duneName, 0.0, doublePrecision);
           // create array of concentration values
-          concs[indices[i]] = f->getConcentrationImageArray();
+          concs[indices[i]] = f->getConcentrationImageArray(invalidPixelConc);
         }
       }
       concentrations.push_back(std::move(concs));
@@ -298,7 +299,7 @@ DuneConverter::DuneConverter(const model::Model &model, bool forExternalUse,
                      doublePrecision);
         if (!forExternalUse) {
           const auto *f = model.getSpecies().getField(name);
-          concs[indices[i]] = f->getConcentrationImageArray();
+          concs[indices[i]] = f->getConcentrationImageArray(invalidPixelConc);
         }
       }
       concentrations.push_back(std::move(concs));

--- a/src/core/simulate/src/dunefunction_t.cpp
+++ b/src/core/simulate/src/dunefunction_t.cpp
@@ -85,10 +85,12 @@ SCENARIO("DUNE: function",
       }
     }
     double avgRelErr{relativeError / n};
-    // note: two potential sources of error
-    //  - TIFF: rescaling & truncating due to 16-bit integer format
-    //  - interpolation(?): maybe occasionally end up with a different pixel for
-    //  the two models due to rounding if point is right on the boundary?
-    REQUIRE(avgRelErr < 0.05);
+    // Note: due to boundary approx in mesh, sometimes the nearest pixel to a
+    // Dune point is in another compartment. In the GUI we correct for this by
+    // using the nearest pixel in the same compartment, but when dune loads a
+    // TIFF it will just use the pixel from the wrong compartment (which will
+    // return zero for the concentration) instead.
+    // Hence the requirement for agreement within 10% on average:
+    REQUIRE(avgRelErr < 0.1);
   }
 }


### PR DESCRIPTION
- GridFunction returns species concentration at a dune point
- Due to boundary approx, the point may actually be a pixel in another compartment
- If so, find the nearest pixel in the right compartment and return the concentration there
- resolves #260