### PR TITLE
add runtime option to enable/disable Pixel multithreading

### DIFF
--- a/cli/spatial-cli.cpp
+++ b/cli/spatial-cli.cpp
@@ -96,7 +96,11 @@ static void doSimulation(const Params &params) {
   if (params.simType == simulate::SimulatorType::DUNE) {
     options.dune.dt = params.imageInterval * 0.2;
   } else {
+    options.pixel.enableMultiThreading = true;
     options.pixel.maxThreads = params.maxThreads;
+    if (params.maxThreads == 1) {
+      options.pixel.enableMultiThreading = false;
+    }
   }
   simulate::Simulation sim(s, params.simType, options);
 

--- a/sme/sme_model.cpp
+++ b/sme/sme_model.cpp
@@ -35,8 +35,7 @@ void pybindModel(const pybind11::module &m) {
       .def("export_sbml_file", &sme::Model::exportSbmlFile,
            pybind11::arg("filename"))
       .def("simulate", &sme::Model::simulate, pybind11::arg("simulation_time"),
-           pybind11::arg("image_interval"),
-           pybind11::arg("max_cpu_threads") = 0)
+           pybind11::arg("image_interval"))
       .def("simulation_time_points", &sme::Model::simulationTimePoints)
       .def("concentration_image", &sme::Model::concentrationImage,
            pybind11::arg("time_point_index"))
@@ -88,12 +87,9 @@ void Model::exportSbmlFile(const std::string &filename) {
   s->exportSBMLFile(filename);
 }
 
-void Model::simulate(double simulationTime, double imageInterval,
-                     std::size_t maxThreads) {
-  simulate::Options options;
-  options.pixel.maxThreads = maxThreads;
-  sim = std::make_unique<simulate::Simulation>(
-      *(s.get()), simulate::SimulatorType::Pixel, options);
+void Model::simulate(double simulationTime, double imageInterval) {
+  sim = std::make_unique<simulate::Simulation>(*(s.get()),
+                                               simulate::SimulatorType::Pixel);
   while (sim->getTimePoints().back() < simulationTime) {
     sim->doTimestep(imageInterval);
   }

--- a/sme/sme_model.hpp
+++ b/sme/sme_model.hpp
@@ -27,8 +27,7 @@ private:
 public:
   explicit Model(const std::string &filename);
   void exportSbmlFile(const std::string &filename);
-  void simulate(double simulationTime, double imageInterval,
-                std::size_t maxThreads = 0);
+  void simulate(double simulationTime, double imageInterval);
   std::vector<double> simulationTimePoints() const;
   std::vector<std::vector<std::vector<int>>>
   concentrationImage(std::size_t timePointIndex) const;

--- a/src/core/simulate/inc/simulate_options.hpp
+++ b/src/core/simulate/inc/simulate_options.hpp
@@ -26,6 +26,7 @@ struct PixelOptions {
   PixelIntegratorType integrator{PixelIntegratorType::RK212};
   PixelIntegratorError maxErr;
   double maxTimestep{std::numeric_limits<double>::max()};
+  bool enableMultiThreading{false};
   std::size_t maxThreads{0};
   bool doCSE{true};
   unsigned optLevel{3};

--- a/src/core/simulate/src/pixelsim.hpp
+++ b/src/core/simulate/src/pixelsim.hpp
@@ -30,15 +30,18 @@ private:
   void doRK212(double dt);
   void doRK323(double dt);
   void doRK435(double dt);
+  void doRKSubstep(double dt, double g1, double g2, double g3, double beta,
+                   double delta);
   double doRKAdaptive(double dtMax);
   double doTimestep(double dt, double dtMax);
-  std::size_t discardedSteps = 0;
+  std::size_t discardedSteps{0};
   PixelIntegratorType integrator;
   PixelIntegratorError errMax;
-  double maxTimestep = std::numeric_limits<double>::max();
-  double nextTimestep = 1e-7;
-  double epsilon = 1e-14;
-  std::size_t numMaxThreads = 1;
+  double maxTimestep{std::numeric_limits<double>::max()};
+  double nextTimestep{1e-7};
+  double epsilon{1e-14};
+  bool enableMultiThreading{false};
+  std::size_t numMaxThreads{1};
   std::string currentErrorMessage;
 
 public:
@@ -54,7 +57,7 @@ public:
   double getLowerOrderConcentration(std::size_t compartmentIndex,
                                     std::size_t speciesIndex,
                                     std::size_t pixelIndex) const;
-  virtual const std::string& errorMessage() const override;
+  virtual const std::string &errorMessage() const override;
 };
 
 } // namespace simulate

--- a/src/core/simulate/src/pixelsim_impl.hpp
+++ b/src/core/simulate/src/pixelsim_impl.hpp
@@ -25,6 +25,13 @@ class Membrane;
 
 namespace simulate {
 
+template <typename Body>
+void serial_for(std::size_t i0, std::size_t n, const Body &body) {
+  for (std::size_t i = i0; i < n; ++i) {
+    body(i);
+  }
+}
+
 class ReacEval {
 private:
   // symengine reaction expression
@@ -56,6 +63,8 @@ private:
   // dimensionless diffusion constants for each species
   std::vector<double> diffConstants;
   const geometry::Compartment *comp;
+  std::size_t nPixels;
+  std::size_t nSpecies;
   std::string compartmentId;
   std::vector<std::string> speciesIds;
   std::vector<std::size_t> nonSpatialSpeciesIndices;
@@ -73,18 +82,53 @@ public:
   ~SimCompartment() = default;
 
   // dcdt = result of applying diffusion operator to conc
+  void evaluateDiffusionOperator(std::size_t begin, std::size_t end);
   void evaluateDiffusionOperator();
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void evaluateDiffusionOperator_tbb();
+#endif
   // dcdt += result of applying reaction expressions to conc
+  void evaluateReactions(std::size_t begin, std::size_t end);
   void evaluateReactions();
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void evaluateReactions_tbb();
+#endif
   void spatiallyAverageDcdt();
+  void doForwardsEulerTimestep(double dt, std::size_t begin, std::size_t end);
   void doForwardsEulerTimestep(double dt);
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void doForwardsEulerTimestep_tbb(double dt);
+#endif
   void doRKInit();
+  void doRK212Substep1(double dt, std::size_t begin, std::size_t end);
   void doRK212Substep1(double dt);
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void doRK212Substep1_tbb(double dt);
+#endif
+  void doRK212Substep2(double dt, std::size_t begin, std::size_t end);
   void doRK212Substep2(double dt);
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void doRK212Substep2_tbb(double dt);
+#endif
+  void doRKSubstep(double dt, double g1, double g2, double g3, double beta,
+                   double delta, std::size_t begin, std::size_t end);
   void doRKSubstep(double dt, double g1, double g2, double g3, double beta,
                    double delta);
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void doRKSubstep_tbb(double dt, double g1, double g2, double g3, double beta,
+                       double delta);
+#endif
+  void doRKFinalise(double cFactor, double s2Factor, double s3Factor,
+                    std::size_t begin, std::size_t end);
   void doRKFinalise(double cFactor, double s2Factor, double s3Factor);
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void doRKFinalise_tbb(double cFactor, double s2Factor, double s3Factor);
+#endif
+  void undoRKStep(std::size_t begin, std::size_t end);
   void undoRKStep();
+#ifdef SPATIAL_MODEL_EDITOR_USE_TBB
+  void undoRKStep_tbb();
+#endif
   PixelIntegratorError calculateRKError(double epsilon) const;
   const std::string &getCompartmentId() const;
   const std::vector<std::string> &getSpeciesIds() const;

--- a/src/gui/dialogs/dialogsimulationoptions.hpp
+++ b/src/gui/dialogs/dialogsimulationoptions.hpp
@@ -31,7 +31,8 @@ private:
   void txtPixelAbsErr_editingFinished();
   void txtPixelRelErr_editingFinished();
   void txtPixelDt_editingFinished();
-  void txtPixelThreads_editingFinished();
+  void chkPixelMultithread_stateChanged();
+  void spnPixelThreads_valueChanged(int value);
   void chkPixelCSE_stateChanged();
   void spnPixelOptLevel_valueChanged(int value);
   void resetPixelToDefaults();

--- a/src/gui/dialogs/dialogsimulationoptions.ui
+++ b/src/gui/dialogs/dialogsimulationoptions.ui
@@ -125,7 +125,7 @@
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="lblPixelThreads">
            <property name="text">
             <string>Max CPU threads</string>
@@ -135,7 +135,14 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="0" colspan="2">
+         <item row="7" column="0">
+          <widget class="QLabel" name="lblPixelCompilerOpt">
+           <property name="text">
+            <string>Compiler optimization level</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0" colspan="2">
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -148,13 +155,20 @@
            </property>
           </spacer>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblPixelIntegrator">
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblPixelAbsErr">
            <property name="text">
-            <string>Integrator</string>
+            <string>Max absolute local error</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="2">
+          <widget class="QPushButton" name="btnPixelReset">
+           <property name="text">
+            <string>Reset to default values</string>
            </property>
           </widget>
          </item>
@@ -168,33 +182,13 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lblPixelDt">
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblPixelRelErr">
            <property name="text">
-            <string>Max timestep</string>
+            <string>Max relative local error</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lblPixelAbsErr">
-           <property name="text">
-            <string>Max absolute local error</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="txtPixelAbsErr">
-           <property name="toolTip">
-            <string>The maximum absolute error allowed for an integration step</string>
-           </property>
-           <property name="statusTip">
-            <string/>
            </property>
           </widget>
          </item>
@@ -228,20 +222,56 @@
            </item>
           </widget>
          </item>
-         <item row="8" column="0" colspan="2">
-          <widget class="QPushButton" name="btnPixelReset">
+         <item row="6" column="1">
+          <widget class="QCheckBox" name="chkPixelCSE">
+           <property name="toolTip">
+            <string>Extract common subexpressions symbolically before compiling reaction terms</string>
+           </property>
            <property name="text">
-            <string>Reset to default values</string>
+            <string>Common Subexpression Elimination</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="7" column="1">
+          <widget class="QSpinBox" name="spnPixelOptLevel">
+           <property name="toolTip">
+            <string>Higher levels do more compiler optimization passes</string>
+           </property>
+           <property name="maximum">
+            <number>3</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
           <widget class="QLabel" name="lblPixelSymbolicOpt">
            <property name="text">
             <string>Symbolic optimization</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="lblPixelDt">
+           <property name="text">
+            <string>Max timestep</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="txtPixelAbsErr">
+           <property name="toolTip">
+            <string>The maximum absolute error allowed for an integration step</string>
+           </property>
+           <property name="statusTip">
+            <string/>
            </property>
           </widget>
          </item>
@@ -255,20 +285,30 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
-          <widget class="QLineEdit" name="txtPixelThreads">
-           <property name="toolTip">
-            <string>Limit the maximum number of CPU threads used. '0' means use all available threads.</string>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblPixelIntegrator">
+           <property name="text">
+            <string>Integrator</string>
            </property>
-           <property name="statusTip">
-            <string/>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lblPixelRelErr">
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="chkPixelMultithread">
+           <property name="toolTip">
+            <string>Using multiple CPU threads can improve performance for large models, but for small models it may reduce performance.</string>
+           </property>
            <property name="text">
-            <string>Max relative local error</string>
+            <string>Enable multithreading</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="lblPixelMultithread">
+           <property name="text">
+            <string>Multithreading</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -276,32 +316,15 @@
           </widget>
          </item>
          <item row="5" column="1">
-          <widget class="QCheckBox" name="chkPixelCSE">
+          <widget class="QSpinBox" name="spnPixelThreads">
            <property name="toolTip">
-            <string>Extract common subexpressions symbolically before compiling reaction terms</string>
+            <string>Limit the maximum number of CPU threads used</string>
            </property>
-           <property name="text">
-            <string>Common Subexpression Elimination</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="lblPixelCompilerOpt">
-           <property name="text">
-            <string>Compiler optimization level</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QSpinBox" name="spnPixelOptLevel">
-           <property name="toolTip">
-            <string>Higher levels do more compiler optimization passes</string>
+           <property name="specialValueText">
+            <string>unlimited</string>
            </property>
            <property name="maximum">
-            <number>3</number>
-           </property>
-           <property name="value">
-            <number>0</number>
+            <number>128</number>
            </property>
           </widget>
          </item>
@@ -333,7 +356,8 @@
   <tabstop>txtPixelRelErr</tabstop>
   <tabstop>txtPixelAbsErr</tabstop>
   <tabstop>txtPixelDt</tabstop>
-  <tabstop>txtPixelThreads</tabstop>
+  <tabstop>chkPixelMultithread</tabstop>
+  <tabstop>spnPixelThreads</tabstop>
   <tabstop>chkPixelCSE</tabstop>
   <tabstop>spnPixelOptLevel</tabstop>
   <tabstop>btnPixelReset</tabstop>

--- a/src/gui/dialogs/dialogsimulationoptions_t.cpp
+++ b/src/gui/dialogs/dialogsimulationoptions_t.cpp
@@ -24,6 +24,8 @@ SCENARIO(
     REQUIRE(opt.pixel.maxErr.rel == dbl_approx(4e-4));
     REQUIRE(opt.pixel.maxErr.abs == dbl_approx(0.01));
     REQUIRE(opt.pixel.maxTimestep == dbl_approx(0.2));
+    REQUIRE(opt.pixel.enableMultiThreading == false);
+    REQUIRE(opt.pixel.maxThreads == 0);
     REQUIRE(opt.pixel.doCSE == true);
     REQUIRE(opt.pixel.optLevel == 3);
     REQUIRE(opt.dune.dt == dbl_approx(0.00123));
@@ -44,9 +46,9 @@ SCENARIO(
     REQUIRE(opt.dune.writeVTKfiles == true);
   }
   WHEN("user changes Pixel values") {
-    mwt.addUserAction({"Right", "Tab", "Up", "Up", "Tab", "7", "Tab", "9", "9",
-                       "Tab", "0", ".", "5", "Tab", "4", "Tab", "Space", "Tab",
-                       "1"});
+    mwt.addUserAction({"Right", "Tab", "Up",  "Up",  "Tab",   "7",   "Tab",
+                       "9",     "9",   "Tab", "0",   ".",     "5",   "Tab",
+                       "Space", "Tab", "4",   "Tab", "Space", "Tab", "1"});
     mwt.start();
     dia.exec();
     auto opt = dia.getOptions();
@@ -54,6 +56,7 @@ SCENARIO(
     REQUIRE(opt.pixel.maxErr.rel == dbl_approx(7));
     REQUIRE(opt.pixel.maxErr.abs == dbl_approx(99));
     REQUIRE(opt.pixel.maxTimestep == dbl_approx(0.5));
+    REQUIRE(opt.pixel.enableMultiThreading == true);
     REQUIRE(opt.pixel.maxThreads == 4);
     REQUIRE(opt.pixel.doCSE == false);
     REQUIRE(opt.pixel.optLevel == 1);
@@ -70,6 +73,7 @@ SCENARIO(
     REQUIRE(opt.pixel.maxErr.rel == dbl_approx(defaultOpts.maxErr.rel));
     REQUIRE(opt.pixel.maxErr.abs == dbl_approx(defaultOpts.maxErr.abs));
     REQUIRE(opt.pixel.maxTimestep == dbl_approx(defaultOpts.maxTimestep));
+    REQUIRE(opt.pixel.enableMultiThreading == defaultOpts.enableMultiThreading);
     REQUIRE(opt.pixel.maxThreads == defaultOpts.maxThreads);
   }
 }


### PR DESCRIPTION
  - user can enable/disable multithreading in GUI
  - for small models, tbb partitioning overhead can make it significantly slower than single threaded version
  - disabled by default: most users will start with the small built-in example geometry images
  - users with large geometry images can then enable it if desired