### PR TITLE
extend image slice functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ jobs:
       services:
         - docker
       env:
-        - DOCKER_IMAGE=lkeegan/sme_manylinux1_x86_64:2020.09.01
+        - DOCKER_IMAGE=lkeegan/sme_manylinux1_x86_64:2020.09.08
       install:
         - docker pull $DOCKER_IMAGE
       before_script:
@@ -211,7 +211,7 @@ jobs:
       services:
         - docker
       env:
-        - DOCKER_IMAGE=lkeegan/sme_manylinux2010_x86_64:2020.09.01
+        - DOCKER_IMAGE=lkeegan/sme_manylinux2010_x86_64:2020.09.08
       install:
         - docker pull $DOCKER_IMAGE
       before_script:
@@ -328,7 +328,6 @@ jobs:
         - $BUILD_SHELL ci/windows-wheels.sh
         - ls dist
         - export TWINE_USERNAME="__token__"
-
         - python -m pip install --upgrade twine
         - python -m pip install dist/sme-*-cp38-cp38-win_amd64.whl
         - python -m unittest discover -v

--- a/src/gui/dialogs/dialogimageslice.hpp
+++ b/src/gui/dialogs/dialogimageslice.hpp
@@ -7,24 +7,34 @@ namespace Ui {
 class DialogImageSlice;
 }
 
+enum class SliceType { Horizontal, Vertical, Custom };
+
 class DialogImageSlice : public QDialog {
   Q_OBJECT
 
- public:
-  explicit DialogImageSlice(const QVector<QImage>& images,
-                            const QVector<double>& timepoints,
-                            QWidget* parent = nullptr);
+public:
+  explicit DialogImageSlice(const QImage &geometryImage,
+                            const QVector<QImage> &images,
+                            const QVector<double> &timepoints,
+                            QWidget *parent = nullptr);
   ~DialogImageSlice();
   QImage getSlicedImage() const;
 
- private:
-  std::unique_ptr<Ui::DialogImageSlice> ui;
-  const QVector<QImage>& imgs;
-  const QVector<double>& time;
+private:
+  const std::unique_ptr<Ui::DialogImageSlice> ui;
+  const QVector<QImage> &imgs;
+  const QVector<double> &time;
   QImage slice;
-  void hslideTime_valueChanged(int value);
-  void sliceAtX(int x);
-  void sliceAtY(int y);
-  void lblImage_mouseOver(const QPoint& point);
+  SliceType sliceType;
+  int horizontal;
+  int vertical;
+  QPoint startPoint{0, 0};
+  QPoint endPoint{0, 0};
+  void updateSlicedImage();
   void saveSlicedImage();
+  void cmbSliceType_activated(int index);
+  void lblSlice_mouseDown(QPoint point);
+  void lblSlice_sliceDrawn(QPoint start, QPoint end);
+  void lblSlice_mouseWheelEvent(int delta);
+  void lblImage_mouseOver(const QPoint &point);
 };

--- a/src/gui/dialogs/dialogimageslice.ui
+++ b/src/gui/dialogs/dialogimageslice.ui
@@ -18,94 +18,126 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="2">
-      <widget class="QLabel" name="lblZLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>x = .</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="cmbImageVerticalAxis">
-       <property name="currentIndex">
-        <number>1</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>x</string>
-        </property>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0">
+        <widget class="QComboBox" name="cmbSliceType">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>horizontal slice</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>vertical slice</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>custom slice</string>
+          </property>
+         </item>
+        </widget>
        </item>
-       <item>
-        <property name="text">
-         <string>y</string>
-        </property>
+       <item row="2" column="0">
+        <widget class="QLabelSlice" name="lblSlice" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="whatsThis">
+          <string>&lt;h4&gt;Slice of geometry&lt;/h4&gt;</string>
+         </property>
+         <property name="text" stdset="0">
+          <string/>
+         </property>
+        </widget>
        </item>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QSlider" name="hslideZ">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="lblYLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>vertical axis of image:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="4">
-      <widget class="QLabel" name="lblMouseLocation">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>mouse location: (x=., y=., t=.)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="4">
-      <widget class="QLabelMouseTracker" name="lblImage" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;h4&gt;Compartment geometry image&lt;/h4&gt;
-&lt;p&gt;An image of the geometry of the model.&lt;/p&gt;</string>
-       </property>
-       <property name="text" stdset="0">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lblGeometrySlice">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&amp;Slice of geometry:</string>
+         </property>
+         <property name="buddy">
+          <cstring>cmbSliceType</cstring>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="gridLayoutWidget">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="chkAspectRatio">
+         <property name="text">
+          <string>Maintain &amp;aspect ratio</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="chkSmoothInterpolation">
+         <property name="text">
+          <string>Smooth &amp;interpolation</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="lblSlicedImage">
+         <property name="text">
+          <string>Species concentrations along slice vs time:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QLabelMouseTracker" name="lblImage" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="whatsThis">
+          <string>&lt;h4&gt;Species concentrations along slice vs time&lt;/h4&gt;</string>
+         </property>
+         <property name="text" stdset="0">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="QLabel" name="lblMouseLocation">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>mouse location: (x=., y=., t=.)</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -124,6 +156,11 @@
    <class>QLabelMouseTracker</class>
    <extends>QWidget</extends>
    <header>qlabelmousetracker.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>QLabelSlice</class>
+   <extends>QWidget</extends>
+   <header>qlabelslice.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/gui/dialogs/dialogimageslice_t.cpp
+++ b/src/gui/dialogs/dialogimageslice_t.cpp
@@ -7,6 +7,7 @@
 SCENARIO("DialogImageSlice",
          "[gui/dialogs/imageslice][gui/dialogs][gui][imageslice]") {
   GIVEN("5 100x50 images") {
+    QImage imgGeometry(100, 50, QImage::Format_ARGB32_Premultiplied);
     QVector<QImage> imgs(5,
                          QImage(100, 50, QImage::Format_ARGB32_Premultiplied));
     QRgb col1 = 0xffa34f6c;
@@ -16,11 +17,10 @@ SCENARIO("DialogImageSlice",
     }
     imgs[3].fill(col2);
     QVector<double> time{0, 1, 2, 3, 4};
-    DialogImageSlice dia(imgs, time);
+    DialogImageSlice dia(imgGeometry, imgs, time);
     ModalWidgetTimer mwt;
-    WHEN("user does nothing") {
+    WHEN("user does nothing: default vertical slice") {
       QImage slice = dia.getSlicedImage();
-      // default: y vs t
       REQUIRE(slice.width() == imgs.size());
       REQUIRE(slice.height() == imgs[0].height());
       REQUIRE(slice.pixel(1, 35) == col1);
@@ -28,14 +28,25 @@ SCENARIO("DialogImageSlice",
       REQUIRE(slice.pixel(3, 12) == col2);
       REQUIRE(slice.pixel(4, 0) == col1);
     }
-    WHEN("user sets image vertical axis to x") {
+    WHEN("user sets slice to horizontal") {
       mwt.addUserAction({"Up"});
       mwt.start();
       dia.exec();
       QImage slice = dia.getSlicedImage();
-      // x vs t
       REQUIRE(slice.width() == imgs.size());
       REQUIRE(slice.height() == imgs[0].width());
+      REQUIRE(slice.pixel(1, 75) == col1);
+      REQUIRE(slice.pixel(2, 28) == col1);
+      REQUIRE(slice.pixel(3, 99) == col2);
+      REQUIRE(slice.pixel(4, 0) == col1);
+    }
+    WHEN("user sets slice to custom: default is diagonal") {
+      mwt.addUserAction({"Down"});
+      mwt.start();
+      dia.exec();
+      QImage slice = dia.getSlicedImage();
+      REQUIRE(slice.width() == imgs.size());
+      REQUIRE(slice.height() == std::max(imgs[0].height(), imgs[0].width()));
       REQUIRE(slice.pixel(1, 75) == col1);
       REQUIRE(slice.pixel(2, 28) == col1);
       REQUIRE(slice.pixel(3, 99) == col2);

--- a/src/gui/dialogs/dialogsimulationoptions_t.cpp
+++ b/src/gui/dialogs/dialogsimulationoptions_t.cpp
@@ -5,6 +5,8 @@
 #include "qt_test_utils.hpp"
 #include "simulate.hpp"
 
+#if defined(SPATIAL_MODEL_EDITOR_WITH_TBB) ||                                  \
+    defined(SPATIAL_MODEL_EDITOR_WITH_OPENMP)
 SCENARIO(
     "DialogSimulationOptions",
     "[gui/dialogs/simulationoptions][gui/dialogs][gui][simulationoptions]") {
@@ -19,6 +21,10 @@ SCENARIO(
   options.pixel.integrator = simulate::PixelIntegratorType::RK435;
   options.pixel.maxErr = {0.01, 4e-4};
   options.pixel.maxTimestep = 0.2;
+  options.pixel.enableMultiThreading = false;
+  options.pixel.maxThreads = 0;
+  options.pixel.doCSE = true;
+  options.pixel.optLevel = 3;
   DialogSimulationOptions dia(options);
   ModalWidgetTimer mwt;
   WHEN("user does nothing: unchanged") {
@@ -43,7 +49,10 @@ SCENARIO(
     REQUIRE(opt.pixel.optLevel == 3);
   }
   WHEN("user changes Dune values") {
-    mwt.addUserAction({"Tab", "Tab", "Down", "Down", "9", "Tab", ".", "4", "Tab", "1", "e", "-", "1", "2", "Tab", "9", "Tab", "1", ".", "2", "Tab", "0", ".", "7", "Tab", " "});
+    mwt.addUserAction({"Tab", "Tab", "Down", "Down", "9", "Tab", ".",
+                       "4",   "Tab", "1",    "e",    "-", "1",   "2",
+                       "Tab", "9",   "Tab",  "1",    ".", "2",   "Tab",
+                       "0",   ".",   "7",    "Tab",  " "});
     mwt.start();
     dia.exec();
     auto opt = dia.getOptions();
@@ -101,3 +110,4 @@ SCENARIO(
     REQUIRE(opt.pixel.maxThreads == defaultOpts.maxThreads);
   }
 }
+#endif

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -269,9 +269,9 @@ void TabSimulate::btnSimulate_clicked() {
 }
 
 void TabSimulate::btnSliceImage_clicked() {
-  DialogImageSlice dialog(images, time);
+  DialogImageSlice dialog(sbmlDoc.getGeometry().getImage(), images, time);
   if (dialog.exec() == QDialog::Accepted) {
-    SPDLOG_DEBUG("do something");
+    SPDLOG_DEBUG("todo: save current slice settings");
   }
 }
 

--- a/src/gui/widgets/CMakeLists.txt
+++ b/src/gui/widgets/CMakeLists.txt
@@ -1,7 +1,14 @@
-target_sources(gui PRIVATE qlabelmousetracker.cpp qplaintextmathedit.cpp)
+target_sources(
+  gui
+  PRIVATE qlabelslice.cpp
+          qlabelmousetracker.cpp
+          qplaintextmathedit.cpp)
 add_subdirectory(ext/qcustomplot)
 target_link_libraries(gui PUBLIC qcustomplot)
 target_include_directories(gui PUBLIC .)
 
-target_sources(gui_tests PUBLIC qlabelmousetracker_t.cpp
-                                qplaintextmathedit_t.cpp)
+target_sources(
+  gui_tests
+  PUBLIC qlabelslice_t.cpp
+         qlabelmousetracker_t.cpp
+         qplaintextmathedit_t.cpp)

--- a/src/gui/widgets/qlabelmousetracker.cpp
+++ b/src/gui/widgets/qlabelmousetracker.cpp
@@ -34,12 +34,6 @@ const QRgb &QLabelMouseTracker::getColour() const { return colour; }
 
 int QLabelMouseTracker::getMaskIndex() const { return maskIndex; }
 
-void QLabelMouseTracker::mouseMoveEvent(QMouseEvent *ev) {
-  if (setCurrentPixel(ev)) {
-    emit mouseOver(currentPixel);
-  }
-}
-
 void QLabelMouseTracker::mousePressEvent(QMouseEvent *ev) {
   if (ev->buttons() != Qt::NoButton) {
     if (setCurrentPixel(ev)) {
@@ -55,19 +49,32 @@ void QLabelMouseTracker::mousePressEvent(QMouseEvent *ev) {
   }
 }
 
-void QLabelMouseTracker::resizeEvent(QResizeEvent *event) {
-  if (event->oldSize() != event->size()) {
-    resizeImage(event->size());
+void QLabelMouseTracker::mouseMoveEvent(QMouseEvent *ev) {
+  if (setCurrentPixel(ev)) {
+    emit mouseOver(currentPixel);
   }
+}
+
+void QLabelMouseTracker::mouseReleaseEvent(QMouseEvent *ev) { ev->accept(); }
+
+void QLabelMouseTracker::mouseDoubleClickEvent(QMouseEvent *ev) {
+  ev->accept();
 }
 
 void QLabelMouseTracker::wheelEvent(QWheelEvent *ev) {
   emit mouseWheelEvent(ev);
 }
 
+void QLabelMouseTracker::resizeEvent(QResizeEvent *event) {
+  if (event->oldSize() != event->size()) {
+    resizeImage(event->size());
+  }
+}
+
 bool QLabelMouseTracker::setCurrentPixel(const QMouseEvent *ev) {
   if (image.isNull() || pixmap.isNull() || (ev->pos().x() >= pixmap.width()) ||
-      (ev->pos().y() >= pixmap.height())) {
+      (ev->pos().y() >= pixmap.height()) || ev->pos().x() < 0 ||
+      ev->pos().y() < 0) {
     return false;
   }
   currentPixel.setX((image.width() * ev->pos().x()) / pixmap.width());
@@ -91,7 +98,10 @@ void QLabelMouseTracker::resizeImage(const QSize &size) {
 
 void QLabelMouseTracker::setAspectRatioMode(Qt::AspectRatioMode mode) {
   aspectRatioMode = mode;
+  resizeImage(size());
 }
+
 void QLabelMouseTracker::setTransformationMode(Qt::TransformationMode mode) {
   transformationMode = mode;
+  resizeImage(size());
 }

--- a/src/gui/widgets/qlabelmousetracker_t.cpp
+++ b/src/gui/widgets/qlabelmousetracker_t.cpp
@@ -1,10 +1,9 @@
-#include <QApplication>
-#include <QDebug>
-
 #include "catch_wrapper.hpp"
 #include "logger.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
+#include <QApplication>
+#include <QDebug>
 
 SCENARIO(
     "QLabelMouseTracker",

--- a/src/gui/widgets/qlabelslice.cpp
+++ b/src/gui/widgets/qlabelslice.cpp
@@ -1,0 +1,133 @@
+#include "qlabelslice.hpp"
+
+#include "logger.hpp"
+
+QLabelSlice::QLabelSlice(QWidget *parent) : QLabel(parent) {
+  setAlignment(Qt::AlignmentFlag::AlignTop | Qt::AlignmentFlag::AlignLeft);
+  setMinimumSize(1, 1);
+  setWordWrap(true);
+}
+
+void QLabelSlice::setImage(const QImage &img) {
+  slicePixels.clear();
+  slicePixels.reserve(imgOriginal.width() + imgOriginal.height());
+  imgOriginal = img.convertToFormat(QImage::Format_RGB32);
+  imgSliced = QImage(imgOriginal.size(), QImage::Format_ARGB32);
+  fadeOriginalImage();
+  // on loading new image, set a minimum size for the widget
+  constexpr int minImageWidth{100};
+  if (this->width() < minImageWidth) {
+    this->resize(minImageWidth, minImageWidth);
+  }
+}
+
+const QImage &QLabelSlice::getImage() const { return imgSliced; }
+
+void QLabelSlice::setAspectRatioMode(Qt::AspectRatioMode mode) {
+  aspectRatioMode = mode;
+}
+void QLabelSlice::setTransformationMode(Qt::TransformationMode mode) {
+  transformationMode = mode;
+}
+
+void QLabelSlice::setSlice(const QPoint &start, const QPoint &end) {
+  slicePixels.clear();
+  fadeOriginalImage();
+  QPoint dp{end - start};
+  int norm = std::max(std::abs(dp.x()), std::abs(dp.y()));
+  QPoint diff{0, 0};
+  int np = norm + 1;
+  norm = std::max(norm, 1); // avoid dividing by zero if start == end
+  for (int i = 0; i < np; ++i) {
+    QPoint pi(start.x() + diff.x() / norm, start.y() + diff.y() / norm);
+    slicePixels.push_back(pi);
+    auto c{imgOriginal.pixel(pi)};
+    imgSliced.setPixel(pi, c);
+    diff += dp;
+  }
+  resizeImage(this->size());
+}
+
+const std::vector<QPoint> &QLabelSlice::getSlicePixels() const {
+  return slicePixels;
+}
+
+void QLabelSlice::setHorizontalSlice(int y) {
+  setSlice(QPoint(0, y), QPoint(imgOriginal.width() - 1, y));
+}
+void QLabelSlice::setVerticalSlice(int x) {
+  setSlice(QPoint(x, imgOriginal.height() - 1), QPoint(x, 0));
+}
+
+void QLabelSlice::mousePressEvent(QMouseEvent *ev) {
+  if (ev->buttons() != Qt::NoButton && setPixel(ev, startPixel)) {
+    currentPixel = startPixel;
+    mouseIsDown = true;
+    emit mouseDown(currentPixel);
+  }
+}
+
+void QLabelSlice::mouseMoveEvent(QMouseEvent *ev) {
+  if (mouseIsDown && setPixel(ev, currentPixel)) {
+    SPDLOG_TRACE("mouseDown ({},{})", currentPixel.x(), currentPixel.y());
+    emit mouseDown(currentPixel);
+  }
+}
+
+void QLabelSlice::mouseReleaseEvent(QMouseEvent *ev) {
+  if (mouseIsDown) {
+    SPDLOG_TRACE("sliceDrawn ({},{})->({},{})", startPixel.x(), startPixel.y(),
+                 currentPixel.x(), currentPixel.y());
+    emit sliceDrawn(startPixel, currentPixel);
+  }
+  ev->accept();
+  mouseIsDown = false;
+}
+
+void QLabelSlice::mouseDoubleClickEvent(QMouseEvent *ev) { ev->accept(); }
+
+void QLabelSlice::wheelEvent(QWheelEvent *ev) {
+  emit mouseWheelEvent(ev->angleDelta().y());
+}
+
+void QLabelSlice::resizeEvent(QResizeEvent *event) {
+  if (event->oldSize() != event->size()) {
+    resizeImage(event->size());
+  }
+}
+
+bool QLabelSlice::setPixel(const QMouseEvent *ev, QPoint &pixel) {
+  int x{ev->pos().x()};
+  int y{ev->pos().y()};
+  if (imgSliced.isNull() || pixmap.isNull() || (x >= pixmap.width()) ||
+      (y >= pixmap.height()) || (x < 0) || (y < 0)) {
+    return false;
+  }
+  pixel.setX((imgSliced.width() * x) / pixmap.width());
+  pixel.setY((imgSliced.height() * y) / pixmap.height());
+  SPDLOG_TRACE("mouse at ({},{}) -> pixel ({},{})", x, y, pixel.x(), pixel.y());
+  return true;
+}
+
+void QLabelSlice::fadeOriginalImage() {
+  constexpr int transparencyAlpha{50};
+  for (int x = 0; x < imgOriginal.width(); ++x) {
+    for (int y = 0; y < imgOriginal.height(); ++y) {
+      auto c{imgOriginal.pixel(x, y)};
+      auto cFaded{qRgba(qRed(c), qGreen(c), qBlue(c), transparencyAlpha)};
+      imgSliced.setPixel(x, y, cFaded);
+    }
+  }
+}
+
+void QLabelSlice::resizeImage(const QSize &size) {
+  if (imgSliced.isNull()) {
+    this->clear();
+    return;
+  }
+  pixmap = QPixmap::fromImage(
+      imgSliced.scaled(size, aspectRatioMode, transformationMode));
+  SPDLOG_DEBUG("resize -> {}x{}, pixmap -> {}x{}", size.width(), size.height(),
+               pixmap.size().width(), pixmap.size().height());
+  this->setPixmap(pixmap);
+}

--- a/src/gui/widgets/qlabelslice.hpp
+++ b/src/gui/widgets/qlabelslice.hpp
@@ -1,4 +1,4 @@
-// QLabelMouseTracker
+// QLabelSlice
 //  - a modified QLabel
 //  - displays (and rescales without interpolation) an image,
 //  - tracks the mouse location in terms of the pixels of the original image
@@ -10,29 +10,25 @@
 
 #include <QLabel>
 #include <QMouseEvent>
+#include <vector>
 
-class QLabelMouseTracker : public QLabel {
+class QLabelSlice : public QLabel {
   Q_OBJECT
 public:
-  explicit QLabelMouseTracker(QWidget *parent = nullptr);
-  // QImage used for pixel location and colour
+  explicit QLabelSlice(QWidget *parent = nullptr);
   void setImage(const QImage &img);
   const QImage &getImage() const;
-  // QImage mask used to translate pixel location to index
-  void setMaskImage(const QImage &img);
-  const QImage &getMaskImage() const;
-  void setImages(const std::pair<QImage, QImage> &imgPair);
-  // colour of pixel at last mouse click position
-  const QRgb &getColour() const;
-  // value of mask index at last mouse click position
-  int getMaskIndex() const;
   void setAspectRatioMode(Qt::AspectRatioMode aspectRatioMode);
   void setTransformationMode(Qt::TransformationMode transformationMode);
+  void setSlice(const QPoint &start, const QPoint &end);
+  const std::vector<QPoint> &getSlicePixels() const;
+  void setHorizontalSlice(int y);
+  void setVerticalSlice(int x);
 
 signals:
-  void mouseClicked(QRgb col, QPoint point);
-  void mouseOver(QPoint point);
-  void mouseWheelEvent(QWheelEvent *ev);
+  void sliceDrawn(QPoint start, QPoint end);
+  void mouseDown(QPoint point);
+  void mouseWheelEvent(int delta);
 
 protected:
   void mousePressEvent(QMouseEvent *ev) override;
@@ -43,16 +39,16 @@ protected:
   void resizeEvent(QResizeEvent *ev) override;
 
 private:
+  std::vector<QPoint> slicePixels;
+  QImage imgOriginal;
+  QImage imgSliced;
+  QPixmap pixmap;
+  QPoint startPixel;
+  QPoint currentPixel;
   Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio;
   Qt::TransformationMode transformationMode = Qt::FastTransformation;
-  // (x,y) location of current pixel
-  bool setCurrentPixel(const QMouseEvent *ev);
+  bool mouseIsDown{false};
+  bool setPixel(const QMouseEvent *ev, QPoint &pixel);
+  void fadeOriginalImage();
   void resizeImage(const QSize &size);
-  QImage image;
-  // Pixmap used to display scaled version of image
-  QPixmap pixmap;
-  QImage maskImage;
-  QPoint currentPixel;
-  QRgb colour{};
-  int maskIndex{};
 };

--- a/src/gui/widgets/qlabelslice_t.cpp
+++ b/src/gui/widgets/qlabelslice_t.cpp
@@ -1,0 +1,133 @@
+#include "catch_wrapper.hpp"
+#include "logger.hpp"
+#include "qlabelslice.hpp"
+#include "qt_test_utils.hpp"
+#include <QApplication>
+#include <QDebug>
+#include <QObject>
+#include <vector>
+
+SCENARIO("QLabelSlice",
+         "[gui/widgets/qlabelslice][gui/widgets][gui][qlabelslice]") {
+  GIVEN("10x5 image") {
+    QLabelSlice lblSlice;
+
+    std::vector<QPoint> mouseDownPoints;
+    std::vector<std::pair<QPoint, QPoint>> slices;
+    QObject::connect(
+        &lblSlice, &QLabelSlice::mouseDown,
+        [&mouseDownPoints](QPoint p) { mouseDownPoints.push_back(p); });
+    QObject::connect(&lblSlice, &QLabelSlice::sliceDrawn,
+                     [&slices](QPoint start, QPoint end) {
+                       slices.push_back({start, end});
+                     });
+    QImage img(10, 5, QImage::Format_RGB32);
+    img.fill(qRgb(12, 66, 99));
+    lblSlice.setAspectRatioMode(Qt::AspectRatioMode::IgnoreAspectRatio);
+    lblSlice.setTransformationMode(Qt::TransformationMode::FastTransformation);
+    lblSlice.show();
+    lblSlice.resize(100, 100);
+    // NB: window managers might interfere with above resizing
+    // so wait a bit until the size is correct and stable
+    wait();
+    lblSlice.setImage(img);
+
+    // no initial slice set
+    REQUIRE(lblSlice.getSlicePixels().empty());
+    REQUIRE(lblSlice.getImage().size() == img.size());
+    // all pixels partially transparent
+    for (int x = 0; x < img.width(); ++x) {
+      for (int y = 0; y < img.height(); ++y) {
+        REQUIRE(qAlpha(lblSlice.getImage().pixel(x, y)) < 255);
+      }
+    }
+
+    // set horizontal slice
+    lblSlice.setHorizontalSlice(2);
+    REQUIRE(lblSlice.getSlicePixels().size() ==
+            static_cast<std::size_t>(img.width()));
+    for (int x = 0; x < img.width(); ++x) {
+      auto p = lblSlice.getSlicePixels()[static_cast<std::size_t>(x)];
+      REQUIRE(p == QPoint(x, 2));
+      // slice pixels not transparent
+      REQUIRE(qAlpha(lblSlice.getImage().pixel(p)) == 255);
+    }
+    for (int x = 0; x < img.width(); ++x) {
+      for (int y = 0; y < img.height(); ++y) {
+        if (y != 2) {
+          REQUIRE(qAlpha(lblSlice.getImage().pixel(x, y)) < 255);
+        }
+      }
+    }
+
+    // click
+    REQUIRE(mouseDownPoints.empty());
+    REQUIRE(slices.empty());
+    sendMouseClick(&lblSlice, {32, 62});
+    REQUIRE(mouseDownPoints.size() == 1);
+    REQUIRE(mouseDownPoints.back() == QPoint(3, 3));
+    REQUIRE(slices.size() == 1);
+    REQUIRE(slices.back() == std::pair<QPoint, QPoint>{{3, 3}, {3, 3}});
+    sendMouseClick(&lblSlice, {42, 62});
+    REQUIRE(mouseDownPoints.size() == 2);
+    REQUIRE(mouseDownPoints.back() == QPoint(4, 3));
+    REQUIRE(slices.size() == 2);
+    REQUIRE(slices.back() == std::pair<QPoint, QPoint>{{4, 3}, {4, 3}});
+
+    // click and drag
+    sendMouseDrag(&lblSlice, {42, 62}, {82, 93});
+    REQUIRE(slices.size() == 3);
+    REQUIRE(slices.back() == std::pair<QPoint, QPoint>{{4, 3}, {8, 4}});
+    sendMouseDrag(&lblSlice, {82, 93}, {42, 62});
+    REQUIRE(slices.size() == 4);
+    REQUIRE(slices.back() == std::pair<QPoint, QPoint>{{8, 4}, {4, 3}});
+
+    // set vertical slice
+    lblSlice.setVerticalSlice(3);
+    REQUIRE(lblSlice.getSlicePixels().size() ==
+            static_cast<std::size_t>(img.height()));
+    for (int y = 0; y < img.height(); ++y) {
+      auto p = lblSlice.getSlicePixels()[static_cast<std::size_t>(y)];
+      REQUIRE(p == QPoint(3, img.height() - 1 - y));
+      // slice pixels not transparent
+      REQUIRE(qAlpha(lblSlice.getImage().pixel(p)) == 255);
+    }
+    for (int x = 0; x < img.width(); ++x) {
+      if (x != 3) {
+        for (int y = 0; y < img.height(); ++y) {
+          REQUIRE(qAlpha(lblSlice.getImage().pixel(x, y)) < 255);
+        }
+      }
+    }
+
+    // set diagonal slice
+    lblSlice.setSlice({0, 0}, {9, 4});
+    std::vector<QPoint> pixels{{0, 0}, {1, 0}, {2, 0}, {3, 1}, {4, 1},
+                               {5, 2}, {6, 2}, {7, 3}, {8, 3}, {9, 4}};
+    REQUIRE(lblSlice.getSlicePixels().size() == pixels.size());
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+      auto p = lblSlice.getSlicePixels()[i];
+      REQUIRE(p == pixels[i]);
+      // slice pixels not transparent
+      REQUIRE(qAlpha(lblSlice.getImage().pixel(p)) == 255);
+    }
+
+    // set reverse diagonal slice
+    pixels = {{9, 4}, {8, 4}, {7, 4}, {6, 3}, {5, 3},
+              {4, 2}, {3, 2}, {2, 1}, {1, 1}, {0, 0}};
+    lblSlice.setSlice({9, 4}, {0, 0});
+    REQUIRE(lblSlice.getSlicePixels().size() == pixels.size());
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+      auto p = lblSlice.getSlicePixels()[i];
+      REQUIRE(p == pixels[i]);
+      // slice pixels not transparent
+      REQUIRE(qAlpha(lblSlice.getImage().pixel(p)) == 255);
+    }
+
+    // set single pixel slice
+    lblSlice.setSlice({5, 3}, {5, 3});
+    REQUIRE(lblSlice.getSlicePixels().size() == 1);
+    REQUIRE(lblSlice.getSlicePixels()[0] == QPoint(5, 3));
+    REQUIRE(qAlpha(lblSlice.getImage().pixel(5, 3)) == 255);
+  }
+}

--- a/test/test_utils/qt_test_utils.hpp
+++ b/test/test_utils/qt_test_utils.hpp
@@ -10,8 +10,6 @@
 #include <queue>
 #include <utility>
 
-class QWidget;
-
 // delay in ms to insert between key events
 const int keyDelay = 0;
 // delay in ms to insert between mouse events
@@ -27,9 +25,21 @@ void sendKeyEvents(QObject *object, const QStringList &keySeqStrings,
 QString sendKeyEventsToNextQDialog(const QStringList &keySeqStrings,
                                    bool sendReleaseEvents = true);
 
-void sendMouseMove(QWidget *widget, const QPoint &location = {});
+void sendMouseMove(QWidget *widget, const QPoint &pos = {},
+                   Qt::MouseButton button = Qt::MouseButton::NoButton);
 
-void sendMouseClick(QWidget *widget, const QPoint &location = {});
+void sendMousePress(QWidget *widget, const QPoint &pos = {},
+                    Qt::MouseButton button = Qt::MouseButton::NoButton);
+
+void sendMouseRelease(QWidget *widget, const QPoint &pos = {},
+                      Qt::MouseButton button = Qt::MouseButton::NoButton);
+
+void sendMouseClick(QWidget *widget, const QPoint &pos = {},
+                    Qt::MouseButton button = Qt::MouseButton::LeftButton);
+
+void sendMouseDrag(QWidget *widget, const QPoint &startPos,
+                   const QPoint &endPos,
+                   Qt::MouseButton button = Qt::MouseButton::LeftButton);
 
 // timer class that repeatedly checks for an active modal widget
 // (a modal widget blocks execution pending user input, e.g. a message box)


### PR DESCRIPTION
  - user can set any (straight line) slice, not just horizontal/vertical
  - geometry now also shown with the current slice highlighted
  - click / spin mouse wheel to set horizontal/vertical slice position
  - click & drag to set custom slice line
  - maintain aspect ratio / smooth interpolation checkboxes
  - [TODO] tests
  - [TODO] consistent horizontal vs custom slice for same start/end points
  - [TODO] physical units for mouse-over location
  - resolves #266

add QLabelSlice widget
  - displays image, with slice pixels highlighted
  - slice can be horizontal, vertical, or line between two points
  - provides a vector of the pixels that make up the slice
  - mouseDown() event returns pixel location of mouse
  - sliceDrawn() event returns start & end pixels of mouse click & drag