### PR TITLE
fix dune crash if model has no reacting species

### DIFF
--- a/src/core/simulate/src/CMakeLists.txt
+++ b/src/core/simulate/src/CMakeLists.txt
@@ -20,5 +20,6 @@ target_sources(
          dunefunction_t.cpp
          dunegrid_t.cpp
          duneini_t.cpp
+         dunesim_t.cpp
          pde_t.cpp
          simulate_t.cpp)

--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -172,10 +172,14 @@ DuneConverter::DuneConverter(const model::Model &model, bool forExternalUse,
   std::vector<IniFile> inis;
   if (independentCompartments) {
     // create independent ini file for each compartment
-    for (const auto &name : model.getCompartments().getNames()) {
-      auto fname{QString("%1_%2.ini").arg(baseIniFile).arg(name)};
-      iniFilenames.push_back(QDir(iniFileDir).filePath(fname));
-      inis.push_back(iniCommon);
+    for (const auto &comp : model.getCompartments().getIds()) {
+      // skip compartments which contain no non-constant species
+      if (compartmentContainsNonConstantSpecies(model, comp)) {
+        const auto &name = model.getCompartments().getName(comp);
+        auto fname{QString("%1_%2.ini").arg(baseIniFile).arg(name)};
+        iniFilenames.push_back(QDir(iniFileDir).filePath(fname));
+        inis.push_back(iniCommon);
+      }
     }
   } else {
     // single ini file for model

--- a/src/core/simulate/src/dunesim.cpp
+++ b/src/core/simulate/src/dunesim.cpp
@@ -195,6 +195,12 @@ DuneSim::DuneSim(
         "Invalid integrator type requested - using 1st order FEM instead");
     options.discretization = DuneDiscretizationType::FEM1;
   }
+  if (dc.getIniFiles().empty()) {
+    currentErrorMessage =
+        "Nothing to simulate: no non-constant species in model";
+    SPDLOG_WARN("{}", currentErrorMessage);
+    return;
+  }
   try {
     if (dc.hasIndependentCompartments()) {
       pDuneImpl = std::make_unique<DuneImplIndependent<1>>(dc, options);

--- a/src/core/simulate/src/dunesim_t.cpp
+++ b/src/core/simulate/src/dunesim_t.cpp
@@ -1,0 +1,22 @@
+#include "catch_wrapper.hpp"
+#include "dunesim.hpp"
+#include "model.hpp"
+#include "utils.hpp"
+#include <QFile>
+
+SCENARIO("DuneSim: model without species",
+         "[core/simulate/dunesim][core/simulate][core][simulate][dunesim]") {
+  model::Model m;
+  QFile f(":/models/ABtoC.xml");
+  f.open(QIODevice::ReadOnly);
+  m.importSBMLString(f.readAll().toStdString());
+  for (const auto &speciesId : m.getSpecies().getIds("comp")) {
+    m.getSpecies().remove(speciesId);
+  }
+  std::vector<std::string> comps{"comp"};
+  std::vector<std::vector<std::string>> species;
+  species.emplace_back();
+  simulate::DuneSim duneSim(m, comps, species);
+  REQUIRE(duneSim.errorMessage() ==
+          "Nothing to simulate: no non-constant species in model");
+}

--- a/src/core/simulate/src/simulate_t.cpp
+++ b/src/core/simulate/src/simulate_t.cpp
@@ -523,25 +523,4 @@ SCENARIO("DUNE: simulation",
     duneSim.doTimestep(0.01);
     REQUIRE(duneSim.errorMessage().empty());
   }
-  /*
-  // too slow in debug mode:
-  GIVEN("brusselator-model, too large timestep") {
-    sbml::SbmlDocWrapper s;
-    if (QFile f(":/models/brusselator-model.xml");
-        f.open(QIODevice::ReadOnly)) {
-      s.importSBMLString(f.readAll().toStdString());
-    }
-    for (auto order : {std::size_t{1}, std::size_t{2}}) {
-      simulate::Simulation duneSim(s, simulate::SimulatorType::DUNE, order);
-      auto options = duneSim.getIntegratorOptions();
-      options.maxTimestep = 50.0;
-      duneSim.setIntegratorOptions(options);
-      // DUNE simulation will fail, but Simulation wrapper should catch
-      // exception...
-      REQUIRE_NOTHROW(duneSim.doTimestep(500.0));
-      // and put the error message here:
-      REQUIRE(!duneSim.errorMessage().empty());
-    }
-  }
-  */
 }


### PR DESCRIPTION
  - only create dune ini file if model has reacting species
  - in dunesim constructor, if no ini file provided: set error message and don't construct model