### PR TITLE
Don't simulate if Simulation::errorMessage() is not empty

### DIFF
--- a/src/core/simulate/src/simulate.cpp
+++ b/src/core/simulate/src/simulate.cpp
@@ -93,7 +93,9 @@ Simulation::Simulation(const model::Model &sbmlDoc, SimulatorType simType,
     simulator = std::make_unique<PixelSim>(
         sbmlDoc, compartmentIds, compartmentSpeciesIds, options.pixel);
   }
-  updateConcentrations(0);
+  if (simulator->errorMessage().empty()) {
+    updateConcentrations(0);
+  }
 }
 
 Simulation::~Simulation() = default;
@@ -105,7 +107,7 @@ std::size_t Simulation::doTimestep(double time) {
   return steps;
 }
 
-const std::string& Simulation::errorMessage() const {
+const std::string &Simulation::errorMessage() const {
   return simulator->errorMessage();
 }
 

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -82,6 +82,15 @@ void TabSimulate::loadModelData() {
     return;
   }
   sim = std::make_unique<simulate::Simulation>(sbmlDoc, simType, simOptions);
+  if (!sim->errorMessage().empty()) {
+    QMessageBox::warning(
+        this, "Simulation Setup Failed",
+        QString("Simulation setup failed.\n\nError message: %1")
+            .arg(sim->errorMessage().c_str()));
+    ui->btnSimulate->setEnabled(false);
+    return;
+  }
+
   ui->btnSimulate->setEnabled(true);
 
   // setup species names


### PR DESCRIPTION
  - in TabSimulate:
    - after constructing Simulation
    - if there is an error message, show message & disable simulate button
  - In Simulation constructor:
    - after constructing PixelSim or DuneSim
    - if there is an error message, don't call updateConcentrations()
  - in PixelSim constructor
    - catch std::runtime_error and set errorMessage
    - this can occur if SymEngine llvm compilation throws
  - resolves #298