### PR TITLE
improve import of non-spatial reactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ branches:
 env:
   global:
     # python wheel building can (and should) be disabled to speed up CI when working on a PR
-    - BUILD_PYTHON_WHEELS=false
+    - BUILD_PYTHON_WHEELS=true
     - MSYS_URL='https://github.com/msys2/msys2-installer/releases/download/2020-09-03/msys2-base-x86_64-20200903.sfx.exe'
-    - CIBUILDWHEEL_VERSION=1.5.5
+    - CIBUILDWHEEL_VERSION=1.6.1
     # pypi TWINE_PASSWORD
     - secure: GFBxgbwP75qb0QW3jFO3e3fbfFLpYue+kUZGm3ArNZ9ExeXPGU3fxfxiBolEPnnPK98VlZZ8R0WBQptvWnaBN0tamt5r7OCXljQdpNgRF04MMa1gtbAEnuYjd6dHQ5CbdiEKxK4MnF28jJ+0wnw35E7YPGq357XWKwGFoG0HT9UenFd7HRbzsM0WmO7sog8bZYahYU+nyIDu6AVGlsc1b4XpVEu/pcuY2PexzYpV4wv+qVprRIeTwi2aFb4bmr3XcPZtyps3eiExLISHmz3mAuHIiNEt3wQA7Kjzsz93lm6DlGi3LSEXugfomGzg3oyHQC8oKKky/D6hHqnc9Jfow4Epj3aHvE4LP00TxDiyrjqvVGeCHa/RL/WIGJ/zZA4W7QTr2wvDOhw5EOuSmIW42tmOsOV4Zo/wr5d9A0r0VUfHhrsi1QUHmFFgTJXeTDyHYC32mvXy8EuaxLRFLBUVKE3gPfaYUgRafvx1Kn7H9WUmrpA7JAj2caMYD6UtKly1J6BFyTpPFlGgk3yxzVYgbeToOOrabQzGzYBuaxz6aysbyPra+rYF5SrJ/Dp4TPjfoE/1IIjmrbVpYEQGdfojnxxN6xnW7woPgq8IUDStw7iR83xyluWEtn1i1KlzRA8NMNdBHxgFWQ9rpE/DZikeJ8yb0FoEleMRjaE6G4C33rc=
 
@@ -121,7 +121,7 @@ jobs:
       script:
         - mkdir build
         - cd build
-        - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DSME_WITH_TBB=ON
+        - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DSME_WITH_TBB=ON -DSME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM=ON
         - make -j2 VERBOSE=1
         # run non-gui c++ tests
         - ./test/tests -as "~[gui]" > tests.txt 2>&1
@@ -186,7 +186,7 @@ jobs:
       services:
         - docker
       env:
-        - DOCKER_IMAGE=lkeegan/sme_manylinux1_x86_64:2020.09.08
+        - DOCKER_IMAGE=lkeegan/sme_manylinux1_x86_64:2020.09.23
       install:
         - docker pull $DOCKER_IMAGE
       before_script:
@@ -211,7 +211,7 @@ jobs:
       services:
         - docker
       env:
-        - DOCKER_IMAGE=lkeegan/sme_manylinux2010_x86_64:2020.09.08
+        - DOCKER_IMAGE=lkeegan/sme_manylinux2010_x86_64:2020.09.23
       install:
         - docker pull $DOCKER_IMAGE
       before_script:
@@ -254,6 +254,7 @@ jobs:
       script:
         - ccache -s
         - export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+        - export SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM="on"
         - export CMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune"
         - python3 -m cibuildwheel --output-dir dist
         - ccache -s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 0.9.1
+  VERSION 0.9.2
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES CXX)
 

--- a/cmake/Finddunecopasi.cmake
+++ b/cmake/Finddunecopasi.cmake
@@ -48,10 +48,4 @@ if(dunecopasi_FOUND
               ENABLE_UG=1
               MUPARSER_STATIC
               UG_USE_NEW_DIMENSION_DEFINES)
-
-  if(APPLE)
-    target_compile_definitions(dunecopasi::dunecopasi
-                               INTERFACE DUNE_COPASI_USE_FALLBACK_FILESYSTEM)
-  endif()
-
 endif()

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ class CMakeBuild(build_ext):
             "SME_EXTRA_EXE_LIBS",
             "PYTHON_LIBRARY",
             "CMAKE_CXX_COMPILER_LAUNCHER",
+            "SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM",
         ]:
             try:
                 cmake_args += ["-D" + e + "=" + os.environ.get(e)]
@@ -88,7 +89,7 @@ with open(path.join(sme_directory, "README.md")) as f:
 
 setup(
     name="sme",
-    version="0.9.1",
+    version="0.9.2",
     author="Liam Keegan",
     author_email="liam@keegan.ch",
     description="Spatial Model Editor python bindings",
@@ -117,6 +118,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,8 +9,7 @@ find_package(
 message(STATUS "Found SymEngine library: ")
 message(STATUS "Testing SymEngine LLVM support")
 try_compile(
-  SYMENGINE_LLVM
-  "${CMAKE_CURRENT_BINARY_DIR}/cxx"
+  SYMENGINE_LLVM "${CMAKE_CURRENT_BINARY_DIR}/cxx"
   "${CMAKE_SOURCE_DIR}/cmake/checkSymEngineLLVM.cpp"
   CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${SYMENGINE_INCLUDE_DIRS}
   LINK_LIBRARIES ${SYMENGINE_LIBRARIES}
@@ -29,8 +28,7 @@ endif()
 find_package(sbml-static REQUIRED)
 message(STATUS "Testing libSBML spatial extension support")
 try_compile(
-  SBML_SPATIAL
-  "${CMAKE_CURRENT_BINARY_DIR}/cxx"
+  SBML_SPATIAL "${CMAKE_CURRENT_BINARY_DIR}/cxx"
   "${CMAKE_SOURCE_DIR}/cmake/checkSpatialSBML.cpp"
   LINK_LIBRARIES sbml-static
   OUTPUT_VARIABLE SBML_SPATIAL_ERROR_LOG)
@@ -54,6 +52,18 @@ find_package(fmt REQUIRED)
 find_package(dunecopasi REQUIRED)
 # dune-logging depends on fmt: temporary hack
 target_link_libraries(dunecopasi::dunecopasi INTERFACE fmt::fmt)
+# dune-copasi may use fallback filesystem implementation
+set(SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM
+    no
+    CACHE
+      BOOL
+      "enable if dune-copasi is built using fallback filesystem implementation")
+if(SME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM)
+  message(STATUS "using DUNE_COPASI_USE_FALLBACK_FILESYSTEM")
+  target_compile_definitions(dunecopasi::dunecopasi
+                             INTERFACE DUNE_COPASI_USE_FALLBACK_FILESYSTEM)
+endif()
+
 find_package(muparser REQUIRED)
 if(SME_WITH_TBB)
   find_package(tbb REQUIRED)

--- a/src/core/model/inc/model_compartments.hpp
+++ b/src/core/model/inc/model_compartments.hpp
@@ -19,6 +19,7 @@ namespace model {
 class ModelGeometry;
 class ModelMembranes;
 class ModelSpecies;
+class ModelReactions;
 
 class ModelCompartments {
 private:
@@ -30,11 +31,13 @@ private:
   ModelGeometry *modelGeometry = nullptr;
   ModelMembranes *modelMembranes = nullptr;
   ModelSpecies *modelSpecies = nullptr;
+  ModelReactions *modelReactions = nullptr;
 
 public:
   ModelCompartments();
   ModelCompartments(libsbml::Model *model, ModelGeometry *geometry,
-                    ModelMembranes *membranes, ModelSpecies *species);
+                    ModelMembranes *membranes, ModelSpecies *species,
+                    ModelReactions *reactions);
   const QStringList &getIds() const;
   const QStringList &getNames() const;
   const QVector<QRgb> &getColours() const;

--- a/src/core/model/inc/model_reactions.hpp
+++ b/src/core/model/inc/model_reactions.hpp
@@ -30,6 +30,7 @@ public:
   ModelReactions();
   explicit ModelReactions(libsbml::Model *model,
                           const std::vector<geometry::Membrane> &membranes);
+  void makeReactionsSpatial(const std::vector<geometry::Membrane> &membranes);
   QStringList getIds(const QString &locationId) const;
   QString add(const QString &name, const QString &locationId,
               const QString &rateExpression = "1");

--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -61,8 +61,8 @@ void Model::initModelData() {
   modelMembranes.clear();
   // todo: reduce these cyclic dependencies: currently order of initialization
   // matters, should be possible to reduce coupling here
-  modelCompartments =
-      ModelCompartments(model, &modelGeometry, &modelMembranes, &modelSpecies);
+  modelCompartments = ModelCompartments(model, &modelGeometry, &modelMembranes,
+                                        &modelSpecies, &modelReactions);
   modelGeometry = ModelGeometry(model, &modelCompartments, &modelMembranes);
   modelGeometry.importSampledFieldGeometry(model);
   modelGeometry.importParametricGeometry(model);

--- a/src/core/model/src/model_compartments.cpp
+++ b/src/core/model/src/model_compartments.cpp
@@ -4,6 +4,7 @@
 #include "logger.hpp"
 #include "model_geometry.hpp"
 #include "model_membranes.hpp"
+#include "model_reactions.hpp"
 #include "model_species.hpp"
 #include "sbml_utils.hpp"
 #include <optional>
@@ -70,10 +71,11 @@ ModelCompartments::ModelCompartments() = default;
 ModelCompartments::ModelCompartments(libsbml::Model *model,
                                      ModelGeometry *geometry,
                                      ModelMembranes *membranes,
-                                     ModelSpecies *species)
+                                     ModelSpecies *species,
+                                     ModelReactions *reactions)
     : ids{importIds(model)}, names{importNamesAndMakeUnique(model, ids)},
       sbmlModel{model}, modelGeometry{geometry}, modelMembranes{membranes},
-      modelSpecies{species} {
+      modelSpecies{species}, modelReactions{reactions} {
   makeSizesValid(model);
   colours = QVector<QRgb>(ids.size(), 0);
   compartments.reserve(static_cast<std::size_t>(ids.size()));
@@ -456,8 +458,7 @@ void ModelCompartments::setColour(const QString &id, QRgb colour) {
       findAllInteriorPoints(modelGeometry->getImage(), colour);
   setInteriorPoints(id, interiorPoints);
   modelGeometry->checkIfGeometryIsValid();
-
-  // todo: update reactions?
+  modelReactions->makeReactionsSpatial(modelMembranes->getMembranes());
 }
 
 QRgb ModelCompartments::getColour(const QString &id) const {

--- a/src/core/model/src/model_geometry_t.cpp
+++ b/src/core/model/src/model_geometry_t.cpp
@@ -35,8 +35,10 @@ SCENARIO("Model geometry",
     model::ModelMembranes mMembranes;
     model::ModelGeometry mGeometry;
     model::ModelSpecies mSpecies;
-    mCompartments = model::ModelCompartments(doc->getModel(), &mGeometry,
-                                             &mMembranes, &mSpecies);
+    model::ModelReactions mReactions(doc->getModel(),
+                                     mMembranes.getMembranes());
+    mCompartments = model::ModelCompartments(
+        doc->getModel(), &mGeometry, &mMembranes, &mSpecies, &mReactions);
     mGeometry =
         model::ModelGeometry(doc->getModel(), &mCompartments, &mMembranes);
     auto &m = mGeometry;
@@ -47,8 +49,6 @@ SCENARIO("Model geometry",
 
     mGeometry.importSampledFieldGeometry(doc->getModel());
     model::ModelParameters mParameters(doc->getModel());
-    model::ModelReactions mReactions(doc->getModel(),
-                                     mMembranes.getMembranes());
     mSpecies = model::ModelSpecies(doc->getModel(), &mCompartments, &mGeometry,
                                    &mParameters, &mReactions);
     REQUIRE(m.getIsValid() == true);


### PR DESCRIPTION
  - change makeReactionsSpatial() behaviour
    - if the reaction involves species from two compartments, i.e. membrane reaction
    - and the membrane exists, set it as the reaction compartment & set `isLocal` to true
    - if membrane not found, don't set `isLocal` to true for this reaction
  - when a compartment colour is set, call makeReactionsSpatial() again
    - if the membrane now exists, it sets `isLocal` to true
  - resolves #297
