### PR TITLE
dune ini file update

### DIFF
--- a/src/core/simulate/src/duneconverter.cpp
+++ b/src/core/simulate/src/duneconverter.cpp
@@ -95,6 +95,7 @@ static void addGrid(IniFile &ini) {
   ini.addSection("grid");
   ini.addValue("file", "grid.msh");
   ini.addValue("initial_level", 0);
+  ini.addValue("dimension", 2);
 }
 
 static void addModel(IniFile &ini) {

--- a/src/core/simulate/src/duneconverter_t.cpp
+++ b/src/core/simulate/src/duneconverter_t.cpp
@@ -19,6 +19,10 @@ SCENARIO("DUNE: DuneConverter",
     simulate::DuneConverter dc(s, true, opt, {}, 14);
     QStringList ini = dc.getIniFile().split("\n");
     auto line = ini.cbegin();
+    REQUIRE(*line++ == "[grid]");
+    REQUIRE(*line++ == "file = grid.msh");
+    REQUIRE(*line++ == "initial_level = 0");
+    REQUIRE(*line++ == "dimension = 2");
     while (line != ini.cend() && *line != "[model.compartments]") {
       ++line;
     }


### PR DESCRIPTION
  - latest dune-copasi executables require grid.dimension to be specified in ini file
  - note: only relevant when exporting dune ini file, doesn't affect GUI simulation
