### PR TITLE
add more image concentration normalisation options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
 env:
   global:
     # python wheel building can (and should) be disabled to speed up CI when working on a PR
-    - BUILD_PYTHON_WHEELS=true
+    - BUILD_PYTHON_WHEELS=false
     - MSYS_URL='https://github.com/msys2/msys2-installer/releases/download/2020-09-03/msys2-base-x86_64-20200903.sfx.exe'
     - CIBUILDWHEEL_VERSION=1.6.1
     # pypi TWINE_PASSWORD

--- a/src/core/simulate/inc/simulate.hpp
+++ b/src/core/simulate/inc/simulate.hpp
@@ -81,7 +81,8 @@ public:
   QImage
   getConcImage(std::size_t timeIndex,
                const std::vector<std::vector<std::size_t>> &speciesToDraw = {},
-               bool normaliseOverWholeSim = false) const;
+               bool normaliseOverAllTimepoints = false,
+               bool normaliseOverAllSpecies = false) const;
   // map from name to vec<vec<double>> species concentration for python bindings
   std::map<std::string, std::vector<std::vector<double>>>
   getPyConcs(std::size_t timeIndex) const;

--- a/src/core/simulate/src/simulate.cpp
+++ b/src/core/simulate/src/simulate.cpp
@@ -166,7 +166,7 @@ double Simulation::getLowerOrderConc(std::size_t compartmentIndex,
 QImage Simulation::getConcImage(
     std::size_t timeIndex,
     const std::vector<std::vector<std::size_t>> &speciesToDraw,
-    bool normaliseOverWholeSim) const {
+    bool normaliseOverAllTimepoints, bool normaliseOverAllSpecies) const {
   if (compartments.empty()) {
     return QImage();
   }
@@ -187,7 +187,7 @@ QImage Simulation::getConcImage(
     // max value of each species = max colour intensity
     // (with lower bound, so constant zero is still zero)
     std::vector<double> maxConcs(compartmentSpeciesIds[compIndex].size(), 1.0);
-    if (normaliseOverWholeSim) {
+    if (normaliseOverAllTimepoints) {
       maxConcs = maxConcWholeSimulation[compIndex];
     } else {
       for (std::size_t is : (*speciesIndices)[compIndex]) {
@@ -195,6 +195,10 @@ QImage Simulation::getConcImage(
         constexpr double minimumNonzeroConc{1e-30};
         maxConcs[is] = m > minimumNonzeroConc ? m : 1.0;
       }
+    }
+    if (normaliseOverAllSpecies) {
+      double maxConc{utils::max(maxConcs)};
+      std::fill(maxConcs.begin(), maxConcs.end(), maxConc);
     }
     for (std::size_t ix = 0; ix < pixels.size(); ++ix) {
       const QPoint &p = pixels[ix];

--- a/src/gui/dialogs/dialogdisplayoptions.cpp
+++ b/src/gui/dialogs/dialogdisplayoptions.cpp
@@ -2,7 +2,7 @@
 
 #include "ui_dialogdisplayoptions.h"
 
-static void checkItem(QTreeWidgetItem* item, bool isChecked) {
+static void checkItem(QTreeWidgetItem *item, bool isChecked) {
   if (isChecked) {
     item->setCheckState(0, Qt::CheckState::Checked);
   } else {
@@ -10,27 +10,41 @@ static void checkItem(QTreeWidgetItem* item, bool isChecked) {
   }
 }
 
+static int boolToIndex(bool value) {
+  if (value) {
+    return 1;
+  }
+  return 0;
+}
+
+static bool indexToBool(int value) {
+  if (value == 1) {
+    return true;
+  }
+  return false;
+}
+
 DialogDisplayOptions::DialogDisplayOptions(
-    const QStringList& compartmentNames,
-    const std::vector<QStringList>& speciesNames,
-    const std::vector<bool>& showSpecies, bool showMinMax, int normalisation,
-    QWidget* parent)
-    : QDialog(parent),
-      ui{std::make_unique<Ui::DialogDisplayOptions>()},
+    const QStringList &compartmentNames,
+    const std::vector<QStringList> &speciesNames,
+    const std::vector<bool> &showSpecies, bool showMinMax,
+    bool normaliseOverAllTimepoints, bool normaliseOverAllSpecies,
+    QWidget *parent)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogDisplayOptions>()},
       nSpecies(showSpecies.size()) {
   ui->setupUi(this);
 
-  auto* ls = ui->listSpecies;
+  auto *ls = ui->listSpecies;
   ls->clear();
   auto iterChecked = showSpecies.cbegin();
   for (int iComp = 0; iComp < compartmentNames.size(); ++iComp) {
-    QTreeWidgetItem* comp = new QTreeWidgetItem(ls, {compartmentNames[iComp]});
+    QTreeWidgetItem *comp = new QTreeWidgetItem(ls, {compartmentNames[iComp]});
     comp->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
                    Qt::ItemIsEnabled | Qt::ItemIsAutoTristate);
     ui->listSpecies->addTopLevelItem(comp);
-    for (const auto& speciesName :
+    for (const auto &speciesName :
          speciesNames[static_cast<std::size_t>(iComp)]) {
-      QTreeWidgetItem* spec =
+      QTreeWidgetItem *spec =
           new QTreeWidgetItem(comp, QStringList({speciesName}));
       spec->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
                      Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
@@ -41,7 +55,10 @@ DialogDisplayOptions::DialogDisplayOptions(
   }
   ls->expandAll();
   ui->chkShowMinMaxRanges->setChecked(showMinMax);
-  ui->cmbNormalisation->setCurrentIndex(normalisation);
+  ui->cmbNormaliseOverAllTimepoints->setCurrentIndex(
+      boolToIndex(normaliseOverAllTimepoints));
+  ui->cmbNormaliseOverAllSpecies->setCurrentIndex(
+      boolToIndex(normaliseOverAllSpecies));
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
           &DialogDisplayOptions::accept);
@@ -54,7 +71,7 @@ DialogDisplayOptions::~DialogDisplayOptions() = default;
 std::vector<bool> DialogDisplayOptions::getShowSpecies() const {
   std::vector<bool> checked;
   for (int ic = 0; ic < ui->listSpecies->topLevelItemCount(); ++ic) {
-    const auto* comp = ui->listSpecies->topLevelItem(ic);
+    const auto *comp = ui->listSpecies->topLevelItem(ic);
     for (int is = 0; is < comp->childCount(); ++is) {
       checked.push_back(comp->child(is)->checkState(0) ==
                         Qt::CheckState::Checked);
@@ -67,6 +84,10 @@ bool DialogDisplayOptions::getShowMinMax() const {
   return ui->chkShowMinMaxRanges->isChecked();
 }
 
-int DialogDisplayOptions::getNormalisationType() const {
-  return ui->cmbNormalisation->currentIndex();
+bool DialogDisplayOptions::getNormaliseOverAllTimepoints() const {
+  return indexToBool(ui->cmbNormaliseOverAllTimepoints->currentIndex());
+}
+
+bool DialogDisplayOptions::getNormaliseOverAllSpecies() const {
+  return indexToBool(ui->cmbNormaliseOverAllSpecies->currentIndex());
 }

--- a/src/gui/dialogs/dialogdisplayoptions.hpp
+++ b/src/gui/dialogs/dialogdisplayoptions.hpp
@@ -10,18 +10,21 @@ class DialogDisplayOptions;
 class DialogDisplayOptions : public QDialog {
   Q_OBJECT
 
- public:
-  explicit DialogDisplayOptions(const QStringList& compartmentNames,
-                                const std::vector<QStringList>& speciesNames,
-                                const std::vector<bool>& showSpecies,
-                                bool showMinMax, int normalisation,
-                                QWidget* parent = nullptr);
+public:
+  explicit DialogDisplayOptions(const QStringList &compartmentNames,
+                                const std::vector<QStringList> &speciesNames,
+                                const std::vector<bool> &showSpecies,
+                                bool showMinMax,
+                                bool normaliseOverAllTimepoints,
+                                bool normaliseOverAllSpecies,
+                                QWidget *parent = nullptr);
   ~DialogDisplayOptions();
   std::vector<bool> getShowSpecies() const;
   bool getShowMinMax() const;
-  int getNormalisationType() const;
+  bool getNormaliseOverAllTimepoints() const;
+  bool getNormaliseOverAllSpecies() const;
 
- private:
+private:
   std::unique_ptr<Ui::DialogDisplayOptions> ui;
   std::size_t nSpecies;
 };

--- a/src/gui/dialogs/dialogdisplayoptions.ui
+++ b/src/gui/dialogs/dialogdisplayoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>377</width>
-    <height>573</height>
+    <width>499</width>
+    <height>585</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,8 +16,36 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QComboBox" name="cmbNormaliseOverAllSpecies">
+     <item>
+      <property name="text">
+       <string>maximum of each species</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>maximum over all species</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="cmbNormaliseOverAllTimepoints">
+     <item>
+      <property name="text">
+       <string>at each timepoint</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>over all timepoints</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
     <widget class="QTreeWidget" name="listSpecies">
      <column>
       <property name="text">
@@ -26,28 +54,27 @@
      </column>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0" colspan="2">
     <widget class="QCheckBox" name="chkShowMinMaxRanges">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Show min/max ranges on plot</string>
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QComboBox" name="cmbNormalisation">
-     <item>
-      <property name="text">
-       <string>Normalise intensity at each timepoint</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Normalise intensity over whole simulation</string>
-      </property>
-     </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="lblNormalise">
+     <property name="text">
+      <string>Normalise concentration image colour intensity to:</string>
+     </property>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -59,6 +86,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>listSpecies</tabstop>
+  <tabstop>chkShowMinMaxRanges</tabstop>
+  <tabstop>cmbNormaliseOverAllSpecies</tabstop>
+  <tabstop>cmbNormaliseOverAllTimepoints</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/dialogs/dialogdisplayoptions_t.cpp
+++ b/src/gui/dialogs/dialogdisplayoptions_t.cpp
@@ -13,12 +13,14 @@ SCENARIO("DialogDisplayOptions",
     species.push_back({"s1_c1", "s2_c1"});
     species.push_back({"s1_c2", "s2_c2", "s3_c2"});
     std::vector<bool> showSpecies{true, false, false, true, false};
-    DialogDisplayOptions dia(compartments, species, showSpecies, false, 0);
+    DialogDisplayOptions dia(compartments, species, showSpecies, false, false,
+                             false);
     ModalWidgetTimer mwt;
     WHEN("user does nothing") {
       REQUIRE(dia.getShowSpecies() == showSpecies);
       REQUIRE(dia.getShowMinMax() == false);
-      REQUIRE(dia.getNormalisationType() == 0);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user checks first compartment: enables all species in compartment") {
       mwt.addUserAction({"Space"});
@@ -27,6 +29,8 @@ SCENARIO("DialogDisplayOptions",
       showSpecies[0] = true;
       showSpecies[1] = true;
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN(
         "user checks, then unchecks first compartment: disables all species in "
@@ -37,6 +41,8 @@ SCENARIO("DialogDisplayOptions",
       showSpecies[0] = false;
       showSpecies[1] = false;
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user unchecks first species") {
       mwt.addUserAction({"Down", "Space"});
@@ -44,30 +50,53 @@ SCENARIO("DialogDisplayOptions",
       dia.exec();
       showSpecies[0] = false;
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user unchecks then checks first species") {
       mwt.addUserAction({"Down", "Space", "Space"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user toggles show min/max checkbox") {
       mwt.addUserAction({"Tab", "Space"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.getShowMinMax() == true);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user toggles show min/max checkbox twice") {
       mwt.addUserAction({"Tab", "Space", "Space"});
       mwt.start();
       dia.exec();
       REQUIRE(dia.getShowMinMax() == false);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
-    WHEN("user changes normalisation") {
+    WHEN("user changes timepoint normalisation") {
       mwt.addUserAction({"Tab", "Tab", "Down"});
       mwt.start();
       dia.exec();
-      REQUIRE(dia.getNormalisationType() == 1);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == true);
+    }
+    WHEN("user changes species normalisation") {
+      mwt.addUserAction({"Tab", "Tab", "Tab", "Down"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == true);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
+    }
+    WHEN("user changes both normalisations") {
+      mwt.addUserAction({"Tab", "Tab", "Down", "Tab", "Down"});
+      mwt.start();
+      dia.exec();
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == true);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == true);
     }
     WHEN("user checks both compartment: enables all species") {
       mwt.addUserAction({"Space", "Down", "Down", "Down", "Space"});
@@ -75,6 +104,8 @@ SCENARIO("DialogDisplayOptions",
       dia.exec();
       showSpecies = {true, true, true, true, true};
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
     WHEN("user checks & unchecks both compartments: disable all species") {
       mwt.addUserAction(
@@ -83,6 +114,8 @@ SCENARIO("DialogDisplayOptions",
       dia.exec();
       showSpecies = {false, false, false, false, false};
       REQUIRE(dia.getShowSpecies() == showSpecies);
+      REQUIRE(dia.getNormaliseOverAllTimepoints() == false);
+      REQUIRE(dia.getNormaliseOverAllSpecies() == false);
     }
   }
 }

--- a/src/gui/tabs/tabsimulate.cpp
+++ b/src/gui/tabs/tabsimulate.cpp
@@ -182,7 +182,7 @@ void TabSimulate::reset() {
   ui->hslideTime->setMaximum(0);
   images.clear();
   time.clear();
-  normaliseImageIntensityOverWholeSimulation = true;
+  normaliseImageIntensityOverAllTimepoints = true;
   // Note: this reset is required to delete all current DUNE objects *before*
   // creating a new one, otherwise the new ones make use of the existing ones,
   // and once they are deleted it dereferences a nullptr and segfaults...
@@ -326,21 +326,24 @@ void TabSimulate::updatePlotAndImages() {
   updateSpeciesToDraw();
   // update images
   for (int iTime = 0; iTime < time.size(); ++iTime) {
-    images[iTime] = sim->getConcImage(
-        static_cast<std::size_t>(iTime), compartmentSpeciesToDraw,
-        normaliseImageIntensityOverWholeSimulation);
+    images[iTime] = sim->getConcImage(static_cast<std::size_t>(iTime),
+                                      compartmentSpeciesToDraw,
+                                      normaliseImageIntensityOverAllTimepoints,
+                                      normaliseImageIntensityOverAllSpecies);
   }
 }
 
 void TabSimulate::btnDisplayOptions_clicked() {
-  int norm = normaliseImageIntensityOverWholeSimulation ? 1 : 0;
   DialogDisplayOptions dialog(compartmentNames, speciesNames, speciesVisible,
-                              plotShowMinMax, norm);
+                              plotShowMinMax,
+                              normaliseImageIntensityOverAllTimepoints,
+                              normaliseImageIntensityOverAllSpecies);
   if (dialog.exec() == QDialog::Accepted) {
     plotShowMinMax = dialog.getShowMinMax();
     speciesVisible = dialog.getShowSpecies();
-    normaliseImageIntensityOverWholeSimulation =
-        dialog.getNormalisationType() == 1;
+    normaliseImageIntensityOverAllTimepoints =
+        dialog.getNormaliseOverAllTimepoints();
+    normaliseImageIntensityOverAllSpecies = dialog.getNormaliseOverAllSpecies();
     updatePlotAndImages();
     hslideTime_valueChanged(ui->hslideTime->value());
   }

--- a/src/gui/tabs/tabsimulate.hpp
+++ b/src/gui/tabs/tabsimulate.hpp
@@ -50,10 +50,11 @@ private:
   QStringList compartmentNames;
   std::vector<QStringList> speciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesToDraw;
-  bool normaliseImageIntensityOverWholeSimulation = true;
+  bool normaliseImageIntensityOverAllTimepoints{true};
+  bool normaliseImageIntensityOverAllSpecies{true};
   std::vector<bool> speciesVisible;
-  bool plotShowMinMax = true;
-  bool isSimulationRunning = false;
+  bool plotShowMinMax{true};
+  bool isSimulationRunning{false};
 
   void btnSimulate_clicked();
   void btnSliceImage_clicked();


### PR DESCRIPTION
  - as before: can normalise at each timepoint, or over all timepoints
  - new: can normalise by max of each species, or max of all species
  - change combobox text to make meaning of these options clearer to user
  - resolves #314
