### PR TITLE
add custom observables to simulation plot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,8 @@ jobs:
         - DEPLOY_FILE_CLI="spatial-cli"
         - STATIC_LIBS_OS="linux"
         - SUDOCMD='sudo'
+      cache:
+        ccache: true
       addons:
         apt:
           sources:
@@ -270,8 +272,10 @@ jobs:
         - export SME_EXTRA_EXE_LIBS="-static-libgcc;-static-libstdc++"
         - mkdir build
         - cd build
-        - /usr/bin/cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/bin/python3 -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS -DSME_WITH_TBB=ON
+        - /usr/bin/cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_EXTRA_EXE_LIBS=$SME_EXTRA_EXE_LIBS -DSME_WITH_TBB=ON
+        - ccache --zero-stats
         - make -j2 VERBOSE=1
+        - ccache --show-stats
         # run c++ tests
         - ./test/tests -as > tests.txt 2>&1
         - tail -n 100 tests.txt
@@ -299,13 +303,21 @@ jobs:
         - DEPLOY_FILE_GUI="spatial-model-editor.dmg"
         - DEPLOY_FILE_CLI="spatial-cli.dmg"
         - SUDOCMD='sudo'
+      addons:
+        homebrew:
+          packages:
+            - ccache
+      cache:
+        ccache: true
       install:
         - python3 -m pip install --user nose
       script:
         - mkdir build
         - cd build
-        - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DSME_WITH_TBB=ON -DSME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM=ON
+        - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/opt/libs;/opt/libs/lib/cmake;/opt/libs/dune" -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSME_WITH_TBB=ON -DSME_DUNE_COPASI_USE_FALLBACK_FILESYSTEM=ON
+        - ccache --zero-stats
         - make -j2 VERBOSE=1
+        - ccache --show-stats
         # run non-gui c++ tests
         - ./test/tests -as "~[gui]" > tests.txt 2>&1
         - tail -n 100 tests.txt
@@ -421,7 +433,6 @@ jobs:
         homebrew:
           packages:
             - ccache
-#          update: true
       env:
         - STATIC_LIBS_OS="osx"
         - SUDOCMD='sudo'

--- a/src/core/common/inc/utils.hpp
+++ b/src/core/common/inc/utils.hpp
@@ -120,12 +120,7 @@ template <typename T> std::string vectorToString(const std::vector<T> &vec) {
 
 class indexedColours {
 private:
-  const std::vector<QColor> colours{
-      {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
-      {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},
-      {210, 245, 60}, {250, 190, 190}, {0, 128, 128},  {230, 190, 255},
-      {170, 110, 40}, {255, 250, 200}, {128, 0, 0},    {170, 255, 195},
-      {128, 128, 0},  {255, 215, 180}, {0, 0, 128},    {128, 128, 128}};
+  const static std::vector<QColor> colours;
 
 public:
   const QColor &operator[](std::size_t i) const;

--- a/src/core/common/src/utils.cpp
+++ b/src/core/common/src/utils.cpp
@@ -34,6 +34,13 @@ std::vector<QRgb> toStdVec(const QVector<QRgb> &q) {
   return v;
 }
 
+const std::vector<QColor> indexedColours::colours = std::vector<QColor>{
+    {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
+    {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},
+    {210, 245, 60}, {250, 190, 190}, {0, 128, 128},  {230, 190, 255},
+    {170, 110, 40}, {255, 250, 200}, {128, 0, 0},    {170, 255, 195},
+    {128, 128, 0},  {255, 215, 180}, {0, 0, 128},    {128, 128, 128}};
+
 const QColor &indexedColours::operator[](std::size_t i) const {
   return colours[i % colours.size()];
 }

--- a/src/gui/dialogs/dialogdisplayoptions.hpp
+++ b/src/gui/dialogs/dialogdisplayoptions.hpp
@@ -7,24 +7,34 @@ namespace Ui {
 class DialogDisplayOptions;
 }
 
+struct PlotWrapperObservable;
+class QTreeWidgetItem;
+
 class DialogDisplayOptions : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogDisplayOptions(const QStringList &compartmentNames,
-                                const std::vector<QStringList> &speciesNames,
-                                const std::vector<bool> &showSpecies,
-                                bool showMinMax,
-                                bool normaliseOverAllTimepoints,
-                                bool normaliseOverAllSpecies,
-                                QWidget *parent = nullptr);
+  explicit DialogDisplayOptions(
+      const QStringList &compartmentNames,
+      const std::vector<QStringList> &speciesNames,
+      const std::vector<bool> &showSpecies, bool showMinMax,
+      bool normaliseOverAllTimepoints, bool normaliseOverAllSpecies,
+      const std::vector<PlotWrapperObservable> &plotWrapperObservables,
+      QWidget *parent = nullptr);
   ~DialogDisplayOptions();
   std::vector<bool> getShowSpecies() const;
   bool getShowMinMax() const;
   bool getNormaliseOverAllTimepoints() const;
   bool getNormaliseOverAllSpecies() const;
+  const std::vector<PlotWrapperObservable> &getObservables();
 
 private:
   std::unique_ptr<Ui::DialogDisplayOptions> ui;
   std::size_t nSpecies;
+  std::vector<PlotWrapperObservable> observables;
+  void listObservables_currentItemChanged(QTreeWidgetItem *current,
+                                          QTreeWidgetItem *previous);
+  void btnAddObservable_clicked();
+  void btnEditObservable_clicked();
+  void btnRemoveObservable_clicked();
 };

--- a/src/gui/dialogs/dialogdisplayoptions.ui
+++ b/src/gui/dialogs/dialogdisplayoptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>499</width>
-    <height>585</height>
+    <width>584</width>
+    <height>633</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
+   <item row="6" column="0">
     <widget class="QComboBox" name="cmbNormaliseOverAllSpecies">
      <item>
       <property name="text">
@@ -31,7 +31,66 @@
      </item>
     </widget>
    </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QTreeWidget" name="listSpecies">
+     <property name="toolTip">
+      <string>Select which species should be displayed in the plot and the concentration images</string>
+     </property>
+     <column>
+      <property name="text">
+       <string>Species to display</string>
+      </property>
+     </column>
+    </widget>
+   </item>
    <item row="3" column="1">
+    <widget class="QPushButton" name="btnEditObservable">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>&amp;Edit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QCheckBox" name="chkShowMinMaxRanges">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Show min/max species concentration ranges on plot</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="btnAddObservable">
+     <property name="text">
+      <string>&amp;Add</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QPushButton" name="btnRemoveObservable">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>&amp;Remove</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="QLabel" name="lblNormalise">
+     <property name="text">
+      <string>Normalise concentration image colour intensity to:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
     <widget class="QComboBox" name="cmbNormaliseOverAllTimepoints">
      <item>
       <property name="text">
@@ -45,36 +104,26 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QTreeWidget" name="listSpecies">
+   <item row="2" column="0" colspan="3">
+    <widget class="QTreeWidget" name="listObservables">
+     <property name="toolTip">
+      <string>Add custom observables to display in the plot, which can be functions of the species and of time (t)</string>
+     </property>
      <column>
       <property name="text">
-       <string>Species to display</string>
+       <string>Custom observables</string>
       </property>
      </column>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkShowMinMaxRanges">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Show min/max ranges on plot</string>
+   <item row="4" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLabel" name="lblNormalise">
-     <property name="text">
-      <string>Normalise concentration image colour intensity to:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -89,6 +138,10 @@
  <tabstops>
   <tabstop>listSpecies</tabstop>
   <tabstop>chkShowMinMaxRanges</tabstop>
+  <tabstop>listObservables</tabstop>
+  <tabstop>btnAddObservable</tabstop>
+  <tabstop>btnEditObservable</tabstop>
+  <tabstop>btnRemoveObservable</tabstop>
   <tabstop>cmbNormaliseOverAllSpecies</tabstop>
   <tabstop>cmbNormaliseOverAllTimepoints</tabstop>
  </tabstops>

--- a/src/gui/tabs/tabsimulate.hpp
+++ b/src/gui/tabs/tabsimulate.hpp
@@ -1,11 +1,10 @@
 // TabSimulate
 
 #pragma once
-
+#include "plotwrapper.hpp"
+#include "simulate.hpp"
 #include <QWidget>
 #include <memory>
-
-#include "simulate.hpp"
 
 namespace Ui {
 class TabSimulate;
@@ -18,6 +17,7 @@ class QLabelMouseTracker;
 namespace model {
 class Model;
 }
+class PlotWrapper;
 
 class TabSimulate : public QWidget {
   Q_OBJECT
@@ -32,16 +32,12 @@ public:
   void reset();
   simulate::Options getOptions() const;
   void setOptions(const simulate::Options &options);
-  void setMaxThreads(std::size_t maxThreads);
-  std::size_t getMaxThreads() const;
 
 private:
   std::unique_ptr<Ui::TabSimulate> ui;
   model::Model &sbmlDoc;
   QLabelMouseTracker *lblGeometry;
-  QCustomPlot *pltPlot;
-  QCPTextElement *pltTitle;
-  QCPItemStraightLine *pltTimeLine;
+  std::unique_ptr<PlotWrapper> plt;
   std::unique_ptr<simulate::Simulation> sim;
   simulate::SimulatorType simType{simulate::SimulatorType::DUNE};
   simulate::Options simOptions;
@@ -53,6 +49,8 @@ private:
   bool normaliseImageIntensityOverAllTimepoints{true};
   bool normaliseImageIntensityOverAllSpecies{true};
   std::vector<bool> speciesVisible;
+  std::vector<PlotWrapperObservable> observables;
+  std::vector<bool> obsVisible;
   bool plotShowMinMax{true};
   bool isSimulationRunning{false};
 

--- a/src/gui/tabs/tabsimulate_t.cpp
+++ b/src/gui/tabs/tabsimulate_t.cpp
@@ -25,10 +25,8 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   auto *btnSimulate = tab.findChild<QPushButton *>("btnSimulate");
   auto *btnResetSimulation = tab.findChild<QPushButton *>("btnResetSimulation");
   auto *hslideTime = tab.findChild<QSlider *>("hslideTime");
-  auto *pltPlot = tab.findChild<QCustomPlot *>("pltPlot");
   auto *btnSaveImage = tab.findChild<QPushButton *>("btnSaveImage");
   auto *btnDisplayOptions = tab.findChild<QPushButton *>("btnDisplayOptions");
-  REQUIRE(pltPlot != nullptr);
 
   if (QFile f(":/models/ABtoC.xml"); f.open(QIODevice::ReadOnly)) {
     sbmlDoc.importSBMLString(f.readAll().toStdString());
@@ -38,7 +36,6 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
 
   // do DUNE simulation with two timesteps of 0.1
   REQUIRE(hslideTime->isEnabled() == true);
-  REQUIRE(pltPlot->graphCount() == 9);
   sendKeyEvents(txtSimLength,
                 {"End", "Backspace", "Backspace", "Backspace", "0", ".", "2"});
   sendKeyEvents(txtSimInterval,
@@ -49,27 +46,9 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   REQUIRE(hslideTime->isEnabled() == true);
   REQUIRE(hslideTime->maximum() == 2);
   REQUIRE(hslideTime->minimum() == 0);
-  REQUIRE(pltPlot->graphCount() == 9);
 
   sendMouseClick(btnResetSimulation);
   REQUIRE(hslideTime->isEnabled() == true);
-  REQUIRE(pltPlot->graphCount() == 9);
-
-  // hide all species
-  mwt.addUserAction({"Space"});
-  mwt.start();
-  sendMouseClick(btnDisplayOptions);
-  REQUIRE(pltPlot->graph(0)->visible() == false);
-  REQUIRE(pltPlot->graph(3)->visible() == false);
-  REQUIRE(pltPlot->graph(6)->visible() == false);
-
-  // only show species B
-  mwt.addUserAction({"Down", "Down", "Space"});
-  mwt.start();
-  sendMouseClick(btnDisplayOptions);
-  REQUIRE(pltPlot->graph(0)->visible() == false);
-  REQUIRE(pltPlot->graph(3)->visible() == true);
-  REQUIRE(pltPlot->graph(6)->visible() == false);
 
   // repeat simulation using Pixel simulator
   tab.useDune(false);
@@ -77,11 +56,14 @@ SCENARIO("Simulate Tab", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   REQUIRE(hslideTime->isEnabled() == true);
   REQUIRE(hslideTime->maximum() == 2);
   REQUIRE(hslideTime->minimum() == 0);
-  REQUIRE(pltPlot->graphCount() == 9);
 
   sendMouseClick(btnResetSimulation);
   REQUIRE(hslideTime->isEnabled() == true);
-  REQUIRE(pltPlot->graphCount() == 9);
+
+  // hide all species
+  mwt.addUserAction({"Space"});
+  mwt.start();
+  sendMouseClick(btnDisplayOptions);
 
   // click save image & cancel
   mwt.addUserAction({"Esc"});

--- a/src/gui/widgets/CMakeLists.txt
+++ b/src/gui/widgets/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   gui
-  PRIVATE qlabelslice.cpp
+  PRIVATE plotwrapper.cpp
+          qlabelslice.cpp
           qlabelmousetracker.cpp
           qplaintextmathedit.cpp)
 add_subdirectory(ext/qcustomplot)
@@ -9,6 +10,7 @@ target_include_directories(gui PUBLIC .)
 
 target_sources(
   gui_tests
-  PUBLIC qlabelslice_t.cpp
+  PUBLIC plotwrapper_t.cpp
+         qlabelslice_t.cpp
          qlabelmousetracker_t.cpp
          qplaintextmathedit_t.cpp)

--- a/src/gui/widgets/plotwrapper.cpp
+++ b/src/gui/widgets/plotwrapper.cpp
@@ -1,0 +1,165 @@
+#include "plotwrapper.hpp"
+#include "logger.hpp"
+#include "symbolic.hpp"
+#include <QColor>
+#include <QFont>
+#include <QString>
+
+PlotWrapper::PlotWrapper(const QString &plotTitle, QWidget *parent)
+    : plot(new QCustomPlot(parent)) {
+  QFont font;
+  if (parent != nullptr) {
+    font = QFont(parent->font().family(), parent->font().pointSize() + 4,
+                 QFont::Bold);
+  }
+  title = new QCPTextElement(plot, plotTitle, font);
+  plot->setInteraction(QCP::iRangeDrag, true);
+  plot->setInteraction(QCP::iRangeZoom, true);
+  plot->setInteraction(QCP::iSelectPlottables, false);
+  plot->legend->setVisible(true);
+  verticalLine = new QCPItemStraightLine(plot);
+  verticalLine->setVisible(false);
+  plot->setObjectName(QString::fromUtf8("plot"));
+  plot->plotLayout()->insertRow(0);
+  plot->plotLayout()->addElement(0, 0, title);
+}
+
+void PlotWrapper::addAvMinMaxLine(const QString &name, QColor col) {
+  SPDLOG_DEBUG("Adding line '{}', colour {:x}", name.toStdString(), col.rgb());
+  // avg
+  auto *av = plot->addGraph();
+  av->setPen(col);
+  av->setName(QString("%1 (average)").arg(name));
+  av->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ScatterShape::ssDisc));
+  // min
+  auto *min = plot->addGraph();
+  col.setAlpha(30);
+  min->setPen(col);
+  min->setBrush(QBrush(col));
+  min->setName(QString("%1 (min/max range)").arg(name));
+  // max
+  auto *max = plot->addGraph();
+  max->setPen(col);
+  min->setChannelFillGraph(max);
+  plot->legend->removeItem(plot->legend->itemCount() - 1);
+  species.push_back(name.toStdString());
+  concs.emplace_back();
+}
+
+void PlotWrapper::addAvMinMaxPoint(int lineIndex, double time, double avg,
+                                   double min, double max) {
+  plot->graph(3 * lineIndex)->addData({time}, {avg}, true);
+  plot->graph(3 * lineIndex + 1)->addData({time}, {min}, true);
+  plot->graph(3 * lineIndex + 2)->addData({time}, {max}, true);
+  concs[static_cast<std::size_t>(lineIndex)].push_back(avg);
+}
+
+void PlotWrapper::addObservableLine(
+    const PlotWrapperObservable &plotWrapperObservable, QColor col) {
+  SPDLOG_DEBUG("Adding observable '{}' = '{}'",
+               plotWrapperObservable.name.toStdString(),
+               plotWrapperObservable.expression.toStdString());
+  if (plot->graphCount() == 0) {
+    return;
+  }
+  auto vars = species;
+  vars.push_back("t");
+  symbolic::Symbolic sym(plotWrapperObservable.expression.toStdString(), vars);
+  if (!sym.isValid()) {
+    SPDLOG_WARN("Skipping invalid expression: '{}'",
+                plotWrapperObservable.expression.toStdString());
+    return;
+  }
+  auto *p = plot->addGraph();
+  p->setPen(col);
+  p->setName(plotWrapperObservable.name);
+  p->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ScatterShape::ssDisc));
+  QVector<double> times;
+  for (const auto &d : *(plot->graph(0)->data().get())) {
+    times.push_back(d.key);
+  }
+  QVector<double> obs;
+  obs.reserve(static_cast<int>(concs.size()));
+  double res;
+  std::vector<double> c(concs.size() + 1, 0.0);
+  for (std::size_t it = 0; it < static_cast<std::size_t>(times.size()); ++it) {
+    for (std::size_t ic = 0; ic < species.size(); ++ic) {
+      c[ic] = concs[ic][it];
+    }
+    c.back() = times[static_cast<int>(it)];
+    sym.eval(&res, c.data());
+    obs.push_back(res);
+  }
+  p->setData(times, obs, true);
+  observables.push_back(plotWrapperObservable);
+}
+
+void PlotWrapper::clearObservableLines() {
+  SPDLOG_TRACE("Clearing {} observables", observables.size());
+  int nSpecies{static_cast<int>(species.size())};
+  int nObservables{static_cast<int>(observables.size())};
+  for (int i = 3 * nSpecies + nObservables - 1; i >= 3 * nSpecies; --i) {
+    if (plot->removeGraph(i)) {
+      SPDLOG_TRACE("Removed graph {}", i);
+    } else {
+      SPDLOG_WARN("Failed to remove graph {}", i);
+    }
+  }
+  observables.clear();
+}
+
+void PlotWrapper::setVerticalLine(double x) {
+  verticalLine->setVisible(true);
+  verticalLine->point1->setCoords(x, 0);
+  verticalLine->point2->setCoords(x, 1);
+  if (!plot->xAxis->range().contains(x)) {
+    plot->rescaleAxes(true);
+  }
+}
+
+void PlotWrapper::update(const std::vector<bool> &speciesVisible,
+                         bool showMinMax) {
+  int iSpecies = 0;
+  plot->legend->clearItems();
+  for (bool visible : speciesVisible) {
+    bool minMaxVisible = visible && showMinMax;
+    plot->graph(3 * iSpecies)->setVisible(visible);
+    if (visible) {
+      plot->graph(3 * iSpecies)->addToLegend();
+    }
+    plot->graph(3 * iSpecies + 1)->setVisible(minMaxVisible);
+    plot->graph(3 * iSpecies + 2)->setVisible(minMaxVisible);
+    if (minMaxVisible) {
+      plot->graph(3 * iSpecies + 1)->addToLegend();
+    }
+    ++iSpecies;
+  }
+  int iObs = 0;
+  for (const auto &observable : observables) {
+    auto *g = plot->graph(3 * static_cast<int>(species.size()) + iObs);
+    g->setVisible(observable.visible);
+    if (observable.visible) {
+      g->addToLegend();
+    }
+    ++iObs;
+  }
+  plot->rescaleAxes(true);
+  plot->replot();
+}
+
+void PlotWrapper::clear() {
+  plot->clearGraphs();
+  plot->replot();
+  observables.clear();
+  species.clear();
+  concs.clear();
+}
+
+double PlotWrapper::xValue(const QMouseEvent *event) const {
+  double x{static_cast<double>(event->x())};
+  double y{static_cast<double>(event->y())};
+  double key;
+  double val;
+  plot->graph(0)->pixelsToCoords(x, y, key, val);
+  return key;
+}

--- a/src/gui/widgets/plotwrapper.hpp
+++ b/src/gui/widgets/plotwrapper.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <qcustomplot.h>
+
+class QWidget;
+
+struct PlotWrapperObservable {
+  QString name;
+  QString expression;
+  bool visible;
+};
+
+class PlotWrapper {
+private:
+  QCPItemStraightLine *verticalLine;
+  QCPTextElement *title;
+  std::vector<std::string> species;
+  std::vector<PlotWrapperObservable> observables;
+  std::vector<std::vector<double>> concs;
+
+public:
+  QCustomPlot *plot;
+  explicit PlotWrapper(const QString &plotTitle, QWidget *parent = nullptr);
+  void addAvMinMaxLine(const QString &name, QColor col);
+  void addAvMinMaxPoint(int lineIndex, double time, double avg, double min,
+                        double max);
+  void addObservableLine(const PlotWrapperObservable &plotWrapperObservable,
+                         QColor col);
+  void clearObservableLines();
+  void setVerticalLine(double x);
+  void update(const std::vector<bool> &speciesVisible, bool showMinMax);
+  void clear();
+  double xValue(const QMouseEvent *event) const;
+};

--- a/src/gui/widgets/plotwrapper_t.cpp
+++ b/src/gui/widgets/plotwrapper_t.cpp
@@ -1,0 +1,89 @@
+#include "catch_wrapper.hpp"
+#include "plotwrapper.hpp"
+#include "qt_test_utils.hpp"
+#include "utils.hpp"
+#include <QApplication>
+#include <QDebug>
+
+SCENARIO("PlotWrapper",
+         "[gui/widgets/plotwrapper][gui/widgets][gui][plotwrapper]") {
+  QWidget parent;
+  PlotWrapper p("title", &parent);
+  REQUIRE(p.plot->graphCount() == 0);
+  // add two species
+  p.addAvMinMaxLine("s1", utils::indexedColours()[0]);
+  REQUIRE(p.plot->graph(0)->name() == "s1 (average)");
+  REQUIRE(p.plot->graph(1)->name() == "s1 (min/max range)");
+  p.addAvMinMaxLine("s2", utils::indexedColours()[1]);
+  REQUIRE(p.plot->graph(3)->name() == "s2 (average)");
+  REQUIRE(p.plot->graph(4)->name() == "s2 (min/max range)");
+  REQUIRE(p.plot->graphCount() == 6);
+  REQUIRE(p.plot->legend->itemCount() == 4);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->dataCount() == 0);
+  }
+
+  // add two data points
+  p.addAvMinMaxPoint(0, 0.0, 1.0, 0.95, 1.05);
+  p.addAvMinMaxPoint(1, 0.0, 1.0, 0.95, 1.05);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->dataCount() == 1);
+  }
+  p.addAvMinMaxPoint(0, 1.0, 1.1, 0.99, 1.15);
+  p.addAvMinMaxPoint(1, 1.0, 0.9, 0.85, 1.01);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->dataCount() == 2);
+  }
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == true);
+  }
+
+  // hide all species
+  p.update({false, false}, false);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == false);
+  }
+  REQUIRE(p.plot->legend->itemCount() == 0);
+
+  // only show avg for all species
+  p.update({true, true}, false);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == (i % 3 == 0));
+  }
+  REQUIRE(p.plot->legend->itemCount() == 2);
+
+  // show all for 1st spec, hide 2nd spec
+  p.update({true, false}, true);
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == i < 3);
+  }
+  REQUIRE(p.plot->legend->itemCount() == 2);
+
+  // add a custom observable
+  p.addObservableLine({"1", "1", true}, utils::indexedColours()[2]);
+  REQUIRE(p.plot->graphCount() == 7);
+  REQUIRE(p.plot->graph(6)->name() == "1");
+  for (int i = 0; i < 6; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == i < 3);
+  }
+  REQUIRE(p.plot->graph(6)->visible() == true);
+  REQUIRE(p.plot->legend->itemCount() == 3);
+
+  // add a custom observable
+  p.addObservableLine({"s1 + s2", "s1 + s2", true}, utils::indexedColours()[3]);
+  REQUIRE(p.plot->graphCount() == 8);
+
+  // make all species visible
+  p.update({true, true}, true);
+  for (int i = 0; i < 8; ++i) {
+    REQUIRE(p.plot->graph(i)->visible() == true);
+  }
+
+  // reset custom observables
+  p.clearObservableLines();
+  REQUIRE(p.plot->graphCount() == 6);
+
+  // reset everything
+  p.clear();
+  REQUIRE(p.plot->graphCount() == 0);
+}


### PR DESCRIPTION
  - user can now define their own observables to add to the plot
  - expressions can be a function of all species and of time (t)
  - they are evaluated at each timepoint using the average values of each species
  - resolves #313

also
  - add PlotWrapper class to wrap QCustomPlot
