### PR TITLE
add membranes to sme

### DIFF
--- a/sme/CMakeLists.txt
+++ b/sme/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
   PRIVATE sme.cpp
           sme_common.cpp
           sme_compartment.cpp
+          sme_membrane.cpp
           sme_model.cpp
           sme_module.cpp
           sme_parameter.cpp

--- a/sme/sme.cpp
+++ b/sme/sme.cpp
@@ -3,6 +3,7 @@
 
 // other headers
 #include "sme_compartment.hpp"
+#include "sme_membrane.hpp"
 #include "sme_model.hpp"
 #include "sme_module.hpp"
 #include "sme_simulationresult.hpp"
@@ -14,6 +15,7 @@ PYBIND11_MODULE(sme, m) {
   sme::pybindModule(m);
   sme::pybindModel(m);
   sme::pybindCompartment(m);
+  sme::pybindMembrane(m);
   sme::pybindSpecies(m);
   sme::pybindParameter(m);
   sme::pybindReaction(m);

--- a/sme/sme_common.cpp
+++ b/sme/sme_common.cpp
@@ -3,8 +3,8 @@
 namespace sme {
 
 PyImageRgb toPyImageRgb(const QImage &img) {
-  std::size_t h = static_cast<std::size_t>(img.height());
-  std::size_t w = static_cast<std::size_t>(img.width());
+  auto h = static_cast<std::size_t>(img.height());
+  auto w = static_cast<std::size_t>(img.width());
   PyImageRgb v(h, std::vector<std::vector<int>>(w, std::vector<int>(3, 0)));
   for (std::size_t y = 0; y < h; ++y) {
     for (std::size_t x = 0; x < w; ++x) {
@@ -18,8 +18,8 @@ PyImageRgb toPyImageRgb(const QImage &img) {
 }
 
 PyImageMask toPyImageMask(const QImage &img) {
-  std::size_t h = static_cast<std::size_t>(img.height());
-  std::size_t w = static_cast<std::size_t>(img.width());
+  auto h = static_cast<std::size_t>(img.height());
+  auto w = static_cast<std::size_t>(img.width());
   PyImageMask v(h, std::vector<bool>(w, false));
   for (std::size_t y = 0; y < h; ++y) {
     for (std::size_t x = 0; x < w; ++x) {

--- a/sme/sme_membrane.cpp
+++ b/sme/sme_membrane.cpp
@@ -1,0 +1,50 @@
+// Python.h (included by pybind11.h) must come first:
+#include <pybind11/pybind11.h>
+
+// other headers
+#include "model.hpp"
+#include "sme_common.hpp"
+#include "sme_membrane.hpp"
+#include <pybind11/stl.h>
+
+namespace sme {
+
+void pybindMembrane(const pybind11::module &m) {
+  pybind11::class_<sme::Membrane>(m, "Membrane")
+      .def_property_readonly("name", &sme::Membrane::getName,
+                    "The name of this membrane")
+      .def_readonly("reactions", &sme::Membrane::reactions,
+                    "The reactions in this membrane")
+      .def("reaction", &sme::Membrane::getReaction, pybind11::arg("name"))
+      .def("__repr__",
+           [](const sme::Membrane &a) {
+             return fmt::format("<sme.Membrane named '{}'>", a.getName());
+           })
+      .def("__str__", &sme::Membrane::getStr);
+}
+
+Membrane::Membrane(model::Model *sbmlDocWrapper, const std::string &sId)
+    : s(sbmlDocWrapper), id(sId) {
+  if (auto reacs = s->getReactions().getIds(sId.c_str()); !reacs.isEmpty()) {
+    for (const auto &reac : reacs) {
+      reactions.emplace_back(s, reac.toStdString());
+    }
+  }
+}
+
+std::string Membrane::getName() const {
+  return s->getMembranes().getName(id.c_str()).toStdString();
+}
+
+const Reaction &Membrane::getReaction(const std::string &name) const {
+  return findElem(reactions, name, "Reaction");
+}
+
+std::string Membrane::getStr() const {
+  std::string str("<sme.Membrane>\n");
+  str.append(fmt::format("  - name: '{}'\n", getName()));
+  str.append(fmt::format("  - reactions: {}", vecToNames(reactions)));
+  return str;
+}
+
+} // namespace sme

--- a/sme/sme_membrane.hpp
+++ b/sme/sme_membrane.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "sme_common.hpp"
+#include "sme_reaction.hpp"
+#include "sme_species.hpp"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace model {
+class Model;
+}
+
+namespace pybind11 {
+class module;
+}
+
+namespace sme {
+
+void pybindMembrane(const pybind11::module &m);
+
+class Membrane {
+private:
+  model::Model *s;
+  std::string id;
+
+public:
+  explicit Membrane(model::Model *sbmlDocWrapper, const std::string &sId);
+  std::string getName() const;
+  std::vector<Reaction> reactions;
+  const Reaction &getReaction(const std::string &name) const;
+  std::string getStr() const;
+};
+
+} // namespace sme

--- a/sme/sme_model.cpp
+++ b/sme/sme_model.cpp
@@ -22,6 +22,9 @@ void pybindModel(const pybind11::module &m) {
       .def_readonly("compartments", &sme::Model::compartments,
                     "The compartments in this model")
       .def("compartment", &sme::Model::getCompartment, pybind11::arg("name"))
+      .def_readonly("membranes", &sme::Model::membranes,
+                    "The membranes in this model")
+      .def("membrane", &sme::Model::getMembrane, pybind11::arg("name"))
       .def_readonly("parameters", &sme::Model::parameters,
                     "The parameters in this model")
       .def("parameter", &sme::Model::getParameter, pybind11::arg("name"))
@@ -48,6 +51,12 @@ void Model::importSbmlFile(const std::string &filename) {
       static_cast<std::size_t>(s->getCompartments().getIds().size()));
   for (const auto &compartmentId : s->getCompartments().getIds()) {
     compartments.emplace_back(s.get(), compartmentId.toStdString());
+  }
+  membranes.clear();
+  membranes.reserve(
+      static_cast<std::size_t>(s->getMembranes().getIds().size()));
+  for (const auto &membraneId : s->getMembranes().getIds()) {
+    membranes.emplace_back(s.get(), membraneId.toStdString());
   }
   parameters.clear();
   parameters.reserve(
@@ -76,6 +85,10 @@ void Model::exportSbmlFile(const std::string &filename) {
 
 const Compartment &Model::getCompartment(const std::string &name) const {
   return findElem(compartments, name, "Compartment");
+}
+
+const Membrane &Model::getMembrane(const std::string &name) const {
+  return findElem(membranes, name, "Membrane");
 }
 
 const Parameter &Model::getParameter(const std::string &name) const {
@@ -113,7 +126,8 @@ std::vector<SimulationResult> Model::simulate(double simulationTime,
 std::string Model::getStr() const {
   std::string str("<sme.Model>\n");
   str.append(fmt::format("  - name: '{}'\n", getName()));
-  str.append(fmt::format("  - compartments:{}", vecToNames(compartments)));
+  str.append(fmt::format("  - compartments:{}\n", vecToNames(compartments)));
+  str.append(fmt::format("  - membranes:{}", vecToNames(membranes)));
   return str;
 }
 

--- a/sme/sme_model.hpp
+++ b/sme/sme_model.hpp
@@ -3,6 +3,7 @@
 #include "simulate.hpp"
 #include "sme_common.hpp"
 #include "sme_compartment.hpp"
+#include "sme_membrane.hpp"
 #include "sme_parameter.hpp"
 #include "sme_simulationresult.hpp"
 #include <memory>
@@ -30,6 +31,8 @@ public:
   void exportSbmlFile(const std::string &filename);
   std::vector<Compartment> compartments;
   const Compartment &getCompartment(const std::string &name) const;
+  std::vector<Membrane> membranes;
+  const Membrane &getMembrane(const std::string &name) const;
   std::vector<Parameter> parameters;
   const Parameter &getParameter(const std::string &name) const;
   PyImageRgb compartmentImage;

--- a/test/test.py
+++ b/test/test.py
@@ -17,10 +17,11 @@ class TestModel(unittest.TestCase):
         self.assertEqual(repr(m), "<sme.Model named 'Very Simple Model'>")
         self.assertEqual(
             str(m),
-            "<sme.Model>\n  - name: 'Very Simple Model'\n  - compartments:\n     - Outside\n     - Cell\n     - Nucleus",
+            "<sme.Model>\n  - name: 'Very Simple Model'\n  - compartments:\n     - Outside\n     - Cell\n     - Nucleus\n  - membranes:\n     - Outside <-> Cell\n     - Cell <-> Nucleus",
         )
         self.assertEqual(m.name, "Very Simple Model")
         self.assertEqual(len(m.compartments), 3)
+        self.assertEqual(len(m.membranes), 2)
         m.name = "Model !"
         self.assertEqual(m.name, "Model !")
 
@@ -31,6 +32,7 @@ class TestModel(unittest.TestCase):
         m.export_sbml_file("tmp.xml")
         m2 = sme.open_sbml_file("tmp.xml")
         self.assertEqual(m2.name, "Mod")
+        self.assertEqual(len(m2.membranes), 2)
         self.assertEqual(len(m2.compartments), 3)
         self.assertEqual(m2.compartment("C").name, "C")
         self.assertEqual(m2.compartment("Nucleus").name, "Nucleus")
@@ -86,6 +88,21 @@ class TestCompartment(unittest.TestCase):
         self.assertEqual(img[0][0], False)
         self.assertEqual(img[30][30], True)
         self.assertEqual(img[50][50], False)
+
+
+class TestMembrane(unittest.TestCase):
+    def test_membrane(self):
+        m = sme.open_example_model()
+        self.assertEqual(len(m.membranes), 2)
+        self.assertRaises(ValueError, lambda: m.membrane("X"))
+        mem = m.membrane("Outside <-> Cell")
+        self.assertEqual(repr(mem), "<sme.Membrane named 'Outside <-> Cell'>")
+        self.assertEqual(str(mem)[0:43], "<sme.Membrane>\n  - name: 'Outside <-> Cell'")
+        self.assertEqual(mem.name, "Outside <-> Cell")
+        self.assertEqual(len(mem.reactions), 2)
+        self.assertRaises(ValueError, lambda: mem.reaction("X"))
+        r = mem.reaction("A uptake from outside")
+        self.assertEqual(r.name, "A uptake from outside")
 
 
 class TestSpecies(unittest.TestCase):


### PR DESCRIPTION
  - add sme.Membrane object
  - provided as a list in model.membranes
  - or name-based lookup: model.membrane("membrane name")
  - contains the reactions that occur in the membrane
  - print(Model) now also prints the membranes in the model
  - resolves #336
