### PR TITLE
add timeout to sme simulate

### DIFF
--- a/sme/sme_common.hpp
+++ b/sme/sme_common.hpp
@@ -3,12 +3,10 @@
 #include "fmt/core.h"
 #include <QImage>
 #include <algorithm>
-#include <exception>
-#include <map>
+#include <stdexcept>
 #include <vector>
 
 namespace sme {
-
 using PyImageRgb = std::vector<std::vector<std::vector<int>>>;
 using PyImageMask = std::vector<std::vector<bool>>;
 using PyConc = std::vector<std::vector<double>>;
@@ -16,6 +14,18 @@ using PyConc = std::vector<std::vector<double>>;
 PyImageRgb toPyImageRgb(const QImage &img);
 PyImageMask toPyImageMask(const QImage &img);
 PyConc toPyConc();
+
+class SmeRuntimeError : public std::runtime_error {
+public:
+  explicit SmeRuntimeError(const std::string &message)
+      : std::runtime_error(message) {}
+};
+
+class SmeInvalidArgument : public std::invalid_argument {
+public:
+  explicit SmeInvalidArgument(const std::string &message)
+      : std::invalid_argument(message) {}
+};
 
 template <typename T> std::string vecToNames(const std::vector<T> &vec) {
   std::string str;
@@ -34,7 +44,7 @@ const T &findElem(const std::vector<T> &vec, const std::string &name,
       iter != vec.cend()) {
     return *iter;
   }
-  throw std::invalid_argument(typeName + " '" + name + "' not found");
+  throw SmeInvalidArgument(typeName + " '" + name + "' not found");
 }
 
 } // namespace sme

--- a/sme/sme_compartment.cpp
+++ b/sme/sme_compartment.cpp
@@ -6,7 +6,6 @@
 #include "model.hpp"
 #include "sme_common.hpp"
 #include "sme_compartment.hpp"
-#include <exception>
 #include <pybind11/stl.h>
 
 namespace sme {

--- a/sme/sme_model.hpp
+++ b/sme/sme_model.hpp
@@ -37,7 +37,8 @@ public:
   const Parameter &getParameter(const std::string &name) const;
   PyImageRgb compartmentImage;
   std::vector<SimulationResult> simulate(double simulationTime,
-                                         double imageInterval);
+                                         double imageInterval,
+                                         int timeoutSeconds = 86400);
   std::string getStr() const;
 };
 

--- a/sme/sme_module.cpp
+++ b/sme/sme_module.cpp
@@ -1,7 +1,8 @@
-// Python.h must come first:
+// Python.h (included by pybind11.h) must come first:
 #include <pybind11/pybind11.h>
 
 // other headers
+#include "sme_common.hpp"
 #include "sme_module.hpp"
 #include "version.hpp"
 
@@ -25,6 +26,8 @@ void pybindModule(pybind11::module &m) {
   m.def("open_example_model", openExampleModel,
         "Open a built-in example model");
   m.attr("__version__") = SPATIAL_MODEL_EDITOR_VERSION;
+  pybind11::register_exception<SmeRuntimeError>(m, "RuntimeError");
+  pybind11::register_exception<SmeInvalidArgument>(m, "InvalidArgument");
 }
 
 Model openSbmlFile(const std::string &filename) { return Model(filename); }

--- a/sme/sme_parameter.cpp
+++ b/sme/sme_parameter.cpp
@@ -1,12 +1,12 @@
-#include "sme_parameter.hpp"
-
+// Python.h (included by pybind11.h) must come first:
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
-#include <utility>
-
+// other headers
 #include "model.hpp"
 #include "sme_common.hpp"
+#include "sme_parameter.hpp"
+#include <pybind11/stl.h>
+#include <utility>
 
 namespace sme {
 

--- a/sme/sme_reaction.cpp
+++ b/sme/sme_reaction.cpp
@@ -1,10 +1,11 @@
-#include "sme_reaction.hpp"
-
+// Python.h (included by pybind11.h) must come first:
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
+// other headers
 #include "model.hpp"
 #include "sme_common.hpp"
+#include "sme_reaction.hpp"
+#include <pybind11/stl.h>
 
 namespace sme {
 

--- a/sme/sme_reactionparameter.cpp
+++ b/sme/sme_reactionparameter.cpp
@@ -1,10 +1,11 @@
-#include "sme_reactionparameter.hpp"
-
+// Python.h (included by pybind11.h) must come first:
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
+// other headers
 #include "model.hpp"
 #include "sme_common.hpp"
+#include "sme_reactionparameter.hpp"
+#include <pybind11/stl.h>
 
 namespace sme {
 

--- a/sme/sme_species.cpp
+++ b/sme/sme_species.cpp
@@ -1,10 +1,11 @@
-#include "sme_species.hpp"
-
+// Python.h (included by pybind11.h) must come first:
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
+// other headers
 #include "model.hpp"
 #include "sme_common.hpp"
+#include "sme_species.hpp"
+#include <pybind11/stl.h>
 
 namespace sme {
 

--- a/test/test.py
+++ b/test/test.py
@@ -9,7 +9,7 @@ class TestModule(unittest.TestCase):
 
 class TestModel(unittest.TestCase):
     def test_load_open_sbml_file(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(sme.InvalidArgument):
             sme.open_sbml_file("idontexist.xml")
 
     def test_open_example_model(self):
@@ -36,7 +36,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(m2.compartments), 3)
         self.assertEqual(m2.compartment("C").name, "C")
         self.assertEqual(m2.compartment("Nucleus").name, "Nucleus")
-        self.assertRaises(ValueError, lambda: m2.compartment("Cell"))
+        self.assertRaises(sme.InvalidArgument, lambda: m2.compartment("Cell"))
 
     def test_simulate(self):
         m = sme.open_example_model()
@@ -58,6 +58,9 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(conc), 100)
         self.assertEqual(len(conc[0]), 100)
         self.assertEqual(conc[0][0], 0.0)
+        # set timeout to 1 second: simulation throws on timeout
+        with self.assertRaises(sme.RuntimeError):
+            m.simulate(10000, 0.01, 1)
 
 
 class TestCompartment(unittest.TestCase):
@@ -81,7 +84,7 @@ class TestCompartment(unittest.TestCase):
         c.name = "NewCell"
         self.assertEqual(c.name, "NewCell")
         self.assertEqual(m.compartment("NewCell").name, "NewCell")
-        self.assertRaises(ValueError, lambda: m.compartment("Cell"))
+        self.assertRaises(sme.InvalidArgument, lambda: m.compartment("Cell"))
         img = c.geometry_mask
         self.assertEqual(len(img), 100)
         self.assertEqual(len(img[0]), 100)
@@ -94,13 +97,13 @@ class TestMembrane(unittest.TestCase):
     def test_membrane(self):
         m = sme.open_example_model()
         self.assertEqual(len(m.membranes), 2)
-        self.assertRaises(ValueError, lambda: m.membrane("X"))
+        self.assertRaises(sme.InvalidArgument, lambda: m.membrane("X"))
         mem = m.membrane("Outside <-> Cell")
         self.assertEqual(repr(mem), "<sme.Membrane named 'Outside <-> Cell'>")
         self.assertEqual(str(mem)[0:43], "<sme.Membrane>\n  - name: 'Outside <-> Cell'")
         self.assertEqual(mem.name, "Outside <-> Cell")
         self.assertEqual(len(mem.reactions), 2)
-        self.assertRaises(ValueError, lambda: mem.reaction("X"))
+        self.assertRaises(sme.InvalidArgument, lambda: mem.reaction("X"))
         r = mem.reaction("A uptake from outside")
         self.assertEqual(r.name, "A uptake from outside")
 
@@ -139,7 +142,7 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(p.name, "New param")
         self.assertEqual(p.value, "0.8765")
         self.assertEqual(len(m.parameters), 1)
-        self.assertRaises(ValueError, lambda: m.parameter("param"))
+        self.assertRaises(sme.InvalidArgument, lambda: m.parameter("param"))
         self.assertEqual(m.parameter("New param").name, "New param")
 
 
@@ -180,7 +183,7 @@ class TestReactionParameter(unittest.TestCase):
         self.assertEqual(k.value, 0.8765)
         r2 = m.compartment("Nucleus").reaction("A to B conversion")
         self.assertEqual(len(r2.parameters), 1)
-        self.assertRaises(ValueError, lambda: r2.parameter("k1"))
+        self.assertRaises(sme.InvalidArgument, lambda: r2.parameter("k1"))
         self.assertEqual(r2.parameter("New k").name, "New k")
 
 


### PR DESCRIPTION
  - add optional parameter `timeout_seconds` to model.simulate()
  - if the simulation takes longer than `timeout_seconds`, it throws a runtime exception
  - `timeout_seconds` has a default value of 86400 (1 day)
  - resolves #327
  - note:
    - the timeout is only checked at the end of each timestep
    - i.e. it is done by sme, not by the underlying simulator
    - so if the timestep itself takes forever, this timeout won't help
