### PR TITLE
user can edit membrane names

### DIFF
--- a/src/core/model/inc/model_membranes.hpp
+++ b/src/core/model/inc/model_membranes.hpp
@@ -36,6 +36,7 @@ private:
 public:
   const QStringList &getIds() const;
   const QStringList &getNames() const;
+  QString setName(const QString &id, const QString &name);
   QString getName(const QString &id) const;
   const std::vector<geometry::Membrane> &getMembranes() const;
   const geometry::Membrane *getMembrane(const QString &id) const;

--- a/src/core/model/src/model_membranes.cpp
+++ b/src/core/model/src/model_membranes.cpp
@@ -22,6 +22,20 @@ const QStringList &ModelMembranes::getIds() const { return ids; }
 
 const QStringList &ModelMembranes::getNames() const { return names; }
 
+QString ModelMembranes::setName(const QString &id, const QString &name){
+  auto i = ids.indexOf(id);
+  if (i < 0) {
+    return {};
+  }
+  if (names[i] == name) {
+    // no-op: setting name to the same value as it already had
+    return name;
+  }
+  hasUnsavedChanges = true;
+  names[i] = name;
+  return name;
+}
+
 QString ModelMembranes::getName(const QString &id) const {
   auto i = ids.indexOf(id);
   if (i < 0) {

--- a/src/core/model/src/model_membranes_t.cpp
+++ b/src/core/model/src/model_membranes_t.cpp
@@ -32,6 +32,9 @@ SCENARIO("SBML membranes",
       REQUIRE(ms.getIds().isEmpty());
       REQUIRE(ms.getMembranes().empty());
       REQUIRE(ms.getNames().isEmpty());
+      // set name is no-op if not found
+      ms.setName("dontexist", "new name");
+      REQUIRE(ms.getNames().isEmpty());
       ms.setHasUnsavedChanges(false);
       ms.updateCompartments(compartments);
       ms.setHasUnsavedChanges(true);
@@ -45,6 +48,13 @@ SCENARIO("SBML membranes",
       REQUIRE(ms.getIds()[0] == "c1_c0_membrane");
       REQUIRE(ms.getNames().size() == 1);
       REQUIRE(ms.getNames()[0] == "c1 name <-> c0 name");
+      ms.setHasUnsavedChanges(false);
+      // setting name to same value is a no-op
+      ms.setName("c1_c0_membrane", "c1 name <-> c0 name");
+      REQUIRE(ms.getHasUnsavedChanges() == false);
+      // but setting a new name is an unsaved change
+      ms.setName("c1_c0_membrane", "mem");
+      REQUIRE(ms.getHasUnsavedChanges() == true);
       REQUIRE(ms.getIdColourPairs().size() == 1);
       REQUIRE(ms.getIdColourPairs()[0].first == "c1_c0_membrane");
       REQUIRE(ms.getIdColourPairs()[0].second ==

--- a/src/gui/tabs/tabgeometry.hpp
+++ b/src/gui/tabs/tabgeometry.hpp
@@ -38,7 +38,8 @@ private:
   sme::model::Model &model;
   QLabelMouseTracker *lblGeometry;
   QLabel *statusBarPermanentMessage;
-  bool waitingForCompartmentChoice = false;
+  bool waitingForCompartmentChoice{false};
+  bool membraneSelected{false};
 
   void lblGeometry_mouseClicked(QRgb col, QPoint point);
   void btnAddCompartment_clicked();

--- a/src/gui/tabs/tabgeometry_t.cpp
+++ b/src/gui/tabs/tabgeometry_t.cpp
@@ -71,6 +71,7 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       REQUIRE(listCompartments->currentItem()->text() == "OutsideX");
       txtCompartmentName->setFocus();
       sendKeyEvents(txtCompartmentName, {"Backspace", "Enter"});
+      REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Outside");
       REQUIRE(listCompartments->currentItem()->text() == "Outside");
       // select Cell compartment
@@ -79,18 +80,31 @@ SCENARIO("Geometry Tab", "[gui/tabs/geometry][gui/tabs][gui][geometry]") {
       REQUIRE(listCompartments->currentItem()->text() == "Cell");
       REQUIRE(lblCompSize->text() == "Area: 4034 m^2 (4034 pixels)");
       REQUIRE(lblCompShape->getImage().pixel(20, 20) == 0xff9061c1);
+      REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Cell");
       // select first membrane
       listMembranes->setFocus();
       sendKeyEvents(listMembranes, {" "});
+      REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(listMembranes->currentItem()->text() == "Outside <-> Cell");
       REQUIRE(lblCompSize->text() == "Length: 338 m (338 pixels)");
       REQUIRE(txtCompartmentName->text() == "Outside <-> Cell");
+      // change membrane name
+      txtCompartmentName->setFocus();
+      sendKeyEvents(txtCompartmentName, {"X", "Enter"});
+      REQUIRE(txtCompartmentName->text() == "Outside <-> CellX");
+      REQUIRE(listMembranes->currentItem()->text() == "Outside <-> CellX");
+      txtCompartmentName->setFocus();
+      sendKeyEvents(txtCompartmentName, {"Backspace", "Enter"});
+      REQUIRE(txtCompartmentName->isEnabled() == true);
+      REQUIRE(txtCompartmentName->text() == "Outside <-> Cell");
+      REQUIRE(listMembranes->currentItem()->text() == "Outside <-> Cell");
       // select Nucleus compartment
       listCompartments->setFocus();
       sendKeyEvents(listCompartments, {"Down"});
       REQUIRE(listCompartments->currentItem()->text() == "Nucleus");
       REQUIRE(lblCompSize->text() == "Area: 525 m^2 (525 pixels)");
+      REQUIRE(txtCompartmentName->isEnabled() == true);
       REQUIRE(txtCompartmentName->text() == "Nucleus");
       REQUIRE(lblCompShape->getImage().pixel(50, 50) == 0xffc58560);
 


### PR DESCRIPTION
- add setName() method to ModelMembranes
- when membranes are first created in the GUI, automatic name "compA <-> compB" is used
- user can edit the name in the GUI, and when the model is saved this name is saved to sbml
- sbml name takes precedence over the automatic name
- resolves #287
