### PR TITLE
add support for importing COPASI cps files

### DIFF
--- a/src/core/model/src/model.cpp
+++ b/src/core/model/src/model.cpp
@@ -14,6 +14,7 @@
 #include <sbml/packages/spatial/extension/SpatialExtension.h>
 #include <stdexcept>
 #include <utility>
+#include <QFileInfo>
 
 namespace sme::model {
 
@@ -30,17 +31,9 @@ void Model::createSBMLFile(const std::string &name) {
   initModelData();
 }
 
-static QString removeExtension(const std::string &filename) {
-  QString f{filename.c_str()};
-  if (int len{f.lastIndexOf(".")}; len > 0) {
-    f.truncate(len);
-  }
-  return f;
-}
-
 void Model::importSBMLFile(const std::string &filename) {
   clear();
-  currentFilename = removeExtension(filename);
+  currentFilename = QFileInfo(filename.c_str()).baseName();
   SPDLOG_INFO("Loading SBML file {}...", filename);
   doc.reset(libsbml::readSBMLFromFile(filename.c_str()));
   initModelData();
@@ -50,7 +43,7 @@ void Model::importSBMLFile(const std::string &filename) {
 void Model::importSBMLString(const std::string &xml,
                              const std::string &filename) {
   clear();
-  currentFilename = removeExtension(filename);
+  currentFilename = QFileInfo(filename.c_str()).baseName();
   SPDLOG_INFO("Importing SBML from string...");
   doc.reset(libsbml::readSBMLFromString(xml.c_str()));
   initModelData();
@@ -127,7 +120,7 @@ void Model::exportSBMLFile(const std::string &filename) {
 
 void Model::importFile(const std::string &filename) {
   clear();
-  currentFilename = removeExtension(filename);
+  currentFilename = QFileInfo(filename.c_str()).baseName();
   SPDLOG_INFO("Importing file {} ...", filename);
   auto contents{utils::importSmeFile(filename)};
   if (!contents.xmlModel.empty()) {

--- a/src/gui/mainwindow.hpp
+++ b/src/gui/mainwindow.hpp
@@ -28,6 +28,7 @@ private:
   std::unique_ptr<Ui::MainWindow> ui;
   QLabel *statusBarPermanentMessage;
   sme::model::Model model;
+  bool haveCopasiSE{false};
 
   void setupTabs();
   void setupConnections();
@@ -46,6 +47,7 @@ private:
   TabEvents *tabEvents;
   TabSimulate *tabSimulate;
 
+  QString getConvertedFilename(const QString &cpsFilename);
   void validateSBMLDoc(const QString &filename = {});
   // if SBML model and geometry are both valid, enable all tabs
   void enableTabs();


### PR DESCRIPTION
- if `CopasiSE` is found on path, enable .cps file import
- uses CopasiSE to convert the cps file to a sbml xml file, then opens that
- resolves #493