### PR TITLE
ci improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,33 +97,8 @@ jobs:
         with:
           path: ./artefacts/*
 
-  update-latest-tag:
-    name: Update latest tag and remove existing latest release
-    if: github.repository == 'spatial-model-editor/spatial-model-editor' && github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-      - run: git show-ref --tags
-      - name: Delete any existing latest release
-        run: gh release delete latest || echo "No latest release found to delete"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Move latest tag
-        run: |
-          git push origin :refs/tags/latest
-          git tag -f latest
-          git push origin latest
-      - run: git show-ref --tags
-
   release:
-    needs: [linux-gui, macos-gui, win64-gui, update-latest-tag]
+    needs: [linux-gui, macos-gui, win64-gui]
     if: github.repository == 'spatial-model-editor/spatial-model-editor' && github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
@@ -140,7 +115,6 @@ jobs:
           overwrite: true
           file_glob: true
           prerelease: true
-          body: "Latest pre-release version"
       - name: Upload binaries to tagged release
         if: startsWith(github.event.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,13 +11,13 @@ env:
 jobs:
   linux-wheel:
     name: Linux Wheels
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.09
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.09
+      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.25
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.08.25
       CIBW_SKIP: '*-manylinux_i686'
       CIBW_TEST_SKIP: 'cp310-manylinux_x86_64'
       CIBW_ENVIRONMENT: 'SME_EXTERNAL_SMECORE=on'
@@ -26,6 +26,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - name: Set "latest" version number unless commit is version tagged
+      if: startsWith(github.event.ref, 'refs/tags/1.') == false
+      run: ./ci/set-latest-version.sh ${GITHUB_SHA}
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
@@ -50,6 +53,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
+      - name: Set "latest" version number unless commit is version tagged
+        if: startsWith(github.event.ref, 'refs/tags/1.') == false
+        run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -80,6 +86,9 @@ jobs:
           msystem: MINGW64
           update: true
           install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache make
+      - name: Set "latest" version number unless commit is version tagged
+        if: startsWith(github.event.ref, 'refs/tags/1.') == false
+        run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Download static libraries
         run: ./ci/getlibs.sh win64
       - name: Build wheels
@@ -107,6 +116,9 @@ jobs:
           msystem: MINGW32
           update: true
           install: mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-ccache make
+      - name: Set "latest" version number unless commit is version tagged
+        if: startsWith(github.event.ref, 'refs/tags/1.') == false
+        run: ./ci/set-latest-version.sh ${GITHUB_SHA}
       - name: Download static libraries
         run: ./ci/getlibs.sh win32
       - name: Build wheels
@@ -154,9 +166,9 @@ jobs:
         # upload selected wheels to github release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/sme-*-cp38-cp38-manylinux*x86_64.whl
+          file: dist/sme-*-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+          asset_name: sme-latest-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
           tag: latest
           overwrite: true
-          file_glob: true
+          file_glob: false
           prerelease: true
-          body: "Latest pre-release version"

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2021.07.13"
+SME_DEPS_VERSION="2021.08.25"
 OS=$1
 
 set -e -x

--- a/ci/linux-gui.sh
+++ b/ci/linux-gui.sh
@@ -42,7 +42,7 @@ tail -n 100 tests.txt
 
 # run python tests
 cd sme
-python -m pip install -r ../../sme/requirements.txt
+python -m pip install -r ../../sme/requirements-test.txt
 python -m unittest discover -s ../../sme/test -v
 PYTHONPATH=`pwd` python ../../sme/test/sme_doctest.py -v
 cd ..

--- a/ci/macos-gui.sh
+++ b/ci/macos-gui.sh
@@ -33,7 +33,7 @@ tail -n 100 tests.txt
 
 # run python tests
 cd sme
-python3 -m pip install -r ../../sme/requirements.txt
+python3 -m pip install -r ../../sme/requirements-test.txt
 python3 -m unittest discover -s ../../sme/test -v
 PYTHONPATH=`pwd` python ../../sme/test/sme_doctest.py -v
 cd ..

--- a/sme/requirements-test.txt
+++ b/sme/requirements-test.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
- also add git commit hash to version number for latest pre-release wheels
- rename pre-release wheel to remove explicit version to give fixed url for readthedocs pip install
- explicitly name the pre-release instead of using latest git commit message
- add sme/requirements-test.txt for CI to pip install before running tests
- update sme_deps & manylinux image -> 2021.08.25
