### PR TITLE
improve ccache use in wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,6 +29,12 @@ jobs:
     - name: Set "latest" version number unless commit is version tagged
       if: startsWith(github.event.ref, 'refs/tags/1.') == false
       run: ./ci/set-latest-version.sh ${GITHUB_SHA}
+    - name: Cache ccache
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/ccache
+        key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+        restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
@@ -56,6 +62,12 @@ jobs:
       - name: Set "latest" version number unless commit is version tagged
         if: startsWith(github.event.ref, 'refs/tags/1.') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: /Users/runner/Library/Caches/ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
@@ -89,6 +101,12 @@ jobs:
       - name: Set "latest" version number unless commit is version tagged
         if: startsWith(github.event.ref, 'refs/tags/1.') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: D:\a\_temp\msys\msys64\home\runneradmin\ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - name: Download static libraries
         run: ./ci/getlibs.sh win64
       - name: Build wheels
@@ -119,6 +137,12 @@ jobs:
       - name: Set "latest" version number unless commit is version tagged
         if: startsWith(github.event.ref, 'refs/tags/1.') == false
         run: ./ci/set-latest-version.sh ${GITHUB_SHA}
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: D:\a\_temp\msys\msys64\home\runneradmin\ccache
+          key: ccache-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ github.job }}-${{ runner.os }}-
       - name: Download static libraries
         run: ./ci/getlibs.sh win32
       - name: Build wheels

--- a/ci/linux-wheels.sh
+++ b/ci/linux-wheels.sh
@@ -4,6 +4,11 @@
 
 set -e -x
 
+ls /host
+export CCACHE_DIR=/host/home/runner/work/spatial-model-editor/spatial-model-editor/ccache
+
+ccache -s
+
 mkdir /project/build
 cd /project/build
 cmake .. \


### PR DESCRIPTION
- cache ccache dir
- note: linux docker image mounts root filesystem as /host
