### PR TITLE
add support for compressed sampledFields

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CIBUILDWHEEL_VERSION: 2.1.2
+  CIBUILDWHEEL_VERSION: 2.1.3
   CIBW_TEST_COMMAND: 'python -m unittest discover -v -s {project}/sme/test'
   CIBW_BUILD_VERBOSITY: 3
   SME_EXTERNAL_SMECORE: 'true'
@@ -25,8 +25,8 @@ jobs:
       run:
         shell: bash
     env:
-      CIBW_MANYLINUX_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.10.01
-      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: spatialmodeleditor/manylinux2010_x86_64:2021.10.01
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2010_x86_64:2021.10.14
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ghcr.io/spatial-model-editor/manylinux2010_x86_64:2021.10.14
       CIBW_SKIP: '*-manylinux_i686'
       CIBW_ENVIRONMENT: 'SME_EXTERNAL_SMECORE=on'
       CIBW_BEFORE_ALL: 'cd {project} && ls && bash ./ci/linux-wheels.sh'

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Spatial Model Editor makes use of the following open source libraries:
 
 - [Cereal](https://github.com/USCiLab/cereal) - license: [BSD](https://github.com/USCiLab/cereal/blob/master/LICENSE)
 
+- [zlib](https://zlib.net/) - license: [zlib](https://zlib.net/zlib_license.html)
+
 ## Licensing Note
 
 The source code in this repository is released under the MIT license, which is a permissive

--- a/ci/getlibs.sh
+++ b/ci/getlibs.sh
@@ -3,7 +3,7 @@
 # bash script to download static libs
 # usage: ./ci/getlibs.sh [linux, osx, win32, win64]
 
-SME_DEPS_VERSION="2021.10.04"
+SME_DEPS_VERSION="2021.10.15"
 OS=$1
 
 set -e -x

--- a/src/core/model/src/model_t.cpp
+++ b/src/core/model/src/model_t.cpp
@@ -964,3 +964,30 @@ TEST_CASE("SBML: import multi-compartment SBML doc without spatial geometry",
   REQUIRE(
       symEq(reactions.getRateExpression("ex"), "0.00166666666666667 * k1 * D"));
 }
+
+TEST_CASE("SBML: import SBML doc with compressed sampledField",
+          "[core/model/model][core/model][core][model]") {
+  auto s{getTestModel("all_SpatialImage_SpatialUseCompression")};
+  REQUIRE(s.getIsValid() == true);
+  REQUIRE(s.getName() == "CellOrganizer2_7");
+  REQUIRE(s.getGeometry().getIsValid() == true);
+  REQUIRE(s.getGeometry().getHasImage() == true);
+  REQUIRE(s.getCompartments().getIds().size() == 4);
+  REQUIRE(s.getCompartments().getCompartment("EC")->nPixels() == 358);
+  REQUIRE(s.getCompartments().getCompartment("cell")->nPixels() == 390);
+  REQUIRE(s.getCompartments().getCompartment("nuc")->nPixels() == 237);
+  REQUIRE(s.getCompartments().getCompartment("vesicle")->nPixels() == 5);
+  // export and re-import, check compartment geometry hasn't changed
+  s.exportSBMLFile("compressedExported.xml");
+  sme::model::Model s2;
+  s2.importSBMLFile("compressedExported.xml");
+  REQUIRE(s2.getIsValid() == true);
+  REQUIRE(s2.getName() == "CellOrganizer2_7");
+  REQUIRE(s2.getGeometry().getIsValid() == true);
+  REQUIRE(s2.getGeometry().getHasImage() == true);
+  REQUIRE(s2.getCompartments().getIds().size() == 4);
+  REQUIRE(s2.getCompartments().getCompartment("EC")->nPixels() == 358);
+  REQUIRE(s2.getCompartments().getCompartment("cell")->nPixels() == 390);
+  REQUIRE(s2.getCompartments().getCompartment("nuc")->nPixels() == 237);
+  REQUIRE(s2.getCompartments().getCompartment("vesicle")->nPixels() == 5);
+}

--- a/test/resources/models/all_SpatialImage_SpatialUseCompression.xml
+++ b/test/resources/models/all_SpatialImage_SpatialUseCompression.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:spatial="http://www.sbml.org/sbml/level3/version1/spatial/version1" level="3" spatial:required="true" version="1">
+   <model areaUnits="um2" id="CellOrganizer2_7" lengthUnits="um" name="CellOrganizer2_7" substanceUnits="molecules" timeUnits="s" volumeUnits="um3">
+      <spatial:geometry spatial:coordinateSystem="cartesian">
+         <spatial:listOfAdjacentDomains>
+            <spatial:adjacentDomains spatial:domain1="cell_domain" spatial:domain2="nuc_domain" spatial:id="cell1_nuc1"/>
+         </spatial:listOfAdjacentDomains>
+         <spatial:listOfCoordinateComponents>
+            <spatial:coordinateComponent spatial:id="x" spatial:type="cartesianX" spatial:unit="um">
+               <spatial:boundaryMin spatial:id="Xmin" spatial:value="0"/>
+               <spatial:boundaryMax spatial:id="Xmax" spatial:value="25.676"/>
+            </spatial:coordinateComponent>
+            <spatial:coordinateComponent spatial:id="y" spatial:type="cartesianY" spatial:unit="um">
+               <spatial:boundaryMin spatial:id="Ymin" spatial:value="-10"/>
+               <spatial:boundaryMax spatial:id="Ymax" spatial:value="10"/>
+            </spatial:coordinateComponent>
+            <spatial:coordinateComponent spatial:id="z" spatial:type="cartesianZ" spatial:unit="um">
+               <spatial:boundaryMin spatial:id="Zmin" spatial:value="-10"/>
+               <spatial:boundaryMax spatial:id="Zmax" spatial:value="10"/>
+            </spatial:coordinateComponent>
+         </spatial:listOfCoordinateComponents>
+         <spatial:listOfDomains>
+            <spatial:domain spatial:domainType="nuc_domainType" spatial:id="nuc_domain">
+               <spatial:listOfInteriorPoints>
+                  <spatial:interiorPoint spatial:coord1="5.243" spatial:coord2="12.103" spatial:coord3="0.049"/>
+               </spatial:listOfInteriorPoints>
+            </spatial:domain>
+            <spatial:domain spatial:domainType="cell_domainType" spatial:id="cell_domain">
+               <spatial:listOfInteriorPoints>
+                  <spatial:interiorPoint spatial:coord1="0.049" spatial:coord2="16.513" spatial:coord3="0.049"/>
+               </spatial:listOfInteriorPoints>
+            </spatial:domain>
+            <spatial:domain spatial:domainType="vesicle_domainType" spatial:id="vesicle_domain">
+               <spatial:listOfInteriorPoints>
+                  <spatial:interiorPoint spatial:coord1="12.887" spatial:coord2="4.949" spatial:coord3="0.049"/>
+               </spatial:listOfInteriorPoints>
+            </spatial:domain>
+            <spatial:domain spatial:domainType="EC_domainType" spatial:id="EC_domain">
+               <spatial:listOfInteriorPoints>
+                  <spatial:interiorPoint spatial:coord1="0.049" spatial:coord2="0.049" spatial:coord3="0.049"/>
+               </spatial:listOfInteriorPoints>
+            </spatial:domain>
+         </spatial:listOfDomains>
+         <spatial:listOfDomainTypes>
+            <spatial:domainType spatial:id="nuc_domainType" spatial:spatialDimensions="3"/>
+            <spatial:domainType spatial:id="cell_domainType" spatial:spatialDimensions="3"/>
+            <spatial:domainType spatial:id="vesicle_domainType" spatial:spatialDimensions="3"/>
+            <spatial:domainType spatial:id="EC_domainType" spatial:spatialDimensions="3"/>
+         </spatial:listOfDomainTypes>
+         <spatial:listOfGeometryDefinitions>
+            <spatial:sampledFieldGeometry spatial:id="universal_sampledFieldGeometry" spatial:isActive="true" spatial:sampledField="universal_sampledField">
+               <spatial:listOfSampledVolumes>
+                  <spatial:sampledVolume spatial:domainType="nuc_domainType" spatial:id="nuc_sampledVolume" spatial:maxValue="3.5" spatial:minValue="2.5"/>
+                  <spatial:sampledVolume spatial:domainType="cell_domainType" spatial:id="cell_sampledVolume" spatial:maxValue="2.5" spatial:minValue="1.5"/>
+                  <spatial:sampledVolume spatial:domainType="vesicle_domainType" spatial:id="vesicle_sampledVolume" spatial:maxValue="4.5" spatial:minValue="3.5"/>
+                  <spatial:sampledVolume spatial:domainType="EC_domainType" spatial:id="EC_sampledVolume" spatial:maxValue="1.5" spatial:minValue="0.5"/>
+               </spatial:listOfSampledVolumes>
+            </spatial:sampledFieldGeometry>
+         </spatial:listOfGeometryDefinitions>
+         <spatial:listOfSampledFields>
+            <spatial:sampledField spatial:compression="deflated" spatial:dataType="uint8" spatial:id="universal_sampledField" spatial:interpolationType="nearestNeighbor" spatial:numSamples1="33" spatial:numSamples2="30" spatial:numSamples3="24" spatial:samplesLength="1306">120 156 237 150 91 114 219 80 12 67 183 210 45 196 241 254 215 214 186 51 25 201 186 36 8 18 86 172 166 24 254 234 28 243 190 8 127 252 250 160 234 246 167 184 47 51 250 38 56 110 75 169 252 222 82 219 50 158 237 167 230 145 225 235 139 251 223 98 28 204 239 225 29 193 133 186 80 13 241 26 62 151 234 117 176 242 200 178 26 50 62 182 116 249 213 161 26 162 93 172 13 159 47 52 196 183 159 55 100 239 231 251 12 249 27 86 59 96 28 209 68 232 24 184 73 212 229 163 151 205 118 143 231 33 79 215 19 166 166 177 129 227 115 7 207 71 158 62 93 187 53 90 233 75 221 29 124 70 206 238 117 71 112 57 187 177 165 203 175 14 213 16 237 98 109 112 118 239 13 249 27 86 59 96 28 206 238 249 76 173 105 108 224 248 220 193 243 145 167 79 215 110 141 86 250 82 119 7 159 145 179 123 221 17 92 206 110 108 233 242 171 67 53 68 187 88 27 156 221 123 67 254 134 213 14 24 135 179 123 62 83 107 26 27 56 62 119 240 124 228 233 211 181 91 163 149 190 212 221 193 103 228 236 94 119 4 151 179 27 91 186 252 234 80 13 209 46 214 6 103 247 222 144 191 97 181 3 198 225 236 158 207 212 154 198 6 142 207 29 60 31 121 250 244 153 165 118 245 202 157 153 158 16 151 154 157 223 103 249 175 111 170 236 238 253 34 118 224 175 186 201 251 10 67 156 16 172 1 207 216 216 192 240 177 99 237 128 155 245 138 33 206 238 143 6 255 236 80 13 209 109 252 94 67 252 138 120 67 254 138 103 29 116 13 213 36 193 60 51 139 38 252 250 54 249 238 243 249 212 163 171 25 195 208 185 129 165 51 75 151 191 118 169 171 82 247 70 61 163 199 215 206 238 173 156 221 216 177 118 192 205 122 197 224 236 62 26 226 87 196 27 242 87 60 235 192 217 157 207 167 30 93 205 24 134 206 13 44 157 89 186 252 181 75 93 149 186 55 234 25 61 190 118 118 111 229 236 198 142 181 3 110 214 43 6 103 247 209 16 191 34 222 144 191 226 89 7 206 238 124 62 245 232 106 198 48 116 110 96 233 204 210 229 175 93 234 170 212 189 81 207 232 241 181 179 123 43 103 55 118 172 29 112 179 94 49 56 187 143 134 248 21 241 134 252 21 207 58 112 118 231 243 169 71 87 51 134 161 115 3 75 103 150 46 127 253 210 214 165 237 143 122 66 143 239 163 180 81 126 159 243 236 191 66 217 221 253 197 202 129 191 100 186 152 25 184 236 230 86 145 209 149 37 50 84 83 186 50 48 147 30 239 35 155 23 153 161 230 227 228 190 82 242 114 60 74 206 142 33 126 141 10 223 89 7 158 8 115 158 59 13 54 123 167 60 126 91 236 100 141 38 68 182 243 156 163 75 31 45 19 246 250 165 173 77 219 95 60 95 57 222 217 189 239 228 44 131 179 59 219 71 46 47 114 3 147 23 106 7 123 135 106 136 238 51 199 59 187 17 239 236 70 142 46 125 180 76 216 235 151 182 54 109 127 241 124 229 120 103 247 190 147 179 12 206 238 108 31 185 188 200 13 76 94 168 29 236 29 170 33 186 207 28 239 236 70 188 179 27 57 186 244 209 50 97 175 95 218 218 180 253 197 243 149 227 157 221 251 78 206 50 56 187 179 125 228 242 34 55 48 121 161 118 176 119 168 134 232 62 115 188 179 27 241 206 110 228 232 210 71 203 132 117 157 95 218 233 168 55 228 182 36 247 252 183 121 75 204 176 125 228 191 122 204 238 126 223 220 58 214 183 253 60 223 43 3 154 48 171 5 245 128 231 188 102 200 82 151 231 247 142 243 12 117 226 84 187 160 27 216 85 168 6 252 38 230 60 123 163 16 95 101 111 205 35 7 51 87 158 13 155 167 158 41 216 209 165 143 158 9 233 186 126 105 167 171 222 47 103 55 174 218 16 231 12 54 100 116 108 65 61 84 89 161 24 156 221 188 193 217 189 191 215 83 30 57 152 185 242 108 216 60 245 76 193 142 46 125 244 76 72 215 245 75 59 93 245 126 57 187 113 213 134 56 103 176 33 163 99 11 234 161 202 10 197 224 236 230 13 206 238 253 189 158 242 200 193 204 149 103 195 230 169 103 10 118 116 233 163 103 66 186 174 95 218 233 170 247 203 217 141 171 54 196 57 131 13 25 29 91 80 15 85 86 40 6 103 55 111 112 118 239 239 245 148 71 14 102 174 60 27 54 79 61 83 176 163 75 31 61 19 210 229 170 234 46 27 94 113 187 31 117 111 59 142 175 235 222 232 99 146 217 60 207 56 142 223 31 179 138 155 181 104 210 241 134 60 49 57 67 158 86 216 81 79 251 239 51 232 171 168 118 146 51 204 78 51 187 77 252 89 34 199 244 78 119 223 68 229 96 248 220 193 210 177 165 75 187 92 231 150 179 123 246 202 171 41 229 236 102 214 129 120 103 183 179 123 194 231 14 150 142 45 93 218 229 58 183 156 221 179 87 94 77 41 103 55 179 14 196 59 187 157 221 19 62 119 176 116 108 233 210 46 215 185 229 236 158 189 242 106 74 57 187 153 117 32 222 217 237 236 158 240 185 131 165 99 75 151 118 185 254 151 154 254 139 216 94 87 215 160 77 8 117 74 85 115 78 159 148 175 48 240 255 31 108 56 219 240 238 219 80 241 149 131 225 207 200 221 46 235 114 185 58 229 236 126 245 172 117 118 255 44 195 187 111 67 197 87 14 134 119 118 187 92 255 90 57 187 95 61 107 157 221 63 203 240 238 219 80 241 149 131 225 157 221 46 215 191 86 206 238 87 207 90 103 247 207 50 188 251 54 84 124 229 96 120 103 247 91 235 55 120 177 155 108</spatial:sampledField>
+         </spatial:listOfSampledFields>
+      </spatial:geometry>
+      <listOfUnitDefinitions>
+         <unitDefinition id="molecules">
+            <listOfUnits>
+               <unit exponent="1" kind="item" multiplier="1" scale="0"/>
+            </listOfUnits>
+         </unitDefinition>
+         <unitDefinition id="um3">
+            <listOfUnits>
+               <unit exponent="3" kind="metre" multiplier="1" scale="-6"/>
+            </listOfUnits>
+         </unitDefinition>
+         <unitDefinition id="um2">
+            <listOfUnits>
+               <unit exponent="2" kind="metre" multiplier="1" scale="-6"/>
+            </listOfUnits>
+         </unitDefinition>
+         <unitDefinition id="um">
+            <listOfUnits>
+               <unit exponent="1" kind="metre" multiplier="1" scale="-6"/>
+            </listOfUnits>
+         </unitDefinition>
+         <unitDefinition id="s">
+            <listOfUnits>
+               <unit exponent="1" kind="second" multiplier="1" scale="0"/>
+            </listOfUnits>
+         </unitDefinition>
+      </listOfUnitDefinitions>
+      <listOfCompartments>
+         <compartment constant="true" id="EC" name="EC" size="50000" spatialDimensions="3" units="um3">
+            <spatial:compartmentMapping spatial:domainType="EC_domainType" spatial:id="ECEC" spatial:unitSize="1"/>
+            <annotation>
+               <cellorganizer/>
+            </annotation>
+         </compartment>
+         <compartment constant="true" id="cell" name="cell" size="50000" spatialDimensions="3" units="um3">
+            <spatial:compartmentMapping spatial:domainType="cell_domainType" spatial:id="cellcell" spatial:unitSize="1"/>
+            <annotation>
+               <cellorganizer/>
+            </annotation>
+         </compartment>
+         <compartment constant="true" id="nuc" name="nuc" size="50000" spatialDimensions="3" units="um3">
+            <spatial:compartmentMapping spatial:domainType="nuc_domainType" spatial:id="nucnuc" spatial:unitSize="1"/>
+            <annotation>
+               <cellorganizer/>
+            </annotation>
+         </compartment>
+         <compartment constant="true" id="vesicle" name="vesicle" size="50000" spatialDimensions="3" units="um3">
+            <spatial:compartmentMapping spatial:domainType="vesicle_domainType" spatial:id="vesiclevesicle" spatial:unitSize="1"/>
+            <annotation>
+               <cellorganizer/>
+            </annotation>
+         </compartment>
+      </listOfCompartments>
+   </model>
+</sbml>

--- a/test/resources/test_resources.qrc
+++ b/test/resources/test_resources.qrc
@@ -20,6 +20,7 @@
         <file>models/single-pixel-meshing.xml</file>
         <file>models/small-single-compartment-diffusion.xml</file>
         <file>models/very-simple-model-invalid-reaction-location.xml</file>
+	<file>models/all_SpatialImage_SpatialUseCompression.xml</file>
         <file>geometry/gt1.png</file>
         <file>geometry/gt2.png</file>
         <file>geometry/gt3.png</file>


### PR DESCRIPTION
- use `double` overload of getSamples() if compressed
- update deps (libSBML is now compiled with zlib)
  - manylinux -> 2021.10.14 and switch to using ghcr.io
  - sme_deps -> 2021.10.15
  - cibuildwheel -> 2.1.3
- add test model with compressed sampledField from sbmlteam/sbml-spatial-models
- resolves #709
