### PR TITLE
revert removal of codecov token

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,6 +17,7 @@ defaults:
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   SONAR_SCANNER_VERSION: '4.6.2.2472'
 
 jobs:


### PR DESCRIPTION
- avoids possible github rate api issues if token is present
- won't be present on forks, so no change to existing behaviour for forks
