### PR TITLE
save/load Optimization settings to/from model

### DIFF
--- a/core/model/include/sme/model.hpp
+++ b/core/model/include/sme/model.hpp
@@ -17,6 +17,7 @@
 #include "sme/model_settings.hpp"
 #include "sme/model_species.hpp"
 #include "sme/model_units.hpp"
+#include "sme/optimize_options.hpp"
 #include "sme/serialization.hpp"
 #include "sme/simulate.hpp"
 #include "sme/simulate_options.hpp"
@@ -103,6 +104,8 @@ public:
   [[nodiscard]] const SimulationSettings &getSimulationSettings() const;
   MeshParameters &getMeshParameters();
   [[nodiscard]] const MeshParameters &getMeshParameters() const;
+  simulate::OptimizeOptions &getOptimizeOptions();
+  [[nodiscard]] const simulate::OptimizeOptions &getOptimizeOptions() const;
 
   explicit Model();
   Model(Model &&) noexcept = default;

--- a/core/model/include/sme/model_settings.hpp
+++ b/core/model/include/sme/model_settings.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "sme/optimize_options.hpp"
 #include "sme/simulate_options.hpp"
 #include <QRgb>
 #include <cereal/cereal.hpp>
@@ -71,12 +72,17 @@ struct Settings {
   DisplayOptions displayOptions{};
   MeshParameters meshParameters{};
   std::map<std::string, QRgb> speciesColours{};
+  sme::simulate::OptimizeOptions optimizeOptions{};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
     if (version == 0) {
       ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
          CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColours));
+    } else if (version == 1) {
+      ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
+         CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColours),
+         CEREAL_NVP(optimizeOptions));
     }
   }
 };
@@ -86,4 +92,4 @@ struct Settings {
 CEREAL_CLASS_VERSION(sme::model::MeshParameters, 1);
 CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 1);
 CEREAL_CLASS_VERSION(sme::model::SimulationSettings, 1);
-CEREAL_CLASS_VERSION(sme::model::Settings, 0);
+CEREAL_CLASS_VERSION(sme::model::Settings, 1);

--- a/core/model/src/model.cpp
+++ b/core/model/src/model.cpp
@@ -263,6 +263,15 @@ const MeshParameters &Model::getMeshParameters() const {
   return settings->meshParameters;
 }
 
+simulate::OptimizeOptions &Model::getOptimizeOptions() {
+  return settings->optimizeOptions;
+}
+
+[[nodiscard]] const simulate::OptimizeOptions &
+Model::getOptimizeOptions() const {
+  return settings->optimizeOptions;
+}
+
 void Model::clear() {
   doc.reset();
   isValid = false;

--- a/core/model/src/xml_annotation_t.cpp
+++ b/core/model/src/xml_annotation_t.cpp
@@ -29,6 +29,15 @@ TEST_CASE("XML Annotations",
     simulationSettings.options.dune.dt = 0.0123;
     auto &meshParameters{settings.meshParameters};
     meshParameters.boundarySimplifierType = 1;
+    auto &optimizeOptions{settings.optimizeOptions};
+    optimizeOptions.nParticles = 7;
+    auto &optCost{optimizeOptions.optCosts.emplace_back()};
+    optCost.name = "myOptCost";
+    optCost.targetValues = {1.0, 3.0, 5.0};
+    auto &optParam{optimizeOptions.optParams.emplace_back()};
+    optParam.name = "myOptParam";
+    // todo: populate all fields above
+
     model::setSbmlAnnotation(model, settings);
 
     // load them from sbml
@@ -44,12 +53,25 @@ TEST_CASE("XML Annotations",
     REQUIRE(newSimulationSettings.times.size() == 2);
     REQUIRE(newSimulationSettings.options.pixel.maxThreads == 4);
     REQUIRE(newSimulationSettings.options.dune.dt == dbl_approx(0.0123));
-    auto &newMeshParameters{settings.meshParameters};
+    auto &newMeshParameters{newSettings.meshParameters};
     REQUIRE(newMeshParameters.boundarySimplifierType == 1);
+    auto &newOptimizeOptions{newSettings.optimizeOptions};
+    REQUIRE(newOptimizeOptions.nParticles == 7);
+    REQUIRE(newOptimizeOptions.optCosts.size() == 1);
+    REQUIRE(newOptimizeOptions.optCosts[0].name == "myOptCost");
+    REQUIRE(newOptimizeOptions.optCosts[0].targetValues.size() == 3);
+    REQUIRE(newOptimizeOptions.optCosts[0].targetValues[0] == dbl_approx(1.0));
+    REQUIRE(newOptimizeOptions.optCosts[0].targetValues[1] == dbl_approx(3.0));
+    REQUIRE(newOptimizeOptions.optCosts[0].targetValues[2] == dbl_approx(5.0));
+    REQUIRE(newOptimizeOptions.optParams.size() == 1);
+    REQUIRE(newOptimizeOptions.optParams[0].name == "myOptParam");
 
     // change options, save & write to file
     newSimulationSettings.times.push_back({7, 0.33});
     newSimulationSettings.options.pixel.maxThreads = 16;
+    newOptimizeOptions.nParticles = 4;
+    newOptimizeOptions.optCosts.emplace_back().name = "optCost2";
+    newOptimizeOptions.optParams[0].name = "newOptParamName";
     model::setSbmlAnnotation(model, newSettings);
     libsbml::writeSBMLToFile(doc.get(), "tmpxmlsettings.xml");
 
@@ -70,6 +92,18 @@ TEST_CASE("XML Annotations",
     REQUIRE(simulationSettings2.times.size() == 3);
     REQUIRE(simulationSettings2.options.pixel.maxThreads == 16);
     REQUIRE(simulationSettings2.options.dune.dt == dbl_approx(0.0123));
+    auto &optimizeOptions2{settings2.optimizeOptions};
+    REQUIRE(optimizeOptions2.nParticles == 4);
+    REQUIRE(optimizeOptions2.optCosts.size() == 2);
+    REQUIRE(optimizeOptions2.optCosts[0].name == "myOptCost");
+    REQUIRE(optimizeOptions2.optCosts[0].targetValues.size() == 3);
+    REQUIRE(optimizeOptions2.optCosts[0].targetValues[0] == dbl_approx(1.0));
+    REQUIRE(optimizeOptions2.optCosts[0].targetValues[1] == dbl_approx(3.0));
+    REQUIRE(optimizeOptions2.optCosts[0].targetValues[2] == dbl_approx(5.0));
+    REQUIRE(optimizeOptions2.optCosts[1].name == "optCost2");
+    REQUIRE(optimizeOptions2.optCosts[1].targetValues.empty());
+    REQUIRE(optimizeOptions2.optParams.size() == 1);
+    REQUIRE(optimizeOptions2.optParams[0].name == "newOptParamName");
   }
   SECTION("Invalid settings annotations") {
     auto doc{getTestSbmlDoc("ABtoC-invalid-annotation")};
@@ -79,6 +113,8 @@ TEST_CASE("XML Annotations",
     REQUIRE(settings.meshParameters.maxAreas.empty());
     REQUIRE(settings.displayOptions.showSpecies.empty());
     REQUIRE(settings.simulationSettings.times.empty());
+    REQUIRE(settings.optimizeOptions.optCosts.empty());
+    REQUIRE(settings.optimizeOptions.optParams.empty());
     REQUIRE(settings.speciesColours.empty());
   }
 }

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -19,7 +19,7 @@ private:
   pagmo::problem prob;
   pagmo::algorithm algo;
   pagmo::population pop;
-  OptimizeOptions options;
+  const OptimizeOptions &options;
   std::atomic<bool> isRunning{false};
   std::atomic<bool> stopRequested{false};
   std::atomic<std::size_t> nIterations{0};
@@ -28,14 +28,11 @@ private:
 
 public:
   /**
-   * @brief Constructs an Optimization object from the supplied model and
-   * optimization options
+   * @brief Constructs an Optimization object from the supplied model
    *
    * @param[in] model the model to optimize
-   * @param[in] optimizeOptions the optimization options
    */
-  explicit Optimization(sme::model::Model &model,
-                        OptimizeOptions optimizeOptions);
+  explicit Optimization(sme::model::Model &model);
   /**
    * @brief Do n iterations of parameter optimization
    */

--- a/core/simulate/include/sme/optimize_options.hpp
+++ b/core/simulate/include/sme/optimize_options.hpp
@@ -1,5 +1,7 @@
 #pragma once
-#include <QString>
+#include <cereal/cereal.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/vector.hpp>
 #include <vector>
 
 namespace sme::simulate {
@@ -20,15 +22,15 @@ struct OptParam {
   /**
    * @brief The name of this OptParam as displayed to the user
    */
-  QString name;
+  std::string name;
   /**
    * @brief The id of the parameter in the model
    */
-  QString id;
+  std::string id;
   /**
    * @brief The id of the parent of the parameter in the model (optional)
    */
-  QString parentId;
+  std::string parentId;
   /**
    * @brief The lower bound on the allowed values of the parameter
    */
@@ -37,6 +39,14 @@ struct OptParam {
    * @brief The upper bound on the allowed values of the parameter
    */
   double upperBound;
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(optParamType), CEREAL_NVP(name), CEREAL_NVP(id),
+         CEREAL_NVP(parentId), CEREAL_NVP(lowerBound), CEREAL_NVP(upperBound));
+    }
+  }
 };
 
 /**
@@ -65,11 +75,11 @@ struct OptCost {
   /**
    * @brief The name of this OptCost as displayed to the user
    */
-  QString name;
+  std::string name;
   /**
    * @brief The id of the species in the model
    */
-  QString id;
+  std::string id;
   /**
    * @brief The simulation time at which the cost function should be calculated
    */
@@ -80,7 +90,7 @@ struct OptCost {
    * This assigns a relative weight to this cost when the optimization involves
    * the sum of multiple cost functions.
    */
-  double scaleFactor{1.0};
+  double weight{1.0};
   /**
    * @brief The index of the compartment containing the species
    */
@@ -104,6 +114,16 @@ struct OptCost {
    * avoid numerical issues caused by dividing by zero.
    */
   double epsilon{1e-15};
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(optCostType), CEREAL_NVP(optCostDiffType), CEREAL_NVP(name),
+         CEREAL_NVP(id), CEREAL_NVP(simulationTime), CEREAL_NVP(weight),
+         CEREAL_NVP(compartmentIndex), CEREAL_NVP(speciesIndex),
+         CEREAL_NVP(targetValues), CEREAL_NVP(epsilon));
+    }
+  }
 };
 
 /**
@@ -122,6 +142,17 @@ struct OptimizeOptions {
    * @brief The costs to minimize
    */
   std::vector<OptCost> optCosts;
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(nParticles), CEREAL_NVP(optParams), CEREAL_NVP(optCosts));
+    }
+  }
 };
 
 } // namespace sme::simulate
+
+CEREAL_CLASS_VERSION(sme::simulate::OptimizeOptions, 0);
+CEREAL_CLASS_VERSION(sme::simulate::OptCost, 0);
+CEREAL_CLASS_VERSION(sme::simulate::OptParam, 0);

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -8,9 +8,8 @@
 
 namespace sme::simulate {
 
-Optimization::Optimization(sme::model::Model &model,
-                           OptimizeOptions optimizeOptions)
-    : options{std::move(optimizeOptions)} {
+Optimization::Optimization(sme::model::Model &model)
+    : options{model.getOptimizeOptions()} {
   PagmoUDP udp{};
   udp.init(model.getXml().toStdString(), options);
   prob = pagmo::problem{std::move(udp)};
@@ -61,7 +60,7 @@ std::vector<QString> Optimization::getParamNames() const {
   std::vector<QString> names;
   names.reserve(options.optParams.size());
   for (const auto &optParam : options.optParams) {
-    names.push_back(optParam.name);
+    names.push_back(optParam.name.c_str());
   }
   return names;
 }

--- a/core/simulate/src/optimize_impl.cpp
+++ b/core/simulate/src/optimize_impl.cpp
@@ -11,15 +11,15 @@ void applyParameters(const pagmo::vector_double &values,
     double value{values[i]};
     switch (param.optParamType) {
     case OptParamType::ModelParameter:
-      SPDLOG_INFO("Setting parameter '{}' to {}", param.id.toStdString(),
-                  value);
-      model->getParameters().setExpression(param.id,
+      SPDLOG_INFO("Setting parameter '{}' to {}", param.id, value);
+      model->getParameters().setExpression(param.id.c_str(),
                                            common::dblToQStr(value, 17));
       break;
     case OptParamType::ReactionParameter:
       SPDLOG_INFO("Setting reaction parameter '{}' of reaction '{}' to {}",
-                  param.id.toStdString(), param.parentId.toStdString(), value);
-      model->getReactions().setParameterValue(param.parentId, param.id, value);
+                  param.id, param.parentId, value);
+      model->getReactions().setParameterValue(param.parentId.c_str(),
+                                              param.id.c_str(), value);
       break;
     default:
       throw std::invalid_argument("Optimization: Invalid OptParamType");
@@ -68,7 +68,7 @@ double calculateCosts(const std::vector<OptCost> &optCosts,
         values[i] = std::abs(diff);
       }
     }
-    cost += optCost.scaleFactor * sme::common::sum(values);
+    cost += optCost.weight * sme::common::sum(values);
   }
   return cost;
 }

--- a/core/simulate/src/optimize_impl_t.cpp
+++ b/core/simulate/src/optimize_impl_t.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Optimize calculateCosts: zero or no target values",
   optCostConc.optCostDiffType = simulate::OptCostDiffType::Absolute;
   optCostConc.name = "name";
   optCostConc.id = "A";
-  optCostConc.scaleFactor = 1.0;
+  optCostConc.weight = 1.0;
   optCostConc.compartmentIndex = 0;
   optCostConc.speciesIndex = 0;
   optCostConc.targetValues = {};
@@ -72,7 +72,7 @@ TEST_CASE("Optimize calculateCosts: zero or no target values",
   optCostDcdt.optCostDiffType = simulate::OptCostDiffType::Absolute;
   optCostDcdt.name = "name";
   optCostDcdt.id = "A";
-  optCostDcdt.scaleFactor = 1.0;
+  optCostDcdt.weight = 1.0;
   optCostDcdt.compartmentIndex = 0;
   optCostDcdt.speciesIndex = 0;
   optCostDcdt.targetValues = {};
@@ -176,7 +176,7 @@ TEST_CASE("Optimize calculateCosts: target values",
   optCostConcAbs.name = "name";
   optCostConcAbs.id = "A";
   optCostConcAbs.simulationTime = 100.0;
-  optCostConcAbs.scaleFactor = 1.0;
+  optCostConcAbs.weight = 1.0;
   optCostConcAbs.compartmentIndex = 0;
   optCostConcAbs.speciesIndex = 0;
   optCostConcAbs.targetValues = target;
@@ -187,7 +187,7 @@ TEST_CASE("Optimize calculateCosts: target values",
   optCostDcdtAbs.name = "name";
   optCostDcdtAbs.id = "A";
   optCostDcdtAbs.simulationTime = 100.0 * (1 + 1e-14);
-  optCostDcdtAbs.scaleFactor = 1.0;
+  optCostDcdtAbs.weight = 1.0;
   optCostDcdtAbs.compartmentIndex = 0;
   optCostDcdtAbs.speciesIndex = 0;
   optCostDcdtAbs.targetValues = target;
@@ -198,7 +198,7 @@ TEST_CASE("Optimize calculateCosts: target values",
   optCostConcRel.name = "name";
   optCostConcRel.id = "A";
   optCostConcRel.simulationTime = 100.0 * (1 - 1e-14);
-  optCostConcRel.scaleFactor = 1.0;
+  optCostConcRel.weight = 1.0;
   optCostConcRel.compartmentIndex = 0;
   optCostConcRel.speciesIndex = 0;
   optCostConcRel.targetValues = target;
@@ -210,7 +210,7 @@ TEST_CASE("Optimize calculateCosts: target values",
   optCostDcdtRel.name = "name";
   optCostDcdtRel.id = "A";
   optCostDcdtRel.simulationTime = 100.0;
-  optCostDcdtRel.scaleFactor = 1.0;
+  optCostDcdtRel.weight = 1.0;
   optCostDcdtRel.compartmentIndex = 0;
   optCostDcdtRel.speciesIndex = 0;
   optCostDcdtRel.targetValues = target;

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -63,7 +63,7 @@ DialogOptCost::DialogOptCost(
     ui->cmbCostType->setEnabled(false);
     ui->txtSimulationTime->setEnabled(false);
     ui->btnEditTargetValues->setEnabled(false);
-    ui->txtScaleFactor->setEnabled(false);
+    ui->txtWeight->setEnabled(false);
     ui->txtEpsilon->setEnabled(false);
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
   } else {
@@ -75,12 +75,12 @@ DialogOptCost::DialogOptCost(
     ui->cmbCostType->setCurrentIndex(toIndex(optCost.optCostType));
     ui->cmbDiffType->setCurrentIndex(toIndex(optCost.optCostDiffType));
     ui->txtSimulationTime->setText(QString::number(optCost.simulationTime));
-    ui->txtScaleFactor->setText(QString::number(optCost.scaleFactor));
+    ui->txtWeight->setText(QString::number(optCost.weight));
     ui->txtEpsilon->setText(QString::number(optCost.epsilon));
     ui->txtEpsilon->setEnabled(optCost.optCostDiffType ==
                                sme::simulate::OptCostDiffType::Relative);
     for (const auto &defaultOptCost : defaultOptCosts) {
-      ui->cmbSpecies->addItem(defaultOptCost.name);
+      ui->cmbSpecies->addItem(defaultOptCost.name.c_str());
       if (defaultOptCost.name == optCost.name) {
         cmbIndex = ui->cmbSpecies->count() - 1;
       }
@@ -95,8 +95,8 @@ DialogOptCost::DialogOptCost(
             &DialogOptCost::txtSimulationTime_editingFinished);
     connect(ui->btnEditTargetValues, &QPushButton::clicked, this,
             &DialogOptCost::btnEditTargetValues_clicked);
-    connect(ui->txtScaleFactor, &QLineEdit::editingFinished, this,
-            &DialogOptCost::txtScaleFactor_editingFinished);
+    connect(ui->txtWeight, &QLineEdit::editingFinished, this,
+            &DialogOptCost::txtWeight_editingFinished);
     connect(ui->txtEpsilon, &QLineEdit::editingFinished, this,
             &DialogOptCost::txtEpsilon_editingFinished);
     ui->cmbSpecies->setCurrentIndex(cmbIndex);
@@ -120,7 +120,7 @@ void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
     ui->cmbCostType->setCurrentIndex(toIndex(optCost.optCostType));
     ui->cmbDiffType->setCurrentIndex(toIndex(optCost.optCostDiffType));
     ui->txtSimulationTime->setText(QString::number(optCost.simulationTime));
-    ui->txtScaleFactor->setText(QString::number(optCost.scaleFactor));
+    ui->txtWeight->setText(QString::number(optCost.weight));
     ui->txtEpsilon->setText(QString::number(optCost.epsilon));
     ui->txtEpsilon->setEnabled(optCost.optCostDiffType ==
                                sme::simulate::OptCostDiffType::Relative);
@@ -145,7 +145,7 @@ void DialogOptCost::txtSimulationTime_editingFinished() {
 void DialogOptCost::btnEditTargetValues_clicked() {
   QString costType{ui->cmbCostType->currentText()};
   DialogConcentrationImage dialog(
-      optCost.targetValues, model.getSpeciesGeometry(optCost.id),
+      optCost.targetValues, model.getSpeciesGeometry(optCost.id.c_str()),
       model.getDisplayOptions().invertYAxis,
       QString("Set target %1").arg(costType),
       optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt);
@@ -154,9 +154,9 @@ void DialogOptCost::btnEditTargetValues_clicked() {
   }
 }
 
-void DialogOptCost::txtScaleFactor_editingFinished() {
-  optCost.scaleFactor = ui->txtScaleFactor->text().toDouble();
-  ui->txtScaleFactor->setText(toQStr(optCost.scaleFactor));
+void DialogOptCost::txtWeight_editingFinished() {
+  optCost.weight = ui->txtWeight->text().toDouble();
+  ui->txtWeight->setText(toQStr(optCost.weight));
 }
 
 void DialogOptCost::txtEpsilon_editingFinished() {

--- a/gui/dialogs/dialogoptcost.hpp
+++ b/gui/dialogs/dialogoptcost.hpp
@@ -31,6 +31,6 @@ private:
   void cmbDiffType_currentIndexChanged(int index);
   void txtSimulationTime_editingFinished();
   void btnEditTargetValues_clicked();
-  void txtScaleFactor_editingFinished();
+  void txtWeight_editingFinished();
   void txtEpsilon_editingFinished();
 };

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -43,7 +43,7 @@
       </widget>
      </item>
      <item row="5" column="3">
-      <widget class="QLineEdit" name="txtScaleFactor"/>
+      <widget class="QLineEdit" name="txtWeight"/>
      </item>
      <item row="2" column="3">
       <widget class="QComboBox" name="cmbDiffType">
@@ -72,7 +72,7 @@
      <item row="5" column="0">
       <widget class="QLabel" name="lblScaleFactorLabel">
        <property name="text">
-        <string>Scale factor:</string>
+        <string>Weight:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -166,7 +166,7 @@
   <tabstop>cmbDiffType</tabstop>
   <tabstop>txtSimulationTime</tabstop>
   <tabstop>btnEditTargetValues</tabstop>
-  <tabstop>txtScaleFactor</tabstop>
+  <tabstop>txtWeight</tabstop>
   <tabstop>txtEpsilon</tabstop>
  </tabstops>
  <resources/>

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -44,7 +44,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().id == "P0");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(12.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.2));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.2));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-12));
   }
   SECTION("user does nothing: correct initial values") {
@@ -56,11 +56,11 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -76,7 +76,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -91,7 +91,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -107,7 +107,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
     REQUIRE(dia.getOptCost().optCostType ==
@@ -120,7 +120,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/T0");
     REQUIRE(dia.getOptCost().id == "T0");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(19.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(0.1));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(0.1));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-13));
     REQUIRE(dia.getOptCost().speciesIndex == 3);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -134,7 +134,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -148,7 +148,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(62.8));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -165,7 +165,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -181,7 +181,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -223,7 +223,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -237,7 +237,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(62.8));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(62.8));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -251,7 +251,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-14));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
@@ -266,7 +266,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
     REQUIRE(dia.getOptCost().simulationTime == dbl_approx(10.0));
-    REQUIRE(dia.getOptCost().scaleFactor == dbl_approx(1.0));
+    REQUIRE(dia.getOptCost().weight == dbl_approx(1.0));
     REQUIRE(dia.getOptCost().epsilon == dbl_approx(1e-17));
     REQUIRE(dia.getOptCost().speciesIndex == 1);
     REQUIRE(dia.getOptCost().compartmentIndex == 0);

--- a/gui/dialogs/dialogoptimize.cpp
+++ b/gui/dialogs/dialogoptimize.cpp
@@ -51,10 +51,8 @@ static void initParamsPlot(QCustomPlot *plot,
   plot->replot();
 }
 
-DialogOptimize::DialogOptimize(
-    sme::model::Model &model,
-    const sme::simulate::OptimizeOptions &optimizeOptions, QWidget *parent)
-    : QDialog(parent), model{model}, optimizeOptions{optimizeOptions},
+DialogOptimize::DialogOptimize(sme::model::Model &model, QWidget *parent)
+    : QDialog(parent), model{model},
       ui{std::make_unique<Ui::DialogOptimize>()} {
   ui->setupUi(this);
   connect(ui->btnStart, &QPushButton::clicked, this,
@@ -84,7 +82,8 @@ DialogOptimize::DialogOptimize(
 DialogOptimize::~DialogOptimize() = default;
 
 void DialogOptimize::init() {
-  if (optimizeOptions.optParams.empty() || optimizeOptions.optCosts.empty()) {
+  if (model.getOptimizeOptions().optParams.empty() ||
+      model.getOptimizeOptions().optCosts.empty()) {
     opt.reset();
     ui->btnStart->setEnabled(false);
     ui->btnStop->setEnabled(false);
@@ -97,7 +96,7 @@ void DialogOptimize::init() {
   this->setCursor(Qt::WaitCursor);
   // todo: this constructor does one or more simulations, should be cancellable
   // & not blocking the GUI thread
-  opt = std::make_unique<sme::simulate::Optimization>(model, optimizeOptions);
+  opt = std::make_unique<sme::simulate::Optimization>(model);
   this->setCursor(Qt::ArrowCursor);
   ui->btnStart->setEnabled(true);
   ui->btnStop->setEnabled(false);
@@ -129,9 +128,9 @@ void DialogOptimize::btnStop_clicked() {
 }
 
 void DialogOptimize::btnSetup_clicked() {
-  DialogOptSetup dialogOptSetup(model, optimizeOptions);
+  DialogOptSetup dialogOptSetup(model);
   if (dialogOptSetup.exec() == QDialog::Accepted) {
-    optimizeOptions = dialogOptSetup.getOptimizeOptions();
+    model.getOptimizeOptions() = dialogOptSetup.getOptimizeOptions();
     init();
   }
 }

--- a/gui/dialogs/dialogoptimize.hpp
+++ b/gui/dialogs/dialogoptimize.hpp
@@ -16,14 +16,11 @@ class DialogOptimize : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogOptimize(sme::model::Model &model,
-                          const sme::simulate::OptimizeOptions &optimizeOptions,
-                          QWidget *parent = nullptr);
+  explicit DialogOptimize(sme::model::Model &model, QWidget *parent = nullptr);
   ~DialogOptimize() override;
 
 private:
   sme::model::Model &model;
-  sme::simulate::OptimizeOptions optimizeOptions;
   std::unique_ptr<Ui::DialogOptimize> ui;
   std::unique_ptr<sme::simulate::Optimization> opt;
   std::future<std::size_t> optIterations;

--- a/gui/dialogs/dialogoptimize_t.cpp
+++ b/gui/dialogs/dialogoptimize_t.cpp
@@ -27,9 +27,11 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
                                       0,
                                       0,
                                       {}});
+  model.getOptimizeOptions() = optimizeOptions;
   ModalWidgetTimer mwt;
   SECTION("no optimizeOptions") {
-    DialogOptimize dia(model, {});
+    model.getOptimizeOptions() = {};
+    DialogOptimize dia(model);
     // get pointers to widgets within dialog
     auto *btnStart{dia.findChild<QPushButton *>("btnStart")};
     REQUIRE(btnStart != nullptr);
@@ -46,7 +48,7 @@ TEST_CASE("DialogOptimize", "[gui/dialogs/optcost][gui/"
     REQUIRE(btnApplyToModel->isEnabled() == false);
   }
   SECTION("existing optimizeOptions") {
-    DialogOptimize dia(model, optimizeOptions);
+    DialogOptimize dia(model);
     // get pointers to widgets within dialog
     auto *btnStart{dia.findChild<QPushButton *>("btnStart")};
     REQUIRE(btnStart != nullptr);

--- a/gui/dialogs/dialogoptparam.cpp
+++ b/gui/dialogs/dialogoptparam.cpp
@@ -27,7 +27,7 @@ DialogOptParam::DialogOptParam(
     ui->txtLowerBound->setText(toQStr(optParam.lowerBound));
     ui->txtUpperBound->setText(toQStr(optParam.upperBound));
     for (const auto &defaultOptParam : defaultOptParams) {
-      ui->cmbParameter->addItem(defaultOptParam.name);
+      ui->cmbParameter->addItem(defaultOptParam.name.c_str());
       if (defaultOptParam.optParamType == optParam.optParamType &&
           defaultOptParam.id == optParam.id &&
           defaultOptParam.parentId == optParam.parentId) {

--- a/gui/dialogs/dialogoptsetup.hpp
+++ b/gui/dialogs/dialogoptsetup.hpp
@@ -12,10 +12,8 @@ class DialogOptSetup : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogOptSetup(
-      const sme::model::Model &model,
-      const sme::simulate::OptimizeOptions &initialOptions = {},
-      QWidget *parent = nullptr);
+  explicit DialogOptSetup(const sme::model::Model &model,
+                          QWidget *parent = nullptr);
   ~DialogOptSetup() override;
   [[nodiscard]] const sme::simulate::OptimizeOptions &
   getOptimizeOptions() const;

--- a/gui/dialogs/dialogoptsetup_t.cpp
+++ b/gui/dialogs/dialogoptsetup_t.cpp
@@ -14,7 +14,6 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
   model.getSimulationSettings().simulatorType =
       sme::simulate::SimulatorType::Pixel;
   SECTION("No initial OptimizeOptions") {
-    sme::simulate::OptimizeOptions optimizeOptions{};
     DialogOptSetup dia(model);
     // get pointers to widgets within dialog
     auto *lstTargets{dia.findChild<QListWidget *>("lstTargets")};
@@ -346,7 +345,7 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
     optCost0.name = "cell/P0";
     optCost0.id = "P0";
     optCost0.simulationTime = 18.0;
-    optCost0.scaleFactor = 0.23;
+    optCost0.weight = 0.23;
     optCost0.compartmentIndex = 0;
     optCost0.speciesIndex = 0;
     optCost0.targetValues = {};
@@ -356,11 +355,12 @@ TEST_CASE("DialogOptSetup", "[gui/dialogs/optsetup][gui/"
     optCost1.name = "cell/T0";
     optCost1.id = "T0";
     optCost1.simulationTime = 9.0;
-    optCost1.scaleFactor = 0.99;
+    optCost1.weight = 0.99;
     optCost1.compartmentIndex = 0;
     optCost1.speciesIndex = 3;
     optCost1.targetValues = {};
-    DialogOptSetup dia(model, optimizeOptions);
+    model.getOptimizeOptions() = optimizeOptions;
+    DialogOptSetup dia(model);
     const auto &optParams{dia.getOptimizeOptions().optParams};
     const auto &optCosts{dia.getOptimizeOptions().optCosts};
     // get pointers to widgets within tab


### PR DESCRIPTION
- add `getOptimizeOptions()` to sme::Model
- add `optimizeOptions` member to `sme::model::Settings`
  - increment cereal class version of `Settings` to 1
- make optimization settings structs serializable
  - refactor `QString` -> `std::string`
  - add cereal name-value-pairs for all struct members
  - add cereal class versions for all structs
- remove `optimizeOptions` argument (as now included in model) from
  - `Optimization`
  - `DialogOptimize`
  - `DialogOptStep`
- rename `scaleFactor` parameter to `weight`
- resolves #762
