### PR TITLE
User can cancel geometry image import

### DIFF
--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -38,7 +38,8 @@ private:
   // offer user to load a valid one if not
   bool isValidModel();
   bool isValidModelAndGeometryImage();
-  void importGeometryImage(const sme::common::ImageStack &image);
+  void importGeometryImage(const sme::common::ImageStack &image,
+                           bool is_model_image = false);
   void tabMain_currentChanged(int index);
   TabGeometry *tabGeometry;
   TabSpecies *tabSpecies;


### PR DESCRIPTION
- Import of geometry image to model only happens if/when user clicks OK in `DialogGeometryImage`
- refactor `MainWindow::importGeometryImage`
  - add `is_model_image` bool argument
  - used to maintain existing color assignments if geometry image is from model and colours unchanged
- resolves #935
