### PR TITLE
Refactor symbolic function substitution

### DIFF
--- a/ci/gui-cli-Linux.sh
+++ b/ci/gui-cli-Linux.sh
@@ -41,9 +41,6 @@ ccache --show-stats
 # when (hopefully) the Xvfb display will be ready
 jwm &
 
-#temp: run tests with output to see where they hang
-./test/tests -as
-
 # run cpp tests
 time ./test/tests -as >tests.txt 2>&1 || (tail -n 1000 tests.txt && exit 1)
 tail -n 100 tests.txt


### PR DESCRIPTION
- post order traversal does substitution of function args and bodies
  - better than previous method of repeatedly calling xreplace until the expression stops changing
  - could also be done recursively but would be at risk of stack overflow errors for complex expressions
- user-provided recursive functions are now directly detected
  - no longer need to have a max number of iterations as a heuristic to detect this
  - user sees the recursively called function name in the error message
- extend the symbolic test suite
