### PR TITLE
Add numThreads to DuneOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [latest]
+### Added
+- option to set the maximum number of CPU threads the DuneCopasi simulator can use [#1082](https://github.com/spatial-model-editor/spatial-model-editor/issues/1082)
+- parameter fitting to CLI [#1073](https://github.com/spatial-model-editor/spatial-model-editor/issues/1073)
+- clipping planes to 3d rendering of compartment geometry and concentrations in the GUI [#972](https://github.com/spatial-model-editor/spatial-model-editor/issues/972)
+- steady state solver in the GUI [#1061](https://github.com/spatial-model-editor/spatial-model-editor/issues/1061)
+
 ## [1.9.0] - 2025-03-31
 ### Added
 - documentation for example models [#1025](https://github.com/spatial-model-editor/spatial-model-editor/issues/1025)

--- a/cli/src/cli_command.cpp
+++ b/cli/src/cli_command.cpp
@@ -42,6 +42,7 @@ bool runCommand(const Params &params) {
   s.getSimulationSettings().simulatorType = params.simType;
   auto &options{s.getSimulationSettings().options};
   options.pixel.enableMultiThreading = true;
+  options.dune.maxThreads = params.maxThreads;
   options.pixel.maxThreads = params.maxThreads;
   if (params.maxThreads == 1) {
     options.pixel.enableMultiThreading = false;

--- a/core/common/src/serialization_t.cpp
+++ b/core/common/src/serialization_t.cpp
@@ -314,9 +314,10 @@ TEST_CASE("Serialization",
     REQUIRE(s4.getColors()[1] == common::indexedColors()[1].rgb());
   }
   SECTION("settings xml roundtrip") {
-    sme::model::Settings s{};
+    model::Settings s{};
     s.simulationSettings.times = {{1, 0.3}, {2, 0.1}};
     s.simulationSettings.options.pixel.maxErr.rel = 0.02;
+    s.simulationSettings.options.dune.maxThreads = 7;
     auto xml{common::toXml(s)};
     auto s2{common::fromXml(xml)};
     REQUIRE(s2.simulationSettings.simulatorType ==
@@ -324,6 +325,7 @@ TEST_CASE("Serialization",
     REQUIRE(s2.simulationSettings.times == s.simulationSettings.times);
     REQUIRE(s2.simulationSettings.options.pixel.maxErr.rel ==
             dbl_approx(s.simulationSettings.options.pixel.maxErr.rel));
+    REQUIRE(s2.simulationSettings.options.dune.maxThreads == 7);
   }
   SECTION("check DE locale doesn't break settings xml roundtrip") {
     // https://github.com/spatial-model-editor/spatial-model-editor/issues/535

--- a/core/mesh/src/boundaries_t.cpp
+++ b/core/mesh/src/boundaries_t.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Boundaries", "[core/mesh/boundaries][core/mesh][core][boundaries]") {
 }
 
 TEST_CASE("Boundaries using images from Medha Bhattacharya",
-          "[core/mesh/boundaries][core/mesh][core][boundaries][expensive]") {
+          "[core/mesh/boundaries][core/mesh][core][boundaries]") {
   // images provided by Medha Bhattacharya
   // https://summerofcode.withgoogle.com/archive/2020/projects/4913136240427008/
   // https://drive.google.com/drive/folders/1z83_pUTlI7eYKL9J9iV-EV6lLAEqC7pG

--- a/core/simulate/include/sme/simulate_options.hpp
+++ b/core/simulate/include/sme/simulate_options.hpp
@@ -34,6 +34,7 @@ struct DuneOptions {
   double newtonRelErr{1e-8};
   double newtonAbsErr{0.0};
   std::string linearSolver{"RestartedGMRes"};
+  std::size_t maxThreads{0};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -48,6 +49,12 @@ struct DuneOptions {
          CEREAL_NVP(decrease), CEREAL_NVP(writeVTKfiles),
          CEREAL_NVP(newtonRelErr), CEREAL_NVP(newtonAbsErr),
          CEREAL_NVP(linearSolver));
+    } else if (version == 2) {
+      ar(CEREAL_NVP(discretization), CEREAL_NVP(integrator), CEREAL_NVP(dt),
+         CEREAL_NVP(minDt), CEREAL_NVP(maxDt), CEREAL_NVP(increase),
+         CEREAL_NVP(decrease), CEREAL_NVP(writeVTKfiles),
+         CEREAL_NVP(newtonRelErr), CEREAL_NVP(newtonAbsErr),
+         CEREAL_NVP(linearSolver), CEREAL_NVP(maxThreads));
     }
   }
 };
@@ -114,7 +121,7 @@ struct AvgMinMax {
 } // namespace sme::simulate
 
 CEREAL_CLASS_VERSION(sme::simulate::Options, 0);
-CEREAL_CLASS_VERSION(sme::simulate::DuneOptions, 1);
+CEREAL_CLASS_VERSION(sme::simulate::DuneOptions, 2);
 CEREAL_CLASS_VERSION(sme::simulate::PixelIntegratorError, 0);
 CEREAL_CLASS_VERSION(sme::simulate::PixelOptions, 0);
 CEREAL_CLASS_VERSION(sme::simulate::AvgMinMax, 0);

--- a/core/simulate/src/dunesim.hpp
+++ b/core/simulate/src/dunesim.hpp
@@ -39,6 +39,7 @@ private:
   std::unique_ptr<DuneImpl<3>> pDuneImpl3d;
   std::string currentErrorMessage{};
   common::ImageStack currentErrorImages{};
+  std::size_t numMaxThreads{0};
 
 public:
   explicit DuneSim(

--- a/core/simulate/src/simulate_steadystate_t.cpp
+++ b/core/simulate/src/simulate_steadystate_t.cpp
@@ -12,9 +12,8 @@
 using namespace sme;
 using namespace sme::test;
 
-TEST_CASE(
-    "SimulateSteadyState",
-    "[core][core/simulate][steadystate][core/simulate/simulate_steadystate]") {
+TEST_CASE("SimulateSteadyState", "[core][core/simulate][steadystate][core/"
+                                 "simulate/simulate_steadystate][expensive]") {
 
   auto m{getExampleModel(Mod::GrayScott)};
   const std::vector<std::string> comps{"compartment"};

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -789,7 +789,7 @@ static double analytic_2d(const QPoint &p, double t, double D, double t0) {
 
 TEST_CASE("Simulate: single-compartment-diffusion, circular geometry",
           "[core/simulate/simulate][core/"
-          "simulate][core][simulate][dune][pixel][expensive]") {
+          "simulate][core][simulate][dune][pixel]") {
   // see docs/tests/diffusion.rst for analytic expressions used here
   // NB central point of initial distribution: (48,99-48) <-> ix=1577
 
@@ -1643,7 +1643,7 @@ TEST_CASE("Reactions depend on x, y, t",
 
 TEST_CASE("circle membrane reaction",
           "[core/simulate/simulate][core/"
-          "simulate][core][simulate][dune][pixel][expensive]") {
+          "simulate][core][simulate][dune][pixel]") {
   auto mDune{getTestModel("membrane-reaction-circle")};
   auto mPixel{getTestModel("membrane-reaction-circle")};
   mDune.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
@@ -2022,9 +2022,8 @@ TEST_CASE("Events: continuing existing simulation",
   }
 }
 
-TEST_CASE(
-    "simulate w/options & save, load, re-simulate",
-    "[core/simulate/simulate][core/simulate][core][simulate][expensive]") {
+TEST_CASE("simulate w/options & save, load, re-simulate",
+          "[core/simulate/simulate][core/simulate][core][simulate]") {
   for (auto simulatorType :
        {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
     CAPTURE(simulatorType);

--- a/ext/getdeps.sh
+++ b/ext/getdeps.sh
@@ -1,7 +1,0 @@
-# simple script to download static libraries as used by linux CI builds
-# puts them in /opt/smelibs & removes anything that was there before
-URL=${1:-"https://github.com/spatial-model-editor/sme_deps/releases/latest/download/sme_deps_linux.tgz"}
-rm -rf /opt/smelibs
-rm -f sme_deps_linux.tgz
-wget $URL
-tar xf sme_deps_linux.tgz -C /

--- a/gui/dialogs/dialogsimulationoptions.cpp
+++ b/gui/dialogs/dialogsimulationoptions.cpp
@@ -84,6 +84,8 @@ void DialogSimulationOptions::setupConnections() {
   connect(ui->cmbDuneLinearSolver,
           qOverload<int>(&QComboBox::currentIndexChanged), this,
           &DialogSimulationOptions::cmbDuneLinearSolver_currentIndexChanged);
+  connect(ui->spnDuneThreads, qOverload<int>(&QSpinBox::valueChanged), this,
+          &DialogSimulationOptions::spnDuneThreads_valueChanged);
   connect(ui->btnDuneReset, &QPushButton::clicked, this,
           &DialogSimulationOptions::resetDuneToDefaults);
   // Pixel tab
@@ -122,6 +124,11 @@ void DialogSimulationOptions::loadDuneOpts() {
   selectMatchingOrFirstItem(ui->cmbDuneLinearSolver,
                             opt.dune.linearSolver.c_str());
   opt.dune.linearSolver = ui->cmbDuneLinearSolver->currentText().toStdString();
+  ui->spnDuneThreads->setMaximum(oneapi::tbb::info::default_concurrency());
+  if (opt.dune.maxThreads > ui->spnDuneThreads->maximum()) {
+    opt.dune.maxThreads = 0;
+  }
+  ui->spnDuneThreads->setValue(opt.dune.maxThreads);
 }
 
 void DialogSimulationOptions::cmbDuneIntegrator_currentIndexChanged(
@@ -173,6 +180,11 @@ void DialogSimulationOptions::cmbDuneLinearSolver_currentIndexChanged(
   opt.dune.linearSolver = ui->cmbDuneLinearSolver->currentText().toStdString();
 }
 
+void DialogSimulationOptions::spnDuneThreads_valueChanged(int value) {
+  opt.dune.maxThreads = static_cast<std::size_t>(value);
+  loadDuneOpts();
+}
+
 void DialogSimulationOptions::resetDuneToDefaults() {
   opt.dune = sme::simulate::DuneOptions{};
   loadDuneOpts();
@@ -187,11 +199,10 @@ void DialogSimulationOptions::loadPixelOpts() {
   ui->spnPixelThreads->setMaximum(oneapi::tbb::info::default_concurrency());
   if (opt.pixel.enableMultiThreading) {
     ui->spnPixelThreads->setEnabled(true);
-    int threads = static_cast<int>(opt.pixel.maxThreads);
-    if (threads > ui->spnPixelThreads->maximum()) {
-      threads = 0;
+    if (opt.pixel.maxThreads > ui->spnPixelThreads->maximum()) {
+      opt.pixel.maxThreads = 0;
     }
-    ui->spnPixelThreads->setValue(threads);
+    ui->spnPixelThreads->setValue(opt.pixel.maxThreads);
   } else {
     ui->spnPixelThreads->setEnabled(false);
   }

--- a/gui/dialogs/dialogsimulationoptions.hpp
+++ b/gui/dialogs/dialogsimulationoptions.hpp
@@ -7,14 +7,14 @@ namespace Ui {
 class DialogSimulationOptions;
 }
 
-class DialogSimulationOptions : public QDialog {
+class DialogSimulationOptions final : public QDialog {
   Q_OBJECT
 
 public:
   explicit DialogSimulationOptions(const sme::simulate::Options &options,
                                    QWidget *parent = nullptr);
-  ~DialogSimulationOptions();
-  const sme::simulate::Options &getOptions() const;
+  ~DialogSimulationOptions() override;
+  [[nodiscard]] const sme::simulate::Options &getOptions() const;
 
 private:
   void setupConnections();
@@ -37,6 +37,7 @@ private:
   void txtPixelDt_editingFinished();
   void chkPixelMultithread_stateChanged();
   void spnPixelThreads_valueChanged(int value);
+  void spnDuneThreads_valueChanged(int value);
   void chkPixelCSE_stateChanged();
   void spnPixelOptLevel_valueChanged(int value);
   void resetPixelToDefaults();

--- a/gui/dialogs/dialogsimulationoptions.ui
+++ b/gui/dialogs/dialogsimulationoptions.ui
@@ -38,13 +38,6 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="4" column="1">
-          <widget class="QLineEdit" name="txtDuneMaxDt">
-           <property name="toolTip">
-            <string>The maximum allowed timestep</string>
-           </property>
-          </widget>
-         </item>
          <item row="7" column="0">
           <widget class="QLabel" name="lblOutputFiles">
            <property name="text">
@@ -55,47 +48,17 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblDuneDiscretization">
-           <property name="text">
-            <string>Discretization</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="lblDuneMaxDt">
-           <property name="text">
-            <string>Max timestep</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLineEdit" name="txtDuneMinDt">
+         <item row="5" column="1">
+          <widget class="QLineEdit" name="txtDuneIncrease">
            <property name="toolTip">
-            <string>The minimum allowed timestep</string>
+            <string>The factor by which the timestep is increased after a successful integration step</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="lblDuneDecrease">
+         <item row="8" column="0">
+          <widget class="QLabel" name="lblDuneNewtonRel">
            <property name="text">
-            <string>Decrease factor</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lblDuneDt">
-           <property name="text">
-            <string>Initial timestep</string>
+            <string>Newton relative error</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -112,32 +75,6 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lblDuneIncrease">
-           <property name="text">
-            <string>Increase factor</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QLineEdit" name="txtDuneDecrease">
-           <property name="toolTip">
-            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbDuneDiscretization">
-           <item>
-            <property name="text">
-             <string>1st order FEM</string>
-            </property>
-           </item>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="lblDuneIntegrator">
            <property name="text">
@@ -148,24 +85,30 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblDuneDt">
+           <property name="text">
+            <string>Initial timestep</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblDuneDiscretization">
+           <property name="text">
+            <string>Discretization</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
          <item row="2" column="1">
           <widget class="QLineEdit" name="txtDuneDt">
            <property name="toolTip">
             <string>The initial timestep to use at the start of the simulation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="0" colspan="2">
-          <widget class="QPushButton" name="btnDuneReset">
-           <property name="text">
-            <string>Reset to default values</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QLineEdit" name="txtDuneIncrease">
-           <property name="toolTip">
-            <string>The factor by which the timestep is increased after a successful integration step</string>
            </property>
           </widget>
          </item>
@@ -216,43 +159,6 @@
            </item>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lblDuneMinDt">
-           <property name="text">
-            <string>Min timestep</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="lblDuneNewtonRel">
-           <property name="text">
-            <string>Newton relative error</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="QLineEdit" name="txtDuneNewtonRel">
-           <property name="toolTip">
-            <string>The relative (to initial) size of defect at which the Newton iteration is considered to have converged</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="lblDuneNewtonAbs">
-           <property name="text">
-            <string>Newton absolute error</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
          <item row="9" column="1">
           <widget class="QLineEdit" name="txtDuneNewtonAbs">
            <property name="toolTip">
@@ -260,10 +166,10 @@
            </property>
           </widget>
          </item>
-         <item row="10" column="0">
-          <widget class="QLabel" name="lblDuneLinearSolver">
+         <item row="4" column="0">
+          <widget class="QLabel" name="lblDuneMaxDt">
            <property name="text">
-            <string>Linear solver</string>
+            <string>Max timestep</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -302,7 +208,53 @@
            </item>
           </widget>
          </item>
-         <item row="11" column="0" rowspan="2" colspan="2">
+         <item row="5" column="0">
+          <widget class="QLabel" name="lblDuneIncrease">
+           <property name="text">
+            <string>Increase factor</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLineEdit" name="txtDuneNewtonRel">
+           <property name="toolTip">
+            <string>The relative (to initial) size of defect at which the Newton iteration is considered to have converged</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDuneDiscretization">
+           <item>
+            <property name="text">
+             <string>1st order FEM</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="lblDuneMinDt">
+           <property name="text">
+            <string>Min timestep</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="lblDuneDecrease">
+           <property name="text">
+            <string>Decrease factor</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0" rowspan="2" colspan="2">
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -314,6 +266,77 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item row="14" column="0" colspan="2">
+          <widget class="QPushButton" name="btnDuneReset">
+           <property name="text">
+            <string>Reset to default values</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="lblDuneNewtonAbs">
+           <property name="text">
+            <string>Newton absolute error</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="lblDuneLinearSolver">
+           <property name="text">
+            <string>Linear solver</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="txtDuneMinDt">
+           <property name="toolTip">
+            <string>The minimum allowed timestep</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLineEdit" name="txtDuneMaxDt">
+           <property name="toolTip">
+            <string>The maximum allowed timestep</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLineEdit" name="txtDuneDecrease">
+           <property name="toolTip">
+            <string>The factor by which the timestep is decreased after an unsuccessful integration step</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0">
+          <widget class="QLabel" name="lblDuneThreads">
+           <property name="text">
+            <string>Max CPU Threads</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="1">
+          <widget class="QSpinBox" name="spnDuneThreads">
+           <property name="toolTip">
+            <string>Limit the maximum number of CPU threads used</string>
+           </property>
+           <property name="specialValueText">
+            <string>unlimited</string>
+           </property>
+           <property name="maximum">
+            <number>128</number>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,8 +1,8 @@
 #include "catch_wrapper.hpp"
 #include "sme/logger.hpp"
 #include <QApplication>
-#include <QSurfaceFormat>
 #include <catch2/catch_session.hpp>
+#include <oneapi/tbb/global_control.h>
 
 int main(int argc, char *argv[]) {
   Catch::StringMaker<double>::precision = 25;


### PR DESCRIPTION
- use 0 (unlimited) as default
  - significantly faster than single thread when running models from our test suite
- add to DuneOptions and bump cereal version
- add to GUI
- add to CLI
- resolves #1082
