### PR TITLE
Resolve missing file dialogs on macos

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -3,9 +3,13 @@ target_sources(spatial-model-editor PRIVATE spatial-model-editor.cpp icon.rc)
 if(WIN32)
   set_target_properties(spatial-model-editor PROPERTIES WIN32_EXECUTABLE TRUE)
 elseif(APPLE)
-  set_target_properties(spatial-model-editor PROPERTIES MACOSX_BUNDLE TRUE)
-  set_target_properties(spatial-model-editor PROPERTIES MACOSX_BUNDLE_ICONFILE
-                                                        icon.icns)
+  set_target_properties(
+    spatial-model-editor
+    PROPERTIES MACOSX_BUNDLE TRUE
+               MACOSX_BUNDLE_NAME "spatial-model-editor"
+               MACOSX_BUNDLE_VERSION "${PROJECT_VERSION}"
+               MACOSX_BUNDLE_GUI_IDENTIFIER "org.spatial-model-editor.gui"
+               MACOSX_BUNDLE_ICONFILE icon.icns)
 endif()
 
 target_compile_features(spatial-model-editor PRIVATE cxx_std_17)


### PR DESCRIPTION
- add `MACOSX_BUNDLE_GUI_IDENTIFIER`
  - must be set as of macos 15.4 if native file dialogs are used
  - see https://bugreports.qt.io/browse/QTBUG-135882?focusedId=886223&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-886223
  - resolves #1085
- also add `MACOSX_BUNDLE_NAME` and `MACOSX_BUNDLE_VERSION`
