### PR TITLE
Fix getConcImage crash for dune sim with empty compartments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.1] - 2025-12-03
+### Fixed
+- crash for some models with empty compartments when using DuneCopasi simulator [#1089](https://github.com/spatial-model-editor/spatial-model-editor/issues/1089)
+
 ## [1.10.0] - 2025-11-20
 ### Added
 - option to set the maximum number of CPU threads the DuneCopasi simulator can use [#1082](https://github.com/spatial-model-editor/spatial-model-editor/issues/1082)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.10.0
+  VERSION 1.10.1
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES C CXX)
 

--- a/core/simulate/src/dunesim_impl.hpp
+++ b/core/simulate/src/dunesim_impl.hpp
@@ -271,16 +271,18 @@ private:
       SPDLOG_INFO("  - {} species", nSpecies);
       SPDLOG_INFO("    - of which {} non-constant species",
                   nNonConstantSpecies);
-      duneCompartments.push_back(
-          {comp->getId(),
-           compIndex,
-           nNonConstantSpecies,
-           compartmentSpeciesNames,
-           geometry::VoxelIndexer(imgVolume, comp->getVoxels()),
-           comp.get(),
-           {},
-           {},
-           std::vector<double>(nPixels * nNonConstantSpecies, 0.0)});
+      if (nNonConstantSpecies > 0) {
+        duneCompartments.push_back(
+            {comp->getId(),
+             compIndex,
+             nNonConstantSpecies,
+             compartmentSpeciesNames,
+             geometry::VoxelIndexer(imgVolume, comp->getVoxels()),
+             comp.get(),
+             {},
+             {},
+             std::vector<double>(nPixels * nNonConstantSpecies, 0.0)});
+      }
       ++compIndex;
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sme"
-version = "1.10.0"
+version = "1.10.1"
 description = "Spatial Model Editor python bindings"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
- empty compartments are (intentionally) not included in the simulation
- however they were included in initDuneSimCompartments
- this didn't affect simulation results, but did affect the species concentration image generation
- if there was an empty compartment before a compartment with species it would get an empty vector of concentrations for the empty compartment and then segfault
- extended existing empty compartment test to reproduce this issue
- bump version
- resolves #1089
