### PR TITLE
Add diffusion constants to parameter fitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## [latest]
+### Added
+- species diffusion constants to the parameters that can be fitted in parameter optimization [#1092](https://github.com/spatial-model-editor/spatial-model-editor/issues/1092)
+
 ### Removed
 - macOS x86_64 (Intel) architecture binaries [#1096](https://github.com/spatial-model-editor/spatial-model-editor/issues/1096)
-
 
 ## [1.10.1] - 2025-12-03
 ### Fixed

--- a/core/simulate/include/sme/optimize_options.hpp
+++ b/core/simulate/include/sme/optimize_options.hpp
@@ -10,7 +10,11 @@ namespace sme::simulate {
 /**
  * @brief Types of model parameters that can be used in optimization
  */
-enum class OptParamType { ModelParameter, ReactionParameter };
+enum class OptParamType {
+  ModelParameter,
+  ReactionParameter,
+  DiffusionConstant
+};
 
 /**
  * @brief Defines a parameter to be used in optimization

--- a/core/simulate/src/optimize_impl.cpp
+++ b/core/simulate/src/optimize_impl.cpp
@@ -21,6 +21,11 @@ void applyParameters(const pagmo::vector_double &values,
       model->getReactions().setParameterValue(param.parentId.c_str(),
                                               param.id.c_str(), value);
       break;
+    case OptParamType::DiffusionConstant:
+      SPDLOG_INFO("Setting diffusion constant of species '{}' to {}", param.id,
+                  value);
+      model->getSpecies().setDiffusionConstant(param.id.c_str(), value);
+      break;
     default:
       throw std::invalid_argument("Optimization: Invalid OptParamType");
     }

--- a/gui/dialogs/dialogoptsetup.cpp
+++ b/gui/dialogs/dialogoptsetup.cpp
@@ -87,6 +87,16 @@ getDefaultOptParams(const sme::model::Model &model) {
       }
     }
   }
+  for (const auto &compartmentId : model.getCompartments().getIds()) {
+    for (const auto &speciesId : model.getSpecies().getIds(compartmentId)) {
+      auto speciesName{model.getSpecies().getName(speciesId)};
+      double value{model.getSpecies().getDiffusionConstant(speciesId)};
+      auto name{QString("Diffusion constant of '%1'").arg(speciesName)};
+      optParams.push_back({sme::simulate::OptParamType::DiffusionConstant,
+                           name.toStdString(), speciesId.toStdString(), "",
+                           value, value});
+    }
+  }
   return optParams;
 }
 


### PR DESCRIPTION
- add `DiffusionConstant` to `OptParamTypes`
- add diffusion constants to defaultOptParams dropdown
- resolves #1092
