### PR TITLE
Align QLabelMouseTracker gridlines with pixels

### DIFF
--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -71,7 +71,12 @@ struct TestOptimization {
 
 static bool algorithmIsGuaranteedToMonotonicallyDecreaseCost(
     sme::simulate::OptAlgorithmType optAlgorithmType) {
-  auto nonDecreasingCostAlgos = {sme::simulate::OptAlgorithmType::PRAXIS};
+  auto nonDecreasingCostAlgos = {sme::simulate::OptAlgorithmType::COBYLA,
+                                 sme::simulate::OptAlgorithmType::BOBYQA,
+                                 sme::simulate::OptAlgorithmType::NMS,
+                                 sme::simulate::OptAlgorithmType::sbplx,
+                                 sme::simulate::OptAlgorithmType::AL,
+                                 sme::simulate::OptAlgorithmType::PRAXIS};
   return std::ranges::find(nonDecreasingCostAlgos, optAlgorithmType) ==
          nonDecreasingCostAlgos.end();
 }


### PR DESCRIPTION
- when zoomed in enough, snap grid spacing to integer pixel steps based on physical voxel size
- draw image and grid in the same transformed coordinate space to ensure alignment between pixels and gridlines
- add test that validates expected number of grid lines and that they land on pixel boundaries
- resolves #847
