### PR TITLE
Improve thread safety and simulation UI responsiveness

### DIFF
--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -60,6 +60,7 @@ private:
   std::atomic<std::size_t> nIterations{0};
   std::vector<double> bestFitness;
   std::vector<std::vector<double>> bestParams;
+  mutable std::mutex resultsMutex;
   mutable std::mutex bestResultsMutex;
   BestResults bestResults{};
   std::unique_ptr<ThreadsafeModelQueue> modelQueue{nullptr};
@@ -88,7 +89,7 @@ public:
   /**
    * @brief The best set of parameters from each iteration
    */
-  [[nodiscard]] const std::vector<std::vector<double>> &getParams() const;
+  [[nodiscard]] std::vector<std::vector<double>> getParams() const;
   /**
    * @brief The names of the parameters being optimized
    */
@@ -96,7 +97,7 @@ public:
   /**
    * @brief The best fitness from each iteration
    */
-  [[nodiscard]] const std::vector<double> &getFitness() const;
+  [[nodiscard]] std::vector<double> getFitness() const;
   /**
    * @brief Try to set a new set of best results for each target
    *

--- a/core/simulate/include/sme/simulate.hpp
+++ b/core/simulate/include/sme/simulate.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -53,6 +54,7 @@ private:
   model::SimulationSettings *settings;
   SimulationData *data;
   common::Volume imageSize;
+  mutable std::shared_mutex dataMutex;
   std::atomic<bool> isRunning{false};
   std::atomic<bool> stopRequested{false};
   std::atomic<std::size_t> nCompletedTimesteps{0};
@@ -79,10 +81,10 @@ public:
   getSpeciesIds(std::size_t compartmentIndex) const;
   [[nodiscard]] const std::vector<QRgb> &
   getSpeciesColors(std::size_t compartmentIndex) const;
-  [[nodiscard]] const std::vector<double> &getTimePoints() const;
-  [[nodiscard]] const AvgMinMax &getAvgMinMax(std::size_t timeIndex,
-                                              std::size_t compartmentIndex,
-                                              std::size_t speciesIndex) const;
+  [[nodiscard]] std::vector<double> getTimePoints() const;
+  [[nodiscard]] AvgMinMax getAvgMinMax(std::size_t timeIndex,
+                                       std::size_t compartmentIndex,
+                                       std::size_t speciesIndex) const;
   [[nodiscard]] std::vector<double> getConc(std::size_t timeIndex,
                                             std::size_t compartmentIndex,
                                             std::size_t speciesIndex) const;

--- a/core/simulate/include/sme/simulate_steadystate.hpp
+++ b/core/simulate/include/sme/simulate_steadystate.hpp
@@ -20,7 +20,7 @@ class SteadyStateSimulation final {
   double m_timeout_ms;
   SteadyStateConvergenceMode m_stop_mode;
   double m_dt; // timestep to check for convergence, not solver timestep
-  std::mutex m_concentration_mutex = std::mutex();
+  mutable std::mutex m_concentration_mutex = std::mutex();
 
   // data members for plotting
   std::atomic<double> m_error = std::numeric_limits<double>::max();

--- a/gui/tabs/tabsimulate.hpp
+++ b/gui/tabs/tabsimulate.hpp
@@ -5,8 +5,10 @@
 #include "plotwrapper.hpp"
 #include "sme/image_stack.hpp"
 #include "sme/simulate.hpp"
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QWidget>
-#include <future>
+#include <atomic>
 #include <memory>
 
 namespace Ui {
@@ -53,14 +55,17 @@ private:
   std::vector<QStringList> speciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesToDraw;
   std::vector<PlotWrapperObservable> observables;
-  std::future<std::size_t> simSteps;
+  QFuture<std::size_t> simSteps;
+  QFutureWatcher<std::size_t> simWatcher;
   QTimer plotRefreshTimer;
   QProgressDialog *progressDialog;
   bool importTimesAndIntervals{false};
   bool flipYAxis{false};
+  std::atomic<bool> simFinishedHandled{true};
 
   std::optional<std::vector<std::pair<std::size_t, double>>>
   parseSimulationTimes();
+  void onSimulationFinished();
   void btnSimulate_clicked();
   void btnSliceImage_clicked();
   void btnExport_clicked();

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -248,10 +248,11 @@ static std::vector<SimulationResult>
 constructSimulationResults(const ::sme::simulate::Simulation *sim,
                            bool getDcdt) {
   std::vector<SimulationResult> results;
-  results.reserve(sim->getTimePoints().size());
-  for (std::size_t i = 0; i < sim->getTimePoints().size(); ++i) {
+  const auto timePoints{sim->getTimePoints()};
+  results.reserve(timePoints.size());
+  for (std::size_t i = 0; i < timePoints.size(); ++i) {
     auto &result = results.emplace_back();
-    result.timePoint = sim->getTimePoints()[i];
+    result.timePoint = timePoints[i];
     auto img = sim->getConcImage(i, {}, true);
     auto shape = img.volume();
     result.concentration_image = toPyImageRgb(img);
@@ -263,7 +264,7 @@ constructSimulationResults(const ::sme::simulate::Simulation *sim,
                                                    names[si].size())] =
             as_ndarray(std::move(concs[si]), shape);
       }
-      if (getDcdt && i + 1 == sim->getTimePoints().size()) {
+      if (getDcdt && i + 1 == timePoints.size()) {
         if (auto dcdts{sim->getPyDcdts(ci)}; !dcdts.empty()) {
           for (std::size_t si = 0; si < names.size(); ++si) {
             result.species_dcdt[nanobind::str(names[si].data(),


### PR DESCRIPTION
- Add locking around SimulationData access and return snapshots to avoid races
- Guard optimization results with a mutex and return copies for GUI reads
- Synchronize steady-state concentration reads/writes
- Use QFutureWatcher to finalize UI promptly after simulation completes
  - the VeryCoarseTimer used to periodically update during the simulation can apparently sometimes be quite laggy
  - possibly this was the cause of the delay after simulation before widgets are enabled again
- Minor GUI safeguards around simulation completion/waiting
