### PR TITLE
Support spatially varying diffusion constant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     env:
-      CIBUILDWHEEL_VERSION: "3.2"
+      CIBUILDWHEEL_VERSION: "3.3"
       CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_x86_64:2025.10.06"
       CIBW_MANYLINUX_AARCH64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_aarch64:2025.10.06"
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## [latest]
+## [1.11.0] - 2026-02-04
 ### Added
 - species diffusion constants to the parameters that can be fitted in parameter optimization [#1092](https://github.com/spatial-model-editor/spatial-model-editor/issues/1092)
+- support for spatially varying diffusion constants [#1093](https://github.com/spatial-model-editor/spatial-model-editor/issues/1093)
+- gridlines now align with pixels when zoomed in to geometry image [#847](https://github.com/spatial-model-editor/spatial-model-editor/issues/847)
+
+### Fixed
+- crash for some models with empty compartments when using DuneCopasi simulator [#1089](https://github.com/spatial-model-editor/spatial-model-editor/issues/1089)
+- delay in UI responsiveness after simulation completion [#1101](https://github.com/spatial-model-editor/spatial-model-editor/issues/1101)
 
 ### Removed
 - macOS x86_64 (Intel) architecture binaries [#1096](https://github.com/spatial-model-editor/spatial-model-editor/issues/1096)
+- Python 3.8 wheels [#1093](https://github.com/spatial-model-editor/spatial-model-editor/issues/1093)
 
 ## [1.10.1] - 2025-12-03
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.10.1
+  VERSION 1.11.0
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES C CXX)
 

--- a/core/model/include/sme/geometry.hpp
+++ b/core/model/include/sme/geometry.hpp
@@ -99,11 +99,16 @@ class Field {
 private:
   std::string id{};
   const Compartment *comp{};
-  double diffusionConstant{};
   QRgb color{};
   std::vector<double> conc{};
+  std::vector<double> diff{};
   bool isUniformConcentration{true};
   bool isSpatial{true};
+  bool isUniformDiffusionConstant{true};
+  std::vector<double> importSbmlArray(const std::vector<double> &sbmlArray);
+  [[nodiscard]] std::vector<double>
+  getImageArray(const std::vector<double> &values,
+                bool maskAndInvertY = false) const;
 
 public:
   Field() = default;
@@ -116,17 +121,24 @@ public:
   void setIsSpatial(bool spatial);
   [[nodiscard]] bool getIsUniformConcentration() const;
   void setIsUniformConcentration(bool uniform);
-  [[nodiscard]] double getDiffusionConstant() const;
-  void setDiffusionConstant(double diffConst);
+  [[nodiscard]] bool getIsUniformDiffusionConstant() const;
+  void setIsUniformDiffusionConstant(bool uniform);
+  [[nodiscard]] const std::vector<double> &getDiffusionConstant() const;
+  void setDiffusionConstant(std::size_t index, double diffusionConstant);
+  void setUniformDiffusionConstant(double diffConst);
+  void setDiffusionConstant(const std::vector<double> &diffusionConstantArray);
+  void importDiffusionConstant(const std::vector<double> &sbmlArray);
+  [[nodiscard]] std::vector<double>
+  getDiffusionConstantImageArray(bool maskAndInvertY = false) const;
   [[nodiscard]] const Compartment *getCompartment() const;
   [[nodiscard]] const std::vector<double> &getConcentration() const;
   void setConcentration(std::size_t index, double concentration);
   void setUniformConcentration(double concentration);
   void importConcentration(const std::vector<double> &sbmlConcentrationArray);
   void setConcentration(const std::vector<double> &concentration);
-  [[nodiscard]] sme::common::ImageStack getConcentrationImages() const;
-  [[nodiscard]] std::vector<double> getConcentrationImageArray(
-      bool maskAndInvertY = false) const; // todo: -> vector of vectors?
+  [[nodiscard]] common::ImageStack getConcentrationImages() const;
+  [[nodiscard]] std::vector<double>
+  getConcentrationImageArray(bool maskAndInvertY = false) const;
   void setCompartment(const Compartment *comp);
 };
 

--- a/core/model/include/sme/model.hpp
+++ b/core/model/include/sme/model.hpp
@@ -17,6 +17,7 @@
 #include "sme/model_reactions.hpp"
 #include "sme/model_settings.hpp"
 #include "sme/model_species.hpp"
+#include "sme/model_types.hpp"
 #include "sme/model_units.hpp"
 #include "sme/optimize_options.hpp"
 #include "sme/serialization.hpp"

--- a/core/model/include/sme/model_compartments.hpp
+++ b/core/model/include/sme/model_compartments.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "sme/geometry.hpp"
+#include "sme/model_types.hpp"
 #include <QPointF>
 #include <QRgb>
 #include <QStringList>

--- a/core/model/include/sme/model_settings.hpp
+++ b/core/model/include/sme/model_settings.hpp
@@ -74,6 +74,8 @@ struct Settings {
   std::map<std::string, QRgb> speciesColors{};
   sme::simulate::OptimizeOptions optimizeOptions{};
   std::vector<QRgb> sampledFieldColors{};
+  std::map<std::string, std::vector<double>> speciesDiffusionConstantArrays{};
+  std::map<std::string, std::string> speciesAnalyticDiffusionConstants{};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -96,6 +98,12 @@ struct Settings {
       ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
          CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColors),
          CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors));
+    } else if (version == 4) {
+      ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
+         CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColors),
+         CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors),
+         CEREAL_NVP(speciesDiffusionConstantArrays),
+         CEREAL_NVP(speciesAnalyticDiffusionConstants));
     }
   }
 };
@@ -105,4 +113,4 @@ struct Settings {
 CEREAL_CLASS_VERSION(sme::model::MeshParameters, 1);
 CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 1);
 CEREAL_CLASS_VERSION(sme::model::SimulationSettings, 1);
-CEREAL_CLASS_VERSION(sme::model::Settings, 3);
+CEREAL_CLASS_VERSION(sme::model::Settings, 4);

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "sme/geometry.hpp"
-#include "sme/model_species_types.hpp"
+#include "sme/model_types.hpp"
 #include <QColor>
 #include <QStringList>
 #include <map>
@@ -28,6 +28,7 @@ struct Settings;
 
 class ModelSpecies {
 private:
+  enum class AnalyticValueType { Concentration, DiffusionConstant };
   QStringList ids;
   QStringList names;
   QStringList compartmentIds;
@@ -42,8 +43,15 @@ private:
   Settings *sbmlAnnotation = nullptr;
   void removeInitialAssignment(const QString &id);
   [[nodiscard]] std::vector<double>
-  getSampledFieldConcentrationFromSBML(const QString &id) const;
+  getSampledFieldFromSBML(const QString &id) const;
   bool hasUnsavedChanges{false};
+  void setFieldAnalyticValues(
+      geometry::Field &field, const std::string &expr,
+      AnalyticValueType valueType,
+      const std::map<std::string, double, std::less<>> &substitutions);
+  void setFieldDiffAnalytic(
+      geometry::Field &field, const std::string &expr,
+      const std::map<std::string, double, std::less<>> &substitutions = {});
 
 public:
   ModelSpecies();
@@ -67,7 +75,9 @@ public:
   [[nodiscard]] bool getIsSpatial(const QString &id) const;
   void setDiffusionConstant(const QString &id, double diffusionConstant);
   [[nodiscard]] double getDiffusionConstant(const QString &id) const;
-  [[nodiscard]] ConcentrationType
+  [[nodiscard]] SpatialDataType
+  getDiffusionConstantType(const QString &id) const;
+  [[nodiscard]] SpatialDataType
   getInitialConcentrationType(const QString &id) const;
   void setInitialConcentration(const QString &id, double concentration);
   [[nodiscard]] double getInitialConcentration(const QString &id) const;
@@ -84,6 +94,16 @@ public:
   [[nodiscard]] std::vector<double>
   getSampledFieldConcentration(const QString &id,
                                bool maskAndInvertY = false) const;
+  void setSampledFieldDiffusionConstant(
+      const QString &id, const std::vector<double> &diffusionConstantArray);
+  [[nodiscard]] std::vector<double>
+  getSampledFieldDiffusionConstant(const QString &id,
+                                   bool maskAndInvertY = false) const;
+  [[nodiscard]] bool
+  isValidAnalyticDiffusionExpression(const QString &analyticExpression) const;
+  void setAnalyticDiffusionConstant(const QString &id,
+                                    const QString &analyticExpression);
+  [[nodiscard]] QString getAnalyticDiffusionConstant(const QString &id) const;
   [[nodiscard]] common::ImageStack
   getConcentrationImages(const QString &id) const;
   void setColor(const QString &id, QRgb color);

--- a/core/model/include/sme/model_species_types.hpp
+++ b/core/model/include/sme/model_species_types.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-namespace sme::model {
-
-enum struct ConcentrationType { Uniform, Analytic, Image };
-
-} // namespace sme::model

--- a/core/model/include/sme/model_types.hpp
+++ b/core/model/include/sme/model_types.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace sme::model {
+enum struct SpatialDataType { Uniform, Analytic, Image };
+}

--- a/core/model/src/model_events_t.cpp
+++ b/core/model/src/model_events_t.cpp
@@ -1,4 +1,5 @@
 #include "catch_wrapper.hpp"
+#include "math_test_utils.hpp"
 #include "model_test_utils.hpp"
 #include "sbml_math.hpp"
 #include "sme/model.hpp"
@@ -92,7 +93,7 @@ TEST_CASE("SBML events",
     REQUIRE(events.isParameter("n") == false);
     events.setExpression("n", "x + y");
     events.applyEvent("n");
-    REQUIRE(species.getAnalyticConcentration("ATP") == "x + y");
+    REQUIRE(symEq(species.getAnalyticConcentration("ATP"), "x + y"));
     // change to non-existent variable: no-op
     events.setHasUnsavedChanges(false);
     events.setVariable("n", "idontexist");

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -1,4 +1,5 @@
 #include "catch_wrapper.hpp"
+#include "math_test_utils.hpp"
 #include "model_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/utils.hpp"
@@ -18,15 +19,15 @@ TEST_CASE("SBML species",
     // initial species concentration
     REQUIRE(s.getIds("c1")[0] == "A_c1");
     REQUIRE(s.getInitialConcentrationType("A_c1") ==
-            model::ConcentrationType::Uniform);
+            model::SpatialDataType::Uniform);
     REQUIRE(s.getInitialConcentration("A_c1") == dbl_approx(1.0));
     // set analytic expression
     s.setAnalyticConcentration("A_c1", "exp(-2*x*x)");
     REQUIRE(s.getHasUnsavedChanges() == true);
     REQUIRE(s.getInitialConcentrationType("A_c1") ==
-            model::ConcentrationType::Analytic);
+            model::SpatialDataType::Analytic);
     REQUIRE(s.getInitialConcentration("A_c1") == dbl_approx(1.0));
-    REQUIRE(s.getAnalyticConcentration("A_c1") == "exp(-2 * x * x)");
+    REQUIRE(symEq(s.getAnalyticConcentration("A_c1"), "exp(-2 * x * x)"));
   }
   SECTION("Non-spatial species") {
     auto m{getExampleModel(Mod::VerySimpleModel)};
@@ -68,7 +69,7 @@ TEST_CASE("SBML species",
     REQUIRE(s.getIds("c1").size() == 2);
     REQUIRE(s.getIds("c1")[0] == "A_c1");
     REQUIRE(s.getInitialConcentrationType("A_c1") ==
-            model::ConcentrationType::Uniform);
+            model::SpatialDataType::Uniform);
     REQUIRE(s.getField("A_c1")->getId() == "A_c1");
     REQUIRE(s.getIds("c1")[1] == "B_c1");
     REQUIRE(s.getField("B_c1")->getId() == "B_c1");
@@ -431,8 +432,8 @@ TEST_CASE("SBML species",
     // set analytic expression that depends on a parameter
     s.setAnalyticConcentration("A_c1", "param");
     REQUIRE(s.getInitialConcentrationType("A_c1") ==
-            model::ConcentrationType::Analytic);
-    REQUIRE(s.getAnalyticConcentration("A_c1") == "param");
+            model::SpatialDataType::Analytic);
+    REQUIRE(symEq(s.getAnalyticConcentration("A_c1"), "param"));
     REQUIRE(common::average(s.getField("A_c1")->getConcentration()) ==
             dbl_approx(1.0));
     m.getParameters().setExpression("param", "2.0");
@@ -444,9 +445,9 @@ TEST_CASE("SBML species",
     auto &s{m.getSpecies()};
     s.setAnalyticConcentration("A_c1", "piecewise(1,x<33,2,x>66,0)");
     REQUIRE(s.getInitialConcentrationType("A_c1") ==
-            model::ConcentrationType::Analytic);
-    REQUIRE(s.getAnalyticConcentration("A_c1") ==
-            "piecewise(1, x < 33, 2, x > 66, 0)");
+            model::SpatialDataType::Analytic);
+    REQUIRE(symEq(s.getAnalyticConcentration("A_c1"),
+                  "piecewise(1, x < 33, 2, x > 66, 0)"));
     const auto &voxels{s.getField("A_c1")->getCompartment()->getVoxels()};
     const auto &concentration{s.getField("A_c1")->getConcentration()};
     REQUIRE(voxels.size() == concentration.size());

--- a/core/simulate/include/sme/duneconverter.hpp
+++ b/core/simulate/include/sme/duneconverter.hpp
@@ -39,6 +39,8 @@ public:
   [[nodiscard]] const mesh::Mesh3d *getMesh3d() const;
   [[nodiscard]] const std::unordered_map<std::string, std::vector<double>> &
   getConcentrations() const;
+  [[nodiscard]] const std::unordered_map<std::string, std::vector<double>> &
+  getDiffusionConstantArrays() const;
   [[nodiscard]] const std::unordered_map<std::string,
                                          std::vector<std::string>> &
   getSpeciesNames() const;
@@ -52,6 +54,7 @@ private:
   const mesh::Mesh2d *mesh;
   const mesh::Mesh3d *mesh3d;
   std::unordered_map<std::string, std::vector<double>> concentrations;
+  std::unordered_map<std::string, std::vector<double>> diffusionConstantArrays;
   std::unordered_map<std::string, std::vector<std::string>> speciesNames;
   std::vector<std::string> compartmentNames;
   common::VoxelF origin;

--- a/core/simulate/src/CMakeLists.txt
+++ b/core/simulate/src/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
           duneconverter.cpp
           duneconverter_impl.cpp
           dunefunction.cpp
+          dunefunctorfactory.cpp
           dunegrid.cpp
           duneini.cpp
           dunesim.cpp
@@ -25,6 +26,7 @@ if(BUILD_TESTING)
     PUBLIC duneconverter_t.cpp
            duneconverter_impl_t.cpp
            dunefunction_t.cpp
+           dunefunctorfactory_t.cpp
            dunegrid_t.cpp
            duneini_t.cpp
            dunesim_t.cpp

--- a/core/simulate/src/dunefunctorfactory.cpp
+++ b/core/simulate/src/dunefunctorfactory.cpp
@@ -1,0 +1,1 @@
+#include "dunefunction.hpp"

--- a/core/simulate/src/dunefunctorfactory.hpp
+++ b/core/simulate/src/dunefunctorfactory.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "dune_headers.hpp"
+#include "sme/duneconverter.hpp"
+#include "sme/logger.hpp"
+#include "sme/voxel.hpp"
+#include <QPoint>
+#include <algorithm>
+#include <cstddef>
+#include <dune/common/parametertree.hh>
+#include <dune/copasi/model/functor_factory.hh>
+#include <dune/copasi/parser/context.hh>
+#include <memory>
+#include <vector>
+
+namespace Dune {
+template <typename F, int n> class FieldVector;
+}
+
+namespace Dune::Copasi {
+template <std::size_t dim> struct LocalDomain;
+}
+
+namespace sme::simulate {
+
+/* A wrapper around the dune-copasi FunctorFactoryParser
+ *
+ * If the parser_type in the config is "sme" and the expression corresponds
+ * to a diffusion constant array defined in the DuneConverter, then a functor
+ * is created that looks up the diffusion constant based on the local position.
+ *
+ * Otherwise, the request is forwarded to the dune-copasi FunctorFactoryParser.
+ */
+template <std::size_t dim>
+class SmeFunctorFactory final : public Dune::Copasi::FunctorFactory<dim> {
+public:
+  explicit SmeFunctorFactory(
+      const DuneConverter &duneConverter,
+      Dune::Copasi::ParserType parser_type = Dune::Copasi::default_parser,
+      std::shared_ptr<const Dune::Copasi::ParserContext> parser_context =
+          nullptr)
+      : Dune::Copasi::FunctorFactory<dim>(), dc(duneConverter) {
+    functor_factory_parser =
+        std::make_shared<Dune::Copasi::FunctorFactoryParser<dim>>(
+            parser_type, std::move(parser_context));
+  }
+
+  SmeFunctorFactory(const SmeFunctorFactory &) = delete;
+  SmeFunctorFactory(SmeFunctorFactory &&) = delete;
+
+  SmeFunctorFactory &operator=(const SmeFunctorFactory &) = delete;
+  SmeFunctorFactory &operator=(SmeFunctorFactory &&) = delete;
+
+  ~SmeFunctorFactory() override = default;
+
+  [[nodiscard]] Dune::Copasi::FunctorFactory<dim>::ScalarFunctor
+  make_scalar(std::string_view prefix, const Dune::ParameterTree &config,
+              const Dune::Copasi::LocalDomain<dim> &local_domain,
+              int codim) const override {
+    if (config.get("parser_type", std::string{}) == "sme") {
+      // special case for SME diffusion constant arrays
+      std::string arrayName = config.get("expression", std::string{});
+      const auto &diffusionConstantArrays = dc.getDiffusionConstantArrays();
+      auto origin = dc.getOrigin();
+      auto voxel = dc.getVoxelSize();
+      auto vol = dc.getImageSize();
+      if (const auto it = diffusionConstantArrays.find(arrayName);
+          it != diffusionConstantArrays.end()) {
+        const auto array = it->second;
+        SPDLOG_DEBUG("Using SME diffusion constant array '{}'", arrayName);
+        auto *pos = &local_domain.position;
+        return [array, pos, origin, voxel, vol]() noexcept {
+          // get nearest voxel to physical point
+          auto ix = std::clamp(
+              static_cast<int>(((*pos)[0] - origin.p.x()) / voxel.width()), 0,
+              vol.width() - 1);
+          auto iy = std::clamp(
+              static_cast<int>(((*pos)[1] - origin.p.y()) / voxel.height()), 0,
+              vol.height() - 1);
+          int iz = 0;
+          if constexpr (dim == 3) {
+            iz = std::clamp(
+                static_cast<int>(((*pos)[2] - origin.z) / voxel.depth()), 0,
+                static_cast<int>(vol.depth()) - 1);
+          }
+          auto ci = static_cast<std::size_t>(ix + vol.width() * iy +
+                                             vol.width() * vol.height() * iz);
+          SPDLOG_TRACE("  -> voxel ({},{},{})", ix, iy, iz);
+          SPDLOG_TRACE("  -> diffusionConstant[{}] = {}", ci, array[ci]);
+          return Dune::FieldVector<double, 1>{array[ci]};
+        };
+      }
+      auto errorMsg =
+          fmt::format("SME diffusion constant array '{}' not found", arrayName);
+      SPDLOG_ERROR("{}", errorMsg);
+      throw std::runtime_error(errorMsg);
+    }
+    return functor_factory_parser->make_scalar(prefix, config, local_domain,
+                                               codim);
+  }
+
+  [[nodiscard]] Dune::Copasi::FunctorFactory<dim>::VectorFunctor
+  make_vector(std::string_view prefix, const Dune::ParameterTree &config,
+              const Dune::Copasi::LocalDomain<dim> &local_domain,
+              int codim) const override {
+    if (config.get("parser_type", std::string{}) == "sme") {
+      throw std::runtime_error("sme make_vector not implemented");
+    }
+    return functor_factory_parser->make_vector(prefix, config, local_domain,
+                                               codim);
+  }
+
+  [[nodiscard]] Dune::Copasi::FunctorFactory<dim>::TensorApplyFunctor
+  make_tensor_apply(std::string_view prefix, const Dune::ParameterTree &config,
+                    const Dune::Copasi::LocalDomain<dim> &local_domain,
+                    int codim) const override {
+    if (config.get("parser_type", std::string{}) == "sme") {
+      if (config.get("type", "scalar") == "scalar") {
+        if (auto f = make_scalar(prefix, config, local_domain, codim)) {
+          return
+              [f = std::move(f)](Dune::FieldVector<double, dim> vec) noexcept {
+                return f()[0] * vec;
+              };
+        }
+        return nullptr;
+      }
+      throw std::runtime_error(
+          "sme make_tensor_apply not implemented for tensors");
+    }
+    return functor_factory_parser->make_tensor_apply(prefix, config,
+                                                     local_domain, codim);
+  }
+
+private:
+  std::shared_ptr<Dune::Copasi::FunctorFactoryParser<dim>>
+      functor_factory_parser;
+  DuneConverter dc;
+};
+
+} // namespace sme::simulate

--- a/core/simulate/src/dunefunctorfactory_t.cpp
+++ b/core/simulate/src/dunefunctorfactory_t.cpp
@@ -1,0 +1,151 @@
+// todo: re-enable tiff tests once
+// https://gitlab.dune-project.org/copasi/dune-copasi/-/issues/80 is resolved
+
+#include "catch_wrapper.hpp"
+#include "dune_headers.hpp"
+#include "dunefunctorfactory.hpp"
+#include "model_test_utils.hpp"
+#include "sme/duneconverter.hpp"
+#include "sme/model.hpp"
+#include <QDir>
+#include <QFile>
+#include <cmath>
+#include <locale>
+
+using namespace sme;
+using namespace sme::test;
+
+static Dune::ParameterTree getConfig(const simulate::DuneConverter &dc) {
+  Dune::ParameterTree config;
+  std::stringstream ssIni(dc.getIniFile().toStdString());
+  Dune::ParameterTreeParser::readINITree(ssIni, config);
+  return config;
+}
+
+static QString getFirstNonConstantSpeciesId(const model::Model &m) {
+  for (const auto &compartmentId : m.getCompartments().getIds()) {
+    for (const auto &speciesId : m.getSpecies().getIds(compartmentId)) {
+      if (!m.getSpecies().getIsConstant(speciesId)) {
+        return speciesId;
+      }
+    }
+  }
+  return {};
+}
+
+TEST_CASE("DUNE: SmeFunctorFactory",
+          "[core/simulate/dunefunctorfactory][core/"
+          "simulate][core][dunefunctorfactory][dune]") {
+  SECTION("constructs for 2d and 3d") {
+    auto m2d{getExampleModel(Mod::VerySimpleModel)};
+    auto m3d{getExampleModel(Mod::VerySimpleModel3D)};
+    simulate::DuneConverter dc2d(m2d);
+    simulate::DuneConverter dc3d(m3d);
+    simulate::SmeFunctorFactory<2> factory2d(dc2d);
+    simulate::SmeFunctorFactory<3> factory3d(dc3d);
+  }
+
+  SECTION("uses sampled diffusion array for 2d scalar and tensor functors") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    const auto vol = m.getGeometry().getImages().volume();
+    const auto arraySize =
+        static_cast<std::size_t>(vol.width()) * vol.height() * vol.depth();
+    std::vector<double> diffusion(arraySize);
+    for (std::size_t i = 0; i < diffusion.size(); ++i) {
+      diffusion[i] = static_cast<double>(i);
+    }
+    const auto speciesId = getFirstNonConstantSpeciesId(m);
+    REQUIRE(!speciesId.isEmpty());
+    m.getSpecies().setSampledFieldDiffusionConstant(speciesId, diffusion);
+
+    simulate::DuneConverter dc(m);
+    simulate::SmeFunctorFactory<2> factory(dc);
+    const auto &arrays = dc.getDiffusionConstantArrays();
+    REQUIRE(!arrays.empty());
+    const auto &arrayName = arrays.begin()->first;
+    const auto &array = arrays.begin()->second;
+
+    Dune::ParameterTree cfg;
+    cfg["parser_type"] = "sme";
+    cfg["expression"] = arrayName;
+
+    Dune::Copasi::LocalDomain<2> local_domain;
+    const auto origin = dc.getOrigin();
+    const auto voxel = dc.getVoxelSize();
+    const auto image = dc.getImageSize();
+    const int ix = image.width() / 2;
+    const int iy = image.height() / 2;
+    local_domain.position = {origin.p.x() + (ix + 0.5) * voxel.width(),
+                             origin.p.y() + (iy + 0.5) * voxel.height()};
+
+    const auto index = static_cast<std::size_t>(ix + image.width() * iy);
+    auto scalar = factory.make_scalar("", cfg, local_domain, 0);
+    REQUIRE(scalar()[0] == Catch::Approx(array[index]));
+
+    auto tensorApply = factory.make_tensor_apply("", cfg, local_domain, 0);
+    auto vec = Dune::FieldVector<double, 2>{2.0, -3.0};
+    auto result = tensorApply(vec);
+    REQUIRE(result[0] == Catch::Approx(array[index] * vec[0]));
+    REQUIRE(result[1] == Catch::Approx(array[index] * vec[1]));
+  }
+
+  SECTION("uses sampled diffusion array for 3d scalar functor and clamps") {
+    auto m{getExampleModel(Mod::SingleCompartmentDiffusion3D)};
+    const auto vol = m.getGeometry().getImages().volume();
+    const auto arraySize =
+        static_cast<std::size_t>(vol.width()) * vol.height() * vol.depth();
+    std::vector<double> diffusion(arraySize);
+    for (std::size_t i = 0; i < diffusion.size(); ++i) {
+      diffusion[i] = static_cast<double>(i % 97);
+    }
+    const auto speciesId = getFirstNonConstantSpeciesId(m);
+    REQUIRE(!speciesId.isEmpty());
+    m.getSpecies().setSampledFieldDiffusionConstant(speciesId, diffusion);
+
+    simulate::DuneConverter dc(m);
+    simulate::SmeFunctorFactory<3> factory(dc);
+    const auto &arrays = dc.getDiffusionConstantArrays();
+    REQUIRE(!arrays.empty());
+    const auto &arrayName = arrays.begin()->first;
+    const auto &array = arrays.begin()->second;
+
+    Dune::ParameterTree cfg;
+    cfg["parser_type"] = "sme";
+    cfg["expression"] = arrayName;
+
+    Dune::Copasi::LocalDomain<3> local_domain;
+    const auto origin = dc.getOrigin();
+    const auto voxel = dc.getVoxelSize();
+    const auto image = dc.getImageSize();
+    const int ix = image.width() - 1;
+    const int iy = image.height() - 1;
+    const int iz = image.depth() - 1;
+    local_domain.position = {origin.p.x() + image.width() * voxel.width(),
+                             origin.p.y() + image.height() * voxel.height(),
+                             origin.z + image.depth() * voxel.depth()};
+
+    const auto index = static_cast<std::size_t>(
+        ix + image.width() * iy + image.width() * image.height() * iz);
+    auto scalar = factory.make_scalar("", cfg, local_domain, 0);
+    REQUIRE(scalar()[0] == Catch::Approx(array[index]));
+  }
+
+  SECTION("throws for missing sme diffusion array and unsupported vector") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    simulate::DuneConverter dc(m);
+    simulate::SmeFunctorFactory<2> factory(dc);
+
+    Dune::Copasi::LocalDomain<2> local_domain;
+    local_domain.position = {0.0, 0.0};
+
+    Dune::ParameterTree missingArrayCfg;
+    missingArrayCfg["parser_type"] = "sme";
+    missingArrayCfg["expression"] = "does_not_exist";
+    REQUIRE_THROWS(factory.make_scalar("", missingArrayCfg, local_domain, 0));
+
+    Dune::ParameterTree vectorCfg;
+    vectorCfg["parser_type"] = "sme";
+    vectorCfg["expression"] = "anything";
+    REQUIRE_THROWS(factory.make_vector("", vectorCfg, local_domain, 0));
+  }
+}

--- a/core/simulate/src/dunesim_impl.hpp
+++ b/core/simulate/src/dunesim_impl.hpp
@@ -4,6 +4,7 @@
 
 #include "dune_headers.hpp"
 #include "dunefunction.hpp"
+#include "dunefunctorfactory.hpp"
 #include "dunegrid.hpp"
 #include "sme/duneconverter.hpp"
 #include "sme/geometry.hpp"
@@ -118,9 +119,8 @@ public:
         config.sub("parser_context"));
     auto parser_type = Dune::Copasi::string2parser.at(
         config.get("model.parser_type", Dune::Copasi::default_parser_str));
-    auto functor_factory =
-        std::make_shared<Dune::Copasi::FunctorFactoryParser<DuneDimensions>>(
-            parser_type, std::move(parser_context));
+    auto functor_factory = std::make_shared<SmeFunctorFactory<DuneDimensions>>(
+        dc, parser_type, std::move(parser_context));
     SPDLOG_INFO("model");
     model = Dune::Copasi::DiffusionReaction::make_model<Model>(
         config.sub("model"), functor_factory);

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -48,9 +48,8 @@ private:
   std::vector<double> dcdt;
   std::vector<double> s2;
   std::vector<double> s3;
-  // dimensionless diffusion constants in x,y,z directions for each species
-  // i.e. [{D/dx^2, D/dy^2, D/dz^2}, {}, .. ]
-  std::vector<std::array<double, 3>> diffConstants;
+  // diffusion constants (D) per voxel for each species
+  std::vector<std::vector<double>> diffConstants;
   const geometry::Compartment *comp;
   std::size_t nPixels;
   std::size_t nSpecies;
@@ -59,6 +58,9 @@ private:
   std::vector<std::string> speciesNames;
   std::vector<std::size_t> nonSpatialSpeciesIndices;
   double maxStableTimestep = std::numeric_limits<double>::max();
+  double dx2{1.0};
+  double dy2{1.0};
+  double dz2{1.0};
 
 public:
   explicit SimCompartment(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "build", "Thumbs.db", ".DS_Store"]
 
 # breathe: generate docs from doxygen xml output
 breathe_projects = {"sme": "build/xml"}

--- a/docs/quickstart/gui-overview.rst
+++ b/docs/quickstart/gui-overview.rst
@@ -7,7 +7,7 @@ A model in spatial-model-editor (SME) consists of five basic parts which all mus
 
 #. A definition of the spatial domain the model should run on. This can be 2D or 3D and can be divided into an arbitrary number of compartments which have interfaces with each other. In the cellular context that is relevant here, these interfaces can represent membranes between cell compartments or cells.
 
-#. A set of chemical species whose concentration is defined in different compartments. These concentrations are assumed to undergo diffusion by default. These chemical species need to have an initial distribution of concentration in the compartments they are defined in and an isotropic, homogeneous diffusion constant.
+#. A set of chemical species whose concentration is defined in different compartments. These concentrations are assumed to undergo diffusion by default. These chemical species need to have an initial distribution of concentration in the compartments they are defined in and an isotropic diffusion constant, which can be uniform, analytic, or image-based.
 
 #. The chemical reactions that can occur between the different species. These can be divided into reactions in the volume of the compartments and fluxes and reactions that only happen on the interfaces between compartments.
 

--- a/docs/quickstart/species.rst
+++ b/docs/quickstart/species.rst
@@ -23,9 +23,15 @@ Two more properties of a species are of primary importance.
 
    .. math::
 
-         D \nabla^{2} c_{i}
+         \nabla \cdot \left( D \nabla c_{i} \right)
 
-   is always assumed by default (see the `documentation on the mathematical formulation <../reference/maths.html>`_ for more details). The diffusion constant `D` is assumed to be isotropic and homogeneous. If you don't want diffusion to be present, set this constant to zero.
+   is assumed by default (see the `documentation on the mathematical formulation <../reference/maths.html>`_ for more details). The diffusion constant can be set in three ways:
+
+   * Uniform: a single scalar value everywhere in the compartment.
+   * Analytic: an expression in the spatial coordinates (`x`, `y`, and `z` for 3D models).
+   * Image: a sampled field loaded from image data, giving a per-voxel value.
+
+   In all cases, `D` is isotropic (scalar, not tensor). If you don't want diffusion to be present, set `D = 0`.
 
 With the definition of these two elements, the species is fully defined and can be used in the next steps of the model definition.
 

--- a/docs/reference/maths.rst
+++ b/docs/reference/maths.rst
@@ -8,18 +8,20 @@ The system of PDEs that we simulate in each compartment is the three-dimensional
 
 .. math::
 
-   \frac{\partial c_s}{\partial t} = D_s \left( \frac{\partial^2}{\partial x^2} + \frac{\partial^2}{\partial y^2} + \frac{\partial^2}{\partial z^2} \right) c_s + R_s
+   \frac{\partial c_s}{\partial t} = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
 
 where
 
 * :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y, z)` and time :math:`t`
-* :math:`D_s` is the diffusion constant for species :math:`s`
+* :math:`D_s` is the (possibly spatially varying) scalar diffusion constant for species :math:`s`
 * :math:`R_s` is the reaction term for species :math:`s`
 
 and we assume that
 
-* the diffusion constant :math:`D_s` is a scalar that does not vary with position or time
+* the diffusion constant :math:`D_s` is isotropic (a scalar, not a tensor)
 * the reaction term :math:`R_s` is a function that can depend on the concentrations of other species in the model, but only locally, i.e. the concentrations at the same spatial coordinate.
+
+If :math:`D_s` is constant in space, this reduces to :math:`D_s \nabla^2 c_s + R_s`.
 
 Compartment Reactions
 ---------------------

--- a/docs/reference/parameter-fitting.rst
+++ b/docs/reference/parameter-fitting.rst
@@ -69,7 +69,8 @@ Optimization Parameter
    Adding or modifying a parameter to be optimized.
 
 * Parameter
-   * This can be a model parameter or a reaction parameter
+   * This can be a model parameter, a reaction parameter, or a species diffusion constant
+   * Diffusion constants are only available here when they are uniform scalar values
 * Lower bound
    * The minimum allowed value this parameter can take
 * Upper bound

--- a/gui/dialogs/CMakeLists.txt
+++ b/gui/dialogs/CMakeLists.txt
@@ -4,8 +4,8 @@ target_sources(
           dialogabout.ui
           dialoganalytic.cpp
           dialoganalytic.ui
-          dialogconcentrationimage.cpp
-          dialogconcentrationimage.ui
+          dialogimagedata.cpp
+          dialogimagedata.ui
           dialogcoordinates.cpp
           dialogcoordinates.ui
           dialogdisplayoptions.cpp
@@ -43,7 +43,7 @@ if(BUILD_TESTING)
     gui_tests
     PUBLIC dialogabout_t.cpp
            dialoganalytic_t.cpp
-           dialogconcentrationimage_t.cpp
+           dialogimagedata_t.cpp
            dialogcoordinates_t.cpp
            dialogdisplayoptions_t.cpp
            dialogeditunit_t.cpp

--- a/gui/dialogs/dialoganalytic.hpp
+++ b/gui/dialogs/dialoganalytic.hpp
@@ -19,11 +19,14 @@ class ModelParameters;
 class ModelFunctions;
 } // namespace sme::model
 
+enum class DialogAnalyticDataType { Concentration, DiffusionConstant };
+
 class DialogAnalytic : public QDialog {
   Q_OBJECT
 
 public:
   explicit DialogAnalytic(const QString &analyticExpression,
+                          DialogAnalyticDataType dataType,
                           const sme::model::SpeciesGeometry &speciesGeometry,
                           const sme::model::ModelParameters &modelParameters,
                           const sme::model::ModelFunctions &modelFunctions,
@@ -40,11 +43,12 @@ private:
   const std::vector<sme::common::Voxel> &voxels;
   const sme::common::VoxelF physicalOrigin;
   QString lengthUnit;
-  QString concentrationUnit;
+  QString valueUnit;
+  QString valueLabel;
 
   sme::common::ImageStack imgs;
   sme::geometry::VoxelIndexer qpi;
-  std::vector<double> concentration;
+  std::vector<double> values;
   std::string displayExpression;
   std::string variableExpression;
   bool expressionIsValid = false;

--- a/gui/dialogs/dialoganalytic_t.cpp
+++ b/gui/dialogs/dialoganalytic_t.cpp
@@ -31,7 +31,7 @@ TEST_CASE("DialogAnalytic",
     auto model{getExampleModel(Mod::ABtoC)};
     auto compartmentVoxels = std::vector<sme::common::Voxel>{
         {5, 5, 0}, {5, 6, 0}, {5, 7, 0}, {6, 6, 0}, {6, 7, 0}};
-    DialogAnalytic dia("x",
+    DialogAnalytic dia("x", DialogAnalyticDataType::Concentration,
                        {{10, 10, 1},
                         compartmentVoxels,
                         {0.0, 0.0, 0.0},
@@ -114,8 +114,9 @@ TEST_CASE("DialogAnalytic",
   }
   SECTION("100x100 image") {
     auto model{getExampleModel(Mod::ABtoC)};
-    DialogAnalytic dia("x", model.getSpeciesGeometry("B"),
-                       model.getParameters(), model.getFunctions(), false);
+    DialogAnalytic dia("x", DialogAnalyticDataType::Concentration,
+                       model.getSpeciesGeometry("B"), model.getParameters(),
+                       model.getFunctions(), false);
     dia.show();
     DialogAnalyticWidgets widgets(&dia);
     REQUIRE(dia.getExpression() == "x");

--- a/gui/dialogs/dialogimagedata.hpp
+++ b/gui/dialogs/dialogimagedata.hpp
@@ -8,24 +8,31 @@
 #include <memory>
 
 namespace Ui {
-class DialogConcentrationImage;
+class DialogImageData;
 }
 
-class DialogConcentrationImage : public QDialog {
+enum class DialogImageDataDataType {
+  Concentration,
+  ConcentrationRateOfChange,
+  DiffusionConstant
+};
+
+class DialogImageData : public QDialog {
   Q_OBJECT
 
 public:
-  explicit DialogConcentrationImage(
-      const std::vector<double> &concentrationArray,
+  explicit DialogImageData(
+      const std::vector<double> &dataArray,
       const sme::model::SpeciesGeometry &speciesGeometry,
       bool invertYAxis = false,
-      const QString &windowTitle = "Set Initial Concentration Image",
-      bool isRateOfChange = false, QWidget *parent = nullptr);
-  ~DialogConcentrationImage() override;
-  [[nodiscard]] std::vector<double> getConcentrationArray() const;
+      DialogImageDataDataType dataType = DialogImageDataDataType::Concentration,
+      QWidget *parent = nullptr);
+  ~DialogImageData() override;
+  const std::vector<double> &getData() const;
+  [[nodiscard]] std::vector<double> getImageArray() const;
 
 private:
-  std::unique_ptr<Ui::DialogConcentrationImage> ui;
+  std::unique_ptr<Ui::DialogImageData> ui;
 
   // user supplied data
   const sme::common::VolumeF voxelSize;
@@ -39,18 +46,16 @@ private:
   QImage colorMinConc;
   sme::common::ImageStack imgs;
   sme::geometry::VoxelIndexer qpi;
-  std::vector<double> concentration;
+  std::vector<double> data;
 
   sme::common::VoxelF physicalPoint(const sme::common::Voxel &voxel) const;
-  std::size_t
-  pointToConcentrationArrayIndex(const sme::common::Voxel &voxel) const;
-  void importConcentrationArray(const std::vector<double> &concentrationArray);
-  void
-  importConcentrationImage(const sme::common::ImageStack &concentrationImage);
-  void updateImageFromConcentration();
-  void rescaleConcentration(double newMin, double newMax);
+  std::size_t pointToArrayIndex(const sme::common::Voxel &voxel) const;
+  void importArray(const std::vector<double> &concentrationArray);
+  void importImage(const sme::common::ImageStack &concentrationImage);
+  void updateImageFromData();
+  void rescaleData(double newMin, double newMax);
   void gaussianFilter(const sme::common::Voxel &direction, double sigma);
-  void smoothConcentration();
+  void smoothData();
   void lblImage_mouseOver(const sme::common::Voxel &voxel);
   void chkGrid_stateChanged(int state);
   void chkScale_stateChanged(int state);

--- a/gui/dialogs/dialogimagedata.ui
+++ b/gui/dialogs/dialogimagedata.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DialogConcentrationImage</class>
- <widget class="QDialog" name="DialogConcentrationImage">
+ <class>DialogImageData</class>
+ <widget class="QDialog" name="DialogImageData">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -1,5 +1,5 @@
 #include "dialogoptcost.hpp"
-#include "dialogconcentrationimage.hpp"
+#include "dialogimagedata.hpp"
 #include "ui_dialogoptcost.h"
 
 static QString toQStr(double x) { return QString::number(x, 'g', 14); }
@@ -146,13 +146,15 @@ void DialogOptCost::txtSimulationTime_editingFinished() {
 
 void DialogOptCost::btnEditTargetValues_clicked() {
   QString costType{ui->cmbCostType->currentText()};
-  DialogConcentrationImage dialog(
-      m_optCost.targetValues, m_model.getSpeciesGeometry(m_optCost.id.c_str()),
-      m_model.getDisplayOptions().invertYAxis,
-      QString("Set target %1").arg(costType),
-      m_optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt);
+  DialogImageDataDataType dataType{DialogImageDataDataType::Concentration};
+  if (m_optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt) {
+    dataType = DialogImageDataDataType::ConcentrationRateOfChange;
+  }
+  DialogImageData dialog(m_optCost.targetValues,
+                         m_model.getSpeciesGeometry(m_optCost.id.c_str()),
+                         m_model.getDisplayOptions().invertYAxis, dataType);
   if (dialog.exec() == QDialog::Accepted) {
-    m_optCost.targetValues = dialog.getConcentrationArray();
+    m_optCost.targetValues = dialog.getImageArray();
     updateImage();
   }
 }

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -210,7 +210,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
     REQUIRE(dia.getOptCost().targetValues.size() == 10000);
-    REQUIRE(mwt.getResult() == "Set target Concentration");
+    REQUIRE(mwt.getResult() == "Concentration image data");
     // all pixels within compartment are set to 1
     REQUIRE(sme::common::max(dia.getOptCost().targetValues) == dbl_approx(1.0));
     // pixels outside of compartment are zero
@@ -237,7 +237,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::ConcentrationDcdt);
-    REQUIRE(mwt.getResult() == "Set target Rate of change of concentration");
+    REQUIRE(mwt.getResult() == "Concentration rate of change image data");
     // all pixels within compartment are set to 1.2
     REQUIRE(sme::common::max(dia.getOptCost().targetValues) == dbl_approx(1.2));
     // pixels outside of compartment are zero

--- a/gui/dialogs/dialogoptsetup.cpp
+++ b/gui/dialogs/dialogoptsetup.cpp
@@ -89,12 +89,15 @@ getDefaultOptParams(const sme::model::Model &model) {
   }
   for (const auto &compartmentId : model.getCompartments().getIds()) {
     for (const auto &speciesId : model.getSpecies().getIds(compartmentId)) {
-      auto speciesName{model.getSpecies().getName(speciesId)};
-      double value{model.getSpecies().getDiffusionConstant(speciesId)};
-      auto name{QString("Diffusion constant of '%1'").arg(speciesName)};
-      optParams.push_back({sme::simulate::OptParamType::DiffusionConstant,
-                           name.toStdString(), speciesId.toStdString(), "",
-                           value, value});
+      if (model.getSpecies().getDiffusionConstantType(speciesId) ==
+          sme::model::SpatialDataType::Uniform) {
+        auto speciesName{model.getSpecies().getName(speciesId)};
+        double value{model.getSpecies().getDiffusionConstant(speciesId)};
+        auto name{QString("Diffusion constant of '%1'").arg(speciesName)};
+        optParams.push_back({sme::simulate::OptParamType::DiffusionConstant,
+                             name.toStdString(), speciesId.toStdString(), "",
+                             value, value});
+      }
     }
   }
   return optParams;

--- a/gui/tabs/tabevents.cpp
+++ b/gui/tabs/tabevents.cpp
@@ -173,6 +173,7 @@ void TabEvents::cmbEventVariable_activated(int index) {
     ui->btnSetSpeciesConcentration->setEnabled(true);
     auto img =
         DialogAnalytic(model.getEvents().getExpression(currentEventId),
+                       DialogAnalyticDataType::Concentration,
                        model.getSpeciesGeometry(variableIds[index]),
                        model.getParameters(), model.getFunctions(), invertYAxis)
             .getImage();
@@ -198,6 +199,7 @@ void TabEvents::btnSetSpeciesConcentration_clicked() {
   QString sId{variableIds[iSpecies]};
   bool invertYAxis{model.getDisplayOptions().invertYAxis};
   DialogAnalytic dialog(model.getEvents().getExpression(currentEventId),
+                        DialogAnalyticDataType::Concentration,
                         model.getSpeciesGeometry(sId), model.getParameters(),
                         model.getFunctions(), invertYAxis);
   if (dialog.exec() == QDialog::Accepted) {

--- a/gui/tabs/tabspecies.hpp
+++ b/gui/tabs/tabspecies.hpp
@@ -47,6 +47,9 @@ private:
   void txtInitialConcentration_editingFinished();
   void btnEditAnalyticConcentration_clicked();
   void btnEditImageConcentration_clicked();
+  void radDiffusionConstant_toggled();
   void txtDiffusionConstant_editingFinished();
+  void btnEditAnalyticDiffusionConstant_clicked();
+  void btnEditImageDiffusionConstant_clicked();
   void btnChangeSpeciesColor_clicked();
 };

--- a/gui/tabs/tabspecies.ui
+++ b/gui/tabs/tabspecies.ui
@@ -105,86 +105,33 @@
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <layout class="QGridLayout" name="gridSpeciesSettings">
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblSpeciesName">
-           <property name="text">
-            <string>Name:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="0">
-          <widget class="QLabel" name="lblSpeciesColorLabel">
+         <item row="6" column="2" colspan="6">
+          <widget class="QPushButton" name="btnEditAnalyticConcentration">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="toolTip">
-            <string>The color that is used to display the concentration of this species</string>
-           </property>
-           <property name="statusTip">
-            <string>The color that is used to display the concentration of this species</string>
-           </property>
-           <property name="whatsThis">
-            <string>The color that is used to display the concentration of this species</string>
-           </property>
            <property name="text">
-            <string>Color:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <string>edit expression...</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lblSpeciesIsSpacial">
-           <property name="toolTip">
-            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-           </property>
-           <property name="statusTip">
-            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>Spatial:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="6">
-          <widget class="QLabel" name="lblDiffusionConstantUnits">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1" colspan="6">
-          <widget class="QCheckBox" name="chkSpeciesIsConstant">
+         <item row="5" column="2" colspan="5">
+          <widget class="QLineEdit" name="txtInitialConcentration">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="toolTip">
-            <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
-           </property>
-           <property name="statusTip">
-            <string>'Constant': species concentration cannot be altered by the simulation</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-           </property>
+          </widget>
+         </item>
+         <item row="11" column="2" colspan="6">
+          <widget class="QPushButton" name="btnEditImageDiffusionConstant">
            <property name="text">
-            <string>species concentration is fixed throughout the whole simulation</string>
+            <string>edit image...</string>
            </property>
           </widget>
          </item>
@@ -211,24 +158,14 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lblSpeciesCompartment">
+         <item row="7" column="1">
+          <widget class="QRadioButton" name="radInitialConcentrationImage">
            <property name="text">
-            <string>Compartment:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <string>Image</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="7">
-          <widget class="Line" name="line">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2" colspan="5">
+         <item row="7" column="2" colspan="6">
           <widget class="QPushButton" name="btnEditImageConcentration">
            <property name="enabled">
             <bool>true</bool>
@@ -253,106 +190,13 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lblSpeciesIsConstant">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>A constant species has a fixed concentration</string>
-           </property>
-           <property name="statusTip">
-            <string>A constant species has a fixed concentration</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-           </property>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblSpeciesCompartment">
            <property name="text">
-            <string>Constant:</string>
+            <string>Compartment:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="lblDiffConst">
-           <property name="toolTip">
-            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-           </property>
-           <property name="statusTip">
-            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
-&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>Diffusion Constant:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1" colspan="6">
-          <widget class="QCheckBox" name="chkSpeciesIsSpatial">
-           <property name="toolTip">
-            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-           </property>
-           <property name="statusTip">
-            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>species concentration has a spatial dependence</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="6">
-          <widget class="QLabel" name="lblInitialConcentrationUnits">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2" colspan="4">
-          <widget class="QLineEdit" name="txtInitialConcentration">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1" colspan="6">
-          <widget class="QLineEdit" name="txtSpeciesName"/>
-         </item>
-         <item row="10" column="6">
-          <widget class="QPushButton" name="btnChangeSpeciesColor">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Change the color that is used to display the concentration of this species</string>
-           </property>
-           <property name="statusTip">
-            <string>Change the color that is used to display the concentration of this species</string>
-           </property>
-           <property name="whatsThis">
-            <string>Change the color that is used to display the concentration of this species</string>
-           </property>
-           <property name="text">
-            <string>change color...</string>
            </property>
           </widget>
          </item>
@@ -382,7 +226,258 @@
            </property>
           </widget>
          </item>
-         <item row="10" column="1" colspan="5">
+         <item row="9" column="7">
+          <widget class="QLabel" name="lblDiffusionConstantUnits">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1" colspan="7">
+          <widget class="QCheckBox" name="chkSpeciesIsConstant">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
+           </property>
+           <property name="statusTip">
+            <string>'Constant': species concentration cannot be altered by the simulation</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>species concentration is fixed throughout the whole simulation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QRadioButton" name="radDiffusionConstantUniform">
+           <property name="text">
+            <string>Spatially uniform</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="7">
+          <widget class="QComboBox" name="cmbSpeciesCompartment"/>
+         </item>
+         <item row="2" column="1" colspan="7">
+          <widget class="QCheckBox" name="chkSpeciesIsSpatial">
+           <property name="toolTip">
+            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+           </property>
+           <property name="statusTip">
+            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>species concentration has a spatial dependence</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblSpeciesName">
+           <property name="text">
+            <string>Name:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0" colspan="8">
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblSpeciesIsSpacial">
+           <property name="toolTip">
+            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+           </property>
+           <property name="statusTip">
+            <string>'Spatial': species concentration can vary depending on the location within the compartment</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Spatial&lt;/h4&gt;&lt;p&gt;A spatial species has a concentration that is a function of space within the compartment, i.e. it can take different values at different locations within the compartment&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>Spatial:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="lblDiffConst">
+           <property name="toolTip">
+            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+           </property>
+           <property name="statusTip">
+            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
+&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>Diffusion Constant:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="7">
+          <widget class="QLabel" name="lblInitialConcentrationUnits">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="8">
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="1">
+          <widget class="QRadioButton" name="radDiffusionConstantImage">
+           <property name="text">
+            <string>Image</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" colspan="7">
+          <widget class="QLineEdit" name="txtSpeciesName"/>
+         </item>
+         <item row="12" column="7">
+          <widget class="QPushButton" name="btnChangeSpeciesColor">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Change the color that is used to display the concentration of this species</string>
+           </property>
+           <property name="statusTip">
+            <string>Change the color that is used to display the concentration of this species</string>
+           </property>
+           <property name="whatsThis">
+            <string>Change the color that is used to display the concentration of this species</string>
+           </property>
+           <property name="text">
+            <string>change color...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="lblInitConc">
+           <property name="text">
+            <string>Initial Concentration:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="2" colspan="5">
+          <widget class="QLineEdit" name="txtDiffusionConstant">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+           </property>
+           <property name="statusTip">
+            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
+&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0">
+          <widget class="QLabel" name="lblSpeciesColorLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>The color that is used to display the concentration of this species</string>
+           </property>
+           <property name="statusTip">
+            <string>The color that is used to display the concentration of this species</string>
+           </property>
+           <property name="whatsThis">
+            <string>The color that is used to display the concentration of this species</string>
+           </property>
+           <property name="text">
+            <string>Color:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="lblSpeciesIsConstant">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>A constant species has a fixed concentration</string>
+           </property>
+           <property name="statusTip">
+            <string>A constant species has a fixed concentration</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>Constant:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QRadioButton" name="radDiffusionConstantAnalytic">
+           <property name="text">
+            <string>Analytic expression</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="2" colspan="6">
+          <widget class="QPushButton" name="btnEditAnalyticDiffusionConstant">
+           <property name="text">
+            <string>edit expression...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="1" colspan="6">
           <widget class="QLabel" name="lblSpeciesColor">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -410,66 +505,6 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1" colspan="6">
-          <widget class="QComboBox" name="cmbSpeciesCompartment"/>
-         </item>
-         <item row="6" column="2" colspan="5">
-          <widget class="QPushButton" name="btnEditAnalyticConcentration">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>edit expression...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="QRadioButton" name="radInitialConcentrationImage">
-           <property name="text">
-            <string>Concentration image</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="1" colspan="5">
-          <widget class="QLineEdit" name="txtDiffusionConstant">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-           </property>
-           <property name="statusTip">
-            <string>Diffusion constant: how fast the species diffuses (spreads out) within the compartment</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Diffusion constant&lt;/h4&gt;
-&lt;p&gt;The rate at which the species diffuses within the compartment&lt;/p&gt;</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0" colspan="7">
-          <widget class="Line" name="line_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lblInitConc">
-           <property name="text">
-            <string>Initial Concentration:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -58,9 +58,25 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
   auto *btnEditImageConcentration{
       tab.findChild<QPushButton *>("btnEditImageConcentration")};
   REQUIRE(btnEditImageConcentration != nullptr);
+  auto *radDiffusionConstantUniform{
+      tab.findChild<QRadioButton *>("radDiffusionConstantUniform")};
+  REQUIRE(radDiffusionConstantUniform != nullptr);
   auto *txtDiffusionConstant{
       tab.findChild<QLineEdit *>("txtDiffusionConstant")};
   REQUIRE(txtDiffusionConstant != nullptr);
+  auto *radDiffusionConstantAnalytic{
+      tab.findChild<QRadioButton *>("radDiffusionConstantAnalytic")};
+  REQUIRE(radDiffusionConstantAnalytic != nullptr);
+  auto *btnEditAnalyticDiffusionConstant{
+      tab.findChild<QPushButton *>("btnEditAnalyticDiffusionConstant")};
+  REQUIRE(btnEditAnalyticDiffusionConstant != nullptr);
+  auto *radDiffusionConstantImage{
+      tab.findChild<QRadioButton *>("radDiffusionConstantImage")};
+  REQUIRE(radDiffusionConstantImage != nullptr);
+  auto *btnEditImageDiffusionConstant{
+      tab.findChild<QPushButton *>("btnEditImageDiffusionConstant")};
+  REQUIRE(btnEditImageDiffusionConstant != nullptr);
+
   auto *btnChangeSpeciesColor{
       tab.findChild<QPushButton *>("btnChangeSpeciesColor")};
   REQUIRE(btnChangeSpeciesColor != nullptr);
@@ -78,6 +94,9 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(radInitialConcentrationUniform->isEnabled() == true);
     REQUIRE(radInitialConcentrationAnalytic->isEnabled() == false);
     REQUIRE(radInitialConcentrationImage->isEnabled() == false);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == false);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == false);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == false);
     REQUIRE(txtDiffusionConstant->isEnabled() == false);
     // edit name
     txtSpeciesName->setFocus();
@@ -92,6 +111,9 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(radInitialConcentrationUniform->isEnabled() == true);
     REQUIRE(radInitialConcentrationAnalytic->isEnabled() == true);
     REQUIRE(radInitialConcentrationImage->isEnabled() == true);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == true);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == true);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == true);
     REQUIRE(txtDiffusionConstant->isEnabled() == true);
     sendKeyEvents(chkSpeciesIsSpatial, {" "});
     REQUIRE(chkSpeciesIsSpatial->isChecked() == false);
@@ -99,6 +121,9 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(radInitialConcentrationUniform->isEnabled() == true);
     REQUIRE(radInitialConcentrationAnalytic->isEnabled() == false);
     REQUIRE(radInitialConcentrationImage->isEnabled() == false);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == false);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == false);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == false);
     REQUIRE(txtDiffusionConstant->isEnabled() == false);
     // toggle is constant checkbox
     sendMouseClick(chkSpeciesIsConstant);
@@ -115,6 +140,9 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(listSpecies->currentItem()->parent()->text(0) == "Outside");
     REQUIRE(chkSpeciesIsConstant->isChecked() == false);
     REQUIRE(chkSpeciesIsSpatial->isChecked() == true);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == true);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == true);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == true);
     // edit initial concentration
     REQUIRE(radInitialConcentrationUniform->isChecked());
     txtInitialConcentration->setFocus();
@@ -132,7 +160,7 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     sendMouseClick(btnEditAnalyticConcentration);
     // enable and edit image initial concentration
     REQUIRE(btnEditImageConcentration->isEnabled() == false);
-    sendMouseClick(radInitialConcentrationImage);
+    radInitialConcentrationImage->setChecked(true);
     REQUIRE(btnEditImageConcentration->isEnabled() == true);
     mwt.addUserAction({"Esc"});
     mwt.start();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sme"
-version = "1.10.1"
+version = "1.11.0"
 description = "Spatial Model Editor python bindings"
 readme = "README.md"
 license = {text = "MIT"}
 authors=[{name="Liam Keegan", email="liam@keegan.ch"}]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers=[
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "License :: OSI Approved :: MIT License",
@@ -18,7 +18,6 @@ classifiers=[
     "Natural Language :: English",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -58,4 +57,4 @@ SME_LOG_LEVEL = "OFF"
 build-verbosity = 3
 test-extras = "test"
 test-command = "python -m pytest {project}/sme/test -v"
-skip = '*-manylinux_i686 *-musllinux* *-win32 cp3??t-win*'
+skip = 'cp38-* *-manylinux_i686 *-musllinux* *-win32 cp3??t-win*'

--- a/sme/src/sme_species.hpp
+++ b/sme/src/sme_species.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "sme/model_species_types.hpp"
+#include "sme/model_types.hpp"
 #include "sme_common.hpp"
 #include <nanobind/nanobind.h>
 #include <string>
@@ -26,7 +26,16 @@ public:
   void setName(const std::string &name);
   [[nodiscard]] double getDiffusionConstant() const;
   void setDiffusionConstant(double diffusionConstant);
-  [[nodiscard]] ::sme::model::ConcentrationType
+  [[nodiscard]] ::sme::model::SpatialDataType getDiffusionConstantType() const;
+  [[nodiscard]] double getUniformDiffusionConstant() const;
+  void setUniformDiffusionConstant(double value);
+  [[nodiscard]] std::string getAnalyticDiffusionConstant() const;
+  void setAnalyticDiffusionConstant(const std::string &expression);
+  [[nodiscard]] nanobind::ndarray<nanobind::numpy, double>
+  getImageDiffusionConstant() const;
+  void
+  setImageDiffusionConstant(nanobind::ndarray<nanobind::numpy, double> array);
+  [[nodiscard]] ::sme::model::SpatialDataType
   getInitialConcentrationType() const;
   [[nodiscard]] double getUniformInitialConcentration() const;
   void setUniformInitialConcentration(double value);

--- a/sme/test/test_species.py
+++ b/sme/test/test_species.py
@@ -7,6 +7,9 @@ def test_species():
     # get an existing species
     m = sme.open_example_model()
     s = m.compartments["Cell"].species["A_cell"]
+    assert sme.SpatialDataType.Uniform == sme.ConcentrationType.Uniform
+    assert sme.SpatialDataType.Analytic == sme.ConcentrationType.Analytic
+    assert sme.SpatialDataType.Image == sme.ConcentrationType.Image
 
     # verify name and properties
     assert repr(s) == "<sme.Species named 'A_cell'>"
@@ -19,6 +22,13 @@ def test_species():
     assert s.concentration_image.shape == (1, 100, 100)
     assert s.concentration_image[0, 1, 2] == 0.0
     assert s.concentration_image[0, 23, 40] == 0.0
+    assert s.diffusion_type == sme.ConcentrationType.Uniform
+    assert s.uniform_diffusion == 6.0
+    assert s.analytic_diffusion == ""
+    assert s.diffusion_image.shape == (1, 100, 100)
+    compartment_mask = m.compartments["Cell"].geometry_mask
+    assert np.allclose(s.diffusion_image[compartment_mask], 6.0)
+    assert np.allclose(s.diffusion_image[~compartment_mask], 0.0)
 
     # assign new values
     s.name = "New A!"
@@ -34,6 +44,13 @@ def test_species():
     assert s.concentration_image.shape == (1, 100, 100)
     assert np.allclose(s.concentration_image[0, 1, 2], 0.0)
     assert np.allclose(s.concentration_image[0, 23, 40], 0.3)
+    assert s.diffusion_type == sme.ConcentrationType.Uniform
+    assert s.uniform_diffusion == 1.0
+    assert s.analytic_diffusion == ""
+    assert s.diffusion_image.shape == (1, 100, 100)
+    compartment_mask = m.compartments["Cell"].geometry_mask
+    assert np.allclose(s.diffusion_image[compartment_mask], 1.0)
+    assert np.allclose(s.diffusion_image[~compartment_mask], 0.0)
 
     # check changes were propagated to model
     with pytest.raises(ValueError):
@@ -85,6 +102,92 @@ def test_species():
     a3 = s.concentration_image
     assert s.concentration_type == sme.ConcentrationType.Image
     assert np.allclose(a2, a3)
+
+    # set an analytic diffusion constant
+    s.analytic_diffusion = "sin(y)+2"
+    assert s.diffusion_type == sme.ConcentrationType.Analytic
+    assert np.isfinite(s.uniform_diffusion)
+    assert s.analytic_diffusion.replace(" ", "") == "sin(y)+2"
+    assert s.diffusion_image.shape == (1, 100, 100)
+    compartment_mask = m.compartments["Cell"].geometry_mask
+    assert np.allclose(s.diffusion_image[~compartment_mask], 0.0)
+    diff_img = s.diffusion_image[0]
+    mask2d = compartment_mask[0]
+    ys = np.where(np.any(mask2d, axis=1))[0]
+    y_samples = [ys[0], ys[len(ys) // 2], ys[-1]]
+    for y in y_samples:
+        row_vals = diff_img[y, mask2d[y]]
+        assert np.std(row_vals) < 1e-6
+        y_phys = (diff_img.shape[0] - 1 - y) + 0.5
+        expected = np.sin(y_phys) + 2.0
+        assert abs(np.mean(row_vals) - expected) < 1e-2
+    prev_analytic_diffusion = s.analytic_diffusion
+    prev_diffusion_image = s.diffusion_image.copy()
+    with pytest.raises(ValueError) as excinfo:
+        s.analytic_diffusion = "sin(y)+("
+    assert "Invalid analytic diffusion expression: 'sin(y)+('" in str(excinfo.value)
+    assert s.analytic_diffusion == prev_analytic_diffusion
+    assert np.allclose(s.diffusion_image, prev_diffusion_image)
+
+    # set a uniform diffusion constant
+    s.uniform_diffusion = 3.0
+    assert s.diffusion_type == sme.ConcentrationType.Uniform
+    assert s.uniform_diffusion == 3.0
+    assert s.analytic_diffusion == ""
+    assert s.diffusion_image.shape == (1, 100, 100)
+    compartment_mask = m.compartments["Cell"].geometry_mask
+    assert np.allclose(s.diffusion_image[compartment_mask], 3.0)
+    assert np.allclose(s.diffusion_image[~compartment_mask], 0.0)
+
+    # round trip check of image diffusion constant
+    d1 = np.random.default_rng().uniform(0, 1, (1, 100, 100))
+    s.diffusion_image = d1
+    assert np.isfinite(s.uniform_diffusion)
+    assert s.diffusion_type == sme.ConcentrationType.Image
+    d2 = s.diffusion_image
+    assert s.diffusion_type == sme.ConcentrationType.Image
+    compartment_mask = m.compartments["Cell"].geometry_mask
+    assert np.allclose(d1[compartment_mask], d2[compartment_mask])
+    assert np.sum(np.square(d2[~compartment_mask])) < 1e-7
+    d1[~compartment_mask] = 0.0
+    assert np.allclose(d1, d2)
+    s.diffusion_image = d2
+    d3 = s.diffusion_image
+    assert s.diffusion_type == sme.ConcentrationType.Image
+    assert np.allclose(d2, d3)
+
+    # invalid diffusion image assignments throw with helpful message
+    with pytest.raises(ValueError) as excinfo:
+        s.diffusion_image = np.random.default_rng().uniform(0, 1, 100)
+    assert (
+        "Invalid diffusion image array: is 1-dimensional, should be 3-dimensional"
+        in str(excinfo.value)
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        s.diffusion_image = np.random.default_rng().uniform(0, 1, (10, 10))
+    assert (
+        "Invalid diffusion image array: is 2-dimensional, should be 3-dimensional"
+        in str(excinfo.value)
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        s.diffusion_image = np.random.default_rng().uniform(0, 1, (2, 10, 100))
+    assert "Invalid diffusion image array: depth is 2, should be 1" in str(
+        excinfo.value
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        s.diffusion_image = np.random.default_rng().uniform(0, 1, (1, 10, 100))
+    assert "Invalid diffusion image array: height is 10, should be 100" in str(
+        excinfo.value
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        s.diffusion_image = np.random.default_rng().uniform(0, 1, (1, 100, 101))
+    assert "Invalid diffusion image array: width is 101, should be 100" in str(
+        excinfo.value
+    )
 
     # invalid image assignments throw with helpful message
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
- add analytic and image options for diffusion constant in GUI species tab
- add diffusion constant array to `Field`
- store diffusion constant arrays as sbml annotation
  - a parameter in SBML cannot have both a `diffusionCoefficient` and a `spatialSymbolReference` spatial plugin
- make image conc and analytic conc dialogs more generic
- add FunctorFactory wrapper to provide diffusion constant image arrays to dune-copasi
- update Pixel to support spatially varying diffusion constants
- fix analytic diff const
- update python bindings for diff const
- add diff const tests
- also restore removed getdeps script for local linux builds as ci/get-deps-local-linux.sh
