### PR TITLE
Fix diffusion constant array import bugs

### DIFF
--- a/core/model/src/geometry.cpp
+++ b/core/model/src/geometry.cpp
@@ -221,8 +221,13 @@ void Field::setDiffusionConstant(
 }
 
 void Field::importDiffusionConstant(const std::vector<double> &sbmlArray) {
-  diff = importSbmlArray(sbmlArray);
-  isUniformDiffusionConstant = false;
+  try {
+    diff = importSbmlArray(sbmlArray);
+    isUniformDiffusionConstant = false;
+  } catch (const std::invalid_argument &e) {
+    SPDLOG_WARN("Ignoring failed diffusion array import for species {}: {}", id,
+                e.what());
+  }
 }
 
 std::vector<double>
@@ -240,8 +245,13 @@ void Field::setConcentration(std::size_t index, double concentration) {
 
 void Field::importConcentration(
     const std::vector<double> &sbmlConcentrationArray) {
-  conc = importSbmlArray(sbmlConcentrationArray);
-  isUniformConcentration = false;
+  try {
+    conc = importSbmlArray(sbmlConcentrationArray);
+    isUniformConcentration = false;
+  } catch (const std::invalid_argument &e) {
+    SPDLOG_WARN("Ignoring failed concentration array import for species {}: {}",
+                id, e.what());
+  }
 }
 
 std::vector<double>
@@ -338,6 +348,7 @@ void Field::setCompartment(const Compartment *compartment) {
   SPDLOG_DEBUG("Changing compartment to {}", compartment->getId());
   comp = compartment;
   conc.assign(compartment->nVoxels(), 0.0);
+  diff.assign(compartment->nVoxels(), 0.0);
 }
 
 } // namespace sme::geometry

--- a/core/model/src/geometry_t.cpp
+++ b/core/model/src/geometry_t.cpp
@@ -100,9 +100,19 @@ TEST_CASE("Geometry: Compartments and Fields",
     REQUIRE(a.size() == 1);
     REQUIRE(a[0] == dbl_approx(0));
 
-    // conc array size must match image volume
-    REQUIRE_THROWS(field.importConcentration({1.0, 2.0}));
-    REQUIRE_THROWS(field.importConcentration({}));
+    // invalid concentration array size is ignored
+    field.importConcentration({1.0});
+    auto concBefore = field.getConcentration();
+    REQUIRE_NOTHROW(field.importConcentration({1.0, 2.0}));
+    REQUIRE_NOTHROW(field.importConcentration({}));
+    REQUIRE(field.getConcentration() == concBefore);
+
+    // invalid diffusion array size is ignored
+    field.importDiffusionConstant({3.1});
+    auto diffBefore = field.getDiffusionConstant();
+    REQUIRE_NOTHROW(field.importDiffusionConstant({1.0, 2.0}));
+    REQUIRE_NOTHROW(field.importDiffusionConstant({}));
+    REQUIRE(field.getDiffusionConstant() == diffBefore);
   }
   SECTION("two pixel compartment, 6x7 image") {
     common::ImageStack img{{QImage(6, 7, QImage::Format_RGB32)}};
@@ -166,9 +176,18 @@ TEST_CASE("Geometry: Compartments and Fields",
     REQUIRE(a2[26] == dbl_approx(0.0));
     REQUIRE(a2.back() == dbl_approx(0.0));
 
-    // conc array size must match image volume
-    REQUIRE_THROWS(field.importConcentration({1.0, 2.0}));
-    REQUIRE_THROWS(field.importConcentration({}));
+    // invalid concentration array size is ignored
+    auto concBefore = field.getConcentration();
+    REQUIRE_NOTHROW(field.importConcentration({1.0, 2.0}));
+    REQUIRE_NOTHROW(field.importConcentration({}));
+    REQUIRE(field.getConcentration() == concBefore);
+
+    // invalid diffusion array size is ignored
+    field.importDiffusionConstant(arr);
+    auto diffBefore = field.getDiffusionConstant();
+    REQUIRE_NOTHROW(field.importDiffusionConstant({1.0, 2.0}));
+    REQUIRE_NOTHROW(field.importDiffusionConstant({}));
+    REQUIRE(field.getDiffusionConstant() == diffBefore);
   }
   SECTION("compartment of field is changed") {
     common::ImageStack img{{QImage(6, 7, QImage::Format_RGB32)}};
@@ -194,8 +213,11 @@ TEST_CASE("Geometry: Compartments and Fields",
     field.setCompartment(&comp2);
     REQUIRE(field.getCompartment() == &comp2);
     REQUIRE(field.getConcentration().size() == comp2.nVoxels());
+    REQUIRE(field.getDiffusionConstant().size() == comp2.nVoxels());
     REQUIRE(field.getConcentration()[0] == dbl_approx(0.0));
     REQUIRE(field.getConcentration()[1] == dbl_approx(0.0));
+    REQUIRE(field.getDiffusionConstant()[0] == dbl_approx(0.0));
+    REQUIRE(field.getDiffusionConstant()[1] == dbl_approx(0.0));
   }
   SECTION("getConcentrationImageArray") {
     common::ImageStack img{

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -272,6 +272,17 @@ TEST_CASE("SBML: import SBML doc without geometry",
       REQUIRE(fieldAfter != nullptr);
       REQUIRE(fieldAfter->getDiffusionConstant().size() == comp1->nVoxels());
     }
+    SECTION("sampled diffusion field and imported geometry size mismatch") {
+      s.getSpecies().setIsSpatial("spec0c0", true);
+      s.getSpecies().setSampledFieldDiffusionConstant("spec0c0",
+                                                      {0.0, 1.0, 2.0});
+      QImage img(4, 1, QImage::Format_RGB32);
+      img.fill(0xffaaaaaa);
+      s.getGeometry().importGeometryFromImages(common::ImageStack{{img}},
+                                               false);
+      REQUIRE_NOTHROW(
+          s.getGeometry().setVoxelSize(s.getGeometry().getVoxelSize()));
+    }
   }
 }
 

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -1,6 +1,7 @@
 #include "dialogoptcost.hpp"
 #include "dialogimagedata.hpp"
 #include "ui_dialogoptcost.h"
+#include <QMessageBox>
 
 static QString toQStr(double x) { return QString::number(x, 'g', 14); }
 
@@ -150,12 +151,16 @@ void DialogOptCost::btnEditTargetValues_clicked() {
   if (m_optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt) {
     dataType = DialogImageDataDataType::ConcentrationRateOfChange;
   }
-  DialogImageData dialog(m_optCost.targetValues,
-                         m_model.getSpeciesGeometry(m_optCost.id.c_str()),
-                         m_model.getDisplayOptions().invertYAxis, dataType);
-  if (dialog.exec() == QDialog::Accepted) {
-    m_optCost.targetValues = dialog.getImageArray();
-    updateImage();
+  try {
+    DialogImageData dialog(m_optCost.targetValues,
+                           m_model.getSpeciesGeometry(m_optCost.id.c_str()),
+                           m_model.getDisplayOptions().invertYAxis, dataType);
+    if (dialog.exec() == QDialog::Accepted) {
+      m_optCost.targetValues = dialog.getImageArray();
+      updateImage();
+    }
+  } catch (const std::invalid_argument &e) {
+    QMessageBox::warning(this, "Error editing target values image", e.what());
   }
 }
 

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -333,19 +333,23 @@ void TabSpecies::btnEditAnalyticConcentration_clicked() {
 void TabSpecies::btnEditImageConcentration_clicked() {
   SPDLOG_DEBUG("editing initial concentration image for species {}...",
                currentSpeciesId.toStdString());
-  DialogImageData dialog(
-      model.getSpecies().getSampledFieldConcentration(currentSpeciesId),
-      model.getSpeciesGeometry(currentSpeciesId),
-      model.getDisplayOptions().invertYAxis,
-      DialogImageDataDataType::Concentration);
-  if (dialog.exec() == QDialog::Accepted) {
-    SPDLOG_DEBUG("  - setting new sampled field concentration array");
-    model.getSpecies().setSampledFieldConcentration(currentSpeciesId,
-                                                    dialog.getImageArray());
-    const auto img =
-        model.getSpecies().getConcentrationImages(currentSpeciesId);
-    lblGeometry->setImage(img);
-    voxGeometry->setImage(img);
+  try {
+    DialogImageData dialog(
+        model.getSpecies().getSampledFieldConcentration(currentSpeciesId),
+        model.getSpeciesGeometry(currentSpeciesId),
+        model.getDisplayOptions().invertYAxis,
+        DialogImageDataDataType::Concentration);
+    if (dialog.exec() == QDialog::Accepted) {
+      SPDLOG_DEBUG("  - setting new sampled field concentration array");
+      model.getSpecies().setSampledFieldConcentration(currentSpeciesId,
+                                                      dialog.getImageArray());
+      const auto img =
+          model.getSpecies().getConcentrationImages(currentSpeciesId);
+      lblGeometry->setImage(img);
+      voxGeometry->setImage(img);
+    }
+  } catch (const std::invalid_argument &e) {
+    QMessageBox::warning(this, "Error editing concentration image", e.what());
   }
 }
 
@@ -394,15 +398,19 @@ void TabSpecies::btnEditAnalyticDiffusionConstant_clicked() {
 void TabSpecies::btnEditImageDiffusionConstant_clicked() {
   SPDLOG_DEBUG("editing diffusion constant image for species {}...",
                currentSpeciesId.toStdString());
-  DialogImageData dialog(
-      model.getSpecies().getSampledFieldDiffusionConstant(currentSpeciesId),
-      model.getSpeciesGeometry(currentSpeciesId),
-      model.getDisplayOptions().invertYAxis,
-      DialogImageDataDataType::DiffusionConstant);
-  if (dialog.exec() == QDialog::Accepted) {
-    SPDLOG_DEBUG("  - setting new sampled field diffusion constant array");
-    model.getSpecies().setSampledFieldDiffusionConstant(currentSpeciesId,
-                                                        dialog.getImageArray());
+  try {
+    DialogImageData dialog(
+        model.getSpecies().getSampledFieldDiffusionConstant(currentSpeciesId),
+        model.getSpeciesGeometry(currentSpeciesId),
+        model.getDisplayOptions().invertYAxis,
+        DialogImageDataDataType::DiffusionConstant);
+    if (dialog.exec() == QDialog::Accepted) {
+      SPDLOG_DEBUG("  - setting new sampled field diffusion constant array");
+      model.getSpecies().setSampledFieldDiffusionConstant(
+          currentSpeciesId, dialog.getImageArray());
+    }
+  } catch (const std::invalid_argument &e) {
+    QMessageBox::warning(this, "Error editing diffusion image", e.what());
   }
 }
 


### PR DESCRIPTION
- ensure diffusion array is also resized in setCompartment
- catch exceptions such that invalid import of diffusion/concentration array becomes a no-op
- catch previously uncaught DialogImageData exceptions and display message box to user instead
