### PR TITLE
Refactor voxel index calculations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
       - id: requirements-txt-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.0
     hooks:
       - id: ruff-check
         types_or: [python, pyi, jupyter]

--- a/core/common/include/sme/voxel.hpp
+++ b/core/common/include/sme/voxel.hpp
@@ -3,6 +3,7 @@
 #include "sme/logger.hpp"
 #include <QPoint>
 #include <QSize>
+#include <algorithm>
 
 namespace sme::common {
 
@@ -85,5 +86,32 @@ public:
             a.depth() / static_cast<double>(b.depth())};
   }
 };
+
+[[nodiscard]] inline int toVoxelIndex(double coordinate, double origin,
+                                      double voxelSize, int nVoxels) noexcept {
+  if (nVoxels <= 1 || voxelSize <= 0.0) {
+    return 0;
+  }
+  return std::clamp(static_cast<int>((coordinate - origin) / voxelSize), 0,
+                    nVoxels - 1);
+}
+
+[[nodiscard]] inline int yIndex(int y, int height, bool invertY) noexcept {
+  return invertY ? (height - 1 - y) : y;
+}
+
+[[nodiscard]] inline std::size_t
+voxelArrayIndex(const Volume &volume, int x, int y, std::size_t z,
+                bool invertY = false) noexcept {
+  return static_cast<std::size_t>(x + volume.width() *
+                                          yIndex(y, volume.height(), invertY)) +
+         static_cast<std::size_t>(volume.width() * volume.height()) * z;
+}
+
+[[nodiscard]] inline std::size_t
+voxelArrayIndex(const Volume &volume, const Voxel &voxel,
+                bool invertY = false) noexcept {
+  return voxelArrayIndex(volume, voxel.p.x(), voxel.p.y(), voxel.z, invertY);
+}
 
 } // namespace sme::common

--- a/core/common/src/tiff.cpp
+++ b/core/common/src/tiff.cpp
@@ -29,6 +29,7 @@ double writeTIFF(const std::string &filename, const QSize &imageSize,
   SPDLOG_TRACE("  - max value: {}", TiffDataTypeMaxValue);
   const auto width{static_cast<std::size_t>(imageSize.width())};
   const auto height{static_cast<std::size_t>(imageSize.height())};
+  const auto volume{common::Volume{imageSize, 1}};
   SPDLOG_TRACE("  - image size {}x{}", width, height);
   auto tifValues = std::vector<std::vector<TiffDataType>>(
       height, std::vector<TiffDataType>(width, 0));
@@ -37,8 +38,10 @@ double writeTIFF(const std::string &filename, const QSize &imageSize,
   SPDLOG_TRACE("{}", scaleFactor);
   for (std::size_t y = 0; y < height; ++y) {
     for (std::size_t x = 0; x < width; ++x) {
-      auto val = static_cast<TiffDataType>(scaleFactor *
-                                           conc[x + width * (height - 1 - y)]);
+      auto val = static_cast<TiffDataType>(
+          scaleFactor *
+          conc[common::voxelArrayIndex(volume, static_cast<int>(x),
+                                       static_cast<int>(y), 0, true)]);
       tifValues[y][x] = val;
     }
   }

--- a/core/common/src/voxel_t.cpp
+++ b/core/common/src/voxel_t.cpp
@@ -17,4 +17,27 @@ TEST_CASE("Voxel", "[core/common/voxel][core/common][core][voxel]") {
     REQUIRE(v3.p.y() == 0);
     REQUIRE(v3.z == 0);
   }
+  SECTION("toVoxelIndex") {
+    REQUIRE(sme::common::toVoxelIndex(0.49, 0.0, 1.0, 5) == 0);
+    REQUIRE(sme::common::toVoxelIndex(2.01, 0.0, 1.0, 5) == 2);
+    REQUIRE(sme::common::toVoxelIndex(-100.0, 0.0, 1.0, 5) == 0);
+    REQUIRE(sme::common::toVoxelIndex(100.0, 0.0, 1.0, 5) == 4);
+    REQUIRE(sme::common::toVoxelIndex(100.0, 0.0, 1.0, 1) == 0);
+    REQUIRE(sme::common::toVoxelIndex(100.0, 0.0, 1.0, 0) == 0);
+    REQUIRE(sme::common::toVoxelIndex(100.0, 0.0, 0.0, 5) == 0);
+  }
+  SECTION("yIndex") {
+    REQUIRE(sme::common::yIndex(1, 6, false) == 1);
+    REQUIRE(sme::common::yIndex(1, 6, true) == 4);
+  }
+  SECTION("voxelArrayIndex") {
+    const sme::common::Volume vol{4, 5, 3};
+    const sme::common::Voxel voxel{2, 1, 2};
+    REQUIRE(sme::common::voxelArrayIndex(vol, voxel, false) ==
+            static_cast<std::size_t>(2 + 4 * 1 + 4 * 5 * 2));
+    REQUIRE(sme::common::voxelArrayIndex(vol, voxel, true) ==
+            static_cast<std::size_t>(2 + 4 * (5 - 1 - 1) + 4 * 5 * 2));
+    REQUIRE(sme::common::voxelArrayIndex(vol, 2, 1, 2, true) ==
+            sme::common::voxelArrayIndex(vol, voxel, true));
+  }
 }

--- a/core/model/src/geometry.cpp
+++ b/core/model/src/geometry.cpp
@@ -41,8 +41,8 @@ Compartment::Compartment(std::string compId, const common::ImageStack &imgs,
           image.setPixel(x, y, 1);
           // NOTE: y=0 in ix is at bottom of image,
           // but we want it at the top in arrayPoints, so y index is inverted
-          arrayPoints[static_cast<std::size_t>(x + nx * (ny - 1 - y)) +
-                      (static_cast<std::size_t>(nx * ny) * z)] = ixIndex++;
+          arrayPoints[common::voxelArrayIndex(images.volume(), x, y, z, true)] =
+              ixIndex++;
         }
       }
     }
@@ -275,9 +275,7 @@ Field::importSbmlArray(const std::vector<double> &sbmlArray) {
   // NOTE: y=0 is at the bottom, QImage has y=0 at the top, so flip y-coord
   for (std::size_t i = 0; i < comp->nVoxels(); ++i) {
     const auto &v{comp->getVoxel(i)};
-    const int arrayIndex{v.p.x() + nx * (ny - 1 - v.p.y()) +
-                         nx * ny * static_cast<int>(v.z)};
-    output[i] = sbmlArray[static_cast<std::size_t>(arrayIndex)];
+    output[i] = sbmlArray[common::voxelArrayIndex(imageSize, v, true)];
   }
   return output;
 }

--- a/core/model/src/geometry_t.cpp
+++ b/core/model/src/geometry_t.cpp
@@ -44,10 +44,11 @@ testGetConcentrationImageArray(const geometry::Field &f) {
   // NOTE: QImage has (0,0) point at top-left, so flip y-coord here
   constexpr double invalidPixelValue{-1.0};
   std::vector<double> arr(static_cast<std::size_t>(size), invalidPixelValue);
+  const common::Volume imageVolume{img.size(), 1};
   for (std::size_t i = 0; i < f.getCompartment()->nVoxels(); ++i) {
     const auto &voxel{f.getCompartment()->getVoxel(i)};
     int arrayIndex =
-        voxel.p.x() + img.width() * (img.height() - 1 - voxel.p.y());
+        static_cast<int>(common::voxelArrayIndex(imageVolume, voxel, true));
     arr[static_cast<std::size_t>(arrayIndex)] = f.getConcentration()[i];
   }
   testFillMissingByDilation(arr, img.width(), img.height());

--- a/core/simulate/src/dunefunction.hpp
+++ b/core/simulate/src/dunefunction.hpp
@@ -42,20 +42,17 @@ public:
       return 0;
     }
     // get nearest voxel to physical point
-    auto ix = std::clamp(
-        static_cast<int>((globalPos[0] - origin.p.x()) / voxel.width()), 0,
-        vol.width() - 1);
-    auto iy = std::clamp(
-        static_cast<int>((globalPos[1] - origin.p.y()) / voxel.height()), 0,
-        vol.height() - 1);
+    auto ix = common::toVoxelIndex(globalPos[0], origin.p.x(), voxel.width(),
+                                   vol.width());
+    auto iy = common::toVoxelIndex(globalPos[1], origin.p.y(), voxel.height(),
+                                   vol.height());
     int iz = 0;
     if constexpr (Domain::size() == 3) {
-      iz = std::clamp(
-          static_cast<int>((globalPos[2] - origin.z) / voxel.depth()), 0,
-          static_cast<int>(vol.depth()) - 1);
+      iz = common::toVoxelIndex(globalPos[2], origin.z, voxel.depth(),
+                                static_cast<int>(vol.depth()));
     }
-    auto ci = static_cast<std::size_t>(ix + vol.width() * iy +
-                                       vol.width() * vol.height() * iz);
+    auto ci =
+        common::voxelArrayIndex(vol, ix, iy, static_cast<std::size_t>(iz));
     SPDLOG_TRACE("  -> voxel ({},{},{})", ix, iy, iz);
     SPDLOG_TRACE("  -> conc[{}] = {}", ci, c[ci]);
     return c[ci];

--- a/core/simulate/src/dunefunctorfactory.hpp
+++ b/core/simulate/src/dunefunctorfactory.hpp
@@ -71,20 +71,17 @@ public:
         auto *pos = &local_domain.position;
         return [array, pos, origin, voxel, vol]() noexcept {
           // get nearest voxel to physical point
-          auto ix = std::clamp(
-              static_cast<int>(((*pos)[0] - origin.p.x()) / voxel.width()), 0,
-              vol.width() - 1);
-          auto iy = std::clamp(
-              static_cast<int>(((*pos)[1] - origin.p.y()) / voxel.height()), 0,
-              vol.height() - 1);
+          auto ix = common::toVoxelIndex((*pos)[0], origin.p.x(), voxel.width(),
+                                         vol.width());
+          auto iy = common::toVoxelIndex((*pos)[1], origin.p.y(),
+                                         voxel.height(), vol.height());
           int iz = 0;
           if constexpr (dim == 3) {
-            iz = std::clamp(
-                static_cast<int>(((*pos)[2] - origin.z) / voxel.depth()), 0,
-                static_cast<int>(vol.depth()) - 1);
+            iz = common::toVoxelIndex((*pos)[2], origin.z, voxel.depth(),
+                                      static_cast<int>(vol.depth()));
           }
-          auto ci = static_cast<std::size_t>(ix + vol.width() * iy +
-                                             vol.width() * vol.height() * iz);
+          auto ci = common::voxelArrayIndex(vol, ix, iy,
+                                            static_cast<std::size_t>(iz));
           SPDLOG_TRACE("  -> voxel ({},{},{})", ix, iy, iz);
           SPDLOG_TRACE("  -> diffusionConstant[{}] = {}", ci, array[ci]);
           return Dune::FieldVector<double, 1>{array[ci]};

--- a/core/simulate/src/dunesim_impl.hpp
+++ b/core/simulate/src/dunesim_impl.hpp
@@ -331,7 +331,8 @@ private:
               // as local coordinate for this element
               auto localPoint = e.geometry().local(duneCoord);
               // note: qpi/QImage has (0,0) in top-left corner:
-              common::Voxel vox{x, geometryImageSize.height() - 1 - y, z};
+              common::Voxel vox{
+                  x, common::yIndex(y, geometryImageSize.height(), true), z};
               if (auto ix{qpi.getIndex(vox)};
                   ix.has_value() && ref.checkInside(localPoint)) {
                 voxelsInElement.push_back({*ix, localPoint});

--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -408,10 +408,7 @@ std::vector<double> Simulation::getConcArray(std::size_t timeIndex,
   std::size_t stride{nSpecies + data->concPadding[timeIndex]};
   for (std::size_t ix = 0; ix < nPixels; ++ix) {
     const auto &point = comp->getVoxel(ix);
-    auto arrayIndex{static_cast<std::size_t>(
-        point.p.x() +
-        imageSize.width() * (imageSize.height() - 1 - point.p.y()) +
-        imageSize.width() * imageSize.height() * point.z)};
+    auto arrayIndex{common::voxelArrayIndex(imageSize, point, true)};
     c[arrayIndex] = compConc[ix * stride + speciesIndex];
   }
   return c;
@@ -462,9 +459,8 @@ std::vector<double> Simulation::getDcdtArray(std::size_t compartmentIndex,
     std::size_t stride{nSpecies + data->concPadding.back()};
     for (std::size_t ix = 0; ix < nPixels; ++ix) {
       const auto &point = comp->getVoxel(ix);
-      auto arrayIndex{static_cast<std::size_t>(
-          point.p.x() +
-          imageSize.width() * (imageSize.height() - 1 - point.p.y()))};
+      auto arrayIndex{common::voxelArrayIndex(imageSize, point.p.x(),
+                                              point.p.y(), 0, true)};
       c[arrayIndex] = compDcdt[ix * stride + speciesIndex];
     }
   }
@@ -564,11 +560,7 @@ Simulation::getPyNames(std::size_t compartmentIndex) const {
 
 static std::size_t voxelToPyIndex(const common::Voxel &v,
                                   const common::Volume imageSize) {
-  auto x{static_cast<std::size_t>(v.p.x())};
-  auto y{static_cast<std::size_t>(v.p.y())};
-  auto w{static_cast<std::size_t>(imageSize.width())};
-  auto d{imageSize.depth()};
-  return x + w * y + w * d * v.z;
+  return common::voxelArrayIndex(imageSize, v, false);
 }
 
 std::vector<std::vector<double>>

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -1130,7 +1130,8 @@ TEST_CASE(
     for (std::size_t z = 0; z < d; ++z) {
       for (std::size_t y = 0; y < h; ++y) {
         for (std::size_t x = 0; x < w; ++x) {
-          auto arrayIndex = x + w * (h - 1 - y) + w * h * z;
+          auto arrayIndex = common::voxelArrayIndex(
+              vol, static_cast<int>(x), static_cast<int>(y), z, true);
           diffArray[arrayIndex] =
               1.0 + static_cast<double>(x) / static_cast<double>(w);
         }
@@ -1196,8 +1197,7 @@ TEST_CASE(
   std::vector<double> diffArray(static_cast<std::size_t>(vol.nVoxels()), 0.0);
   const double pi = 3.14159265358979323846;
   for (const auto &voxel : comp->getVoxels()) {
-    auto arrayIndex = static_cast<std::size_t>(
-        voxel.p.x() + w * (h - 1 - voxel.p.y()) + w * h * voxel.z);
+    auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
     if (static_cast<std::size_t>(voxel.p.x()) < mid) {
       // smooth spatial variation in left half
       double x = static_cast<double>(voxel.p.x());
@@ -1246,8 +1246,7 @@ TEST_CASE(
       if (x + leftBuffer >= mid) {
         continue;
       }
-      auto arrayIndex = static_cast<std::size_t>(
-          voxel.p.x() + w * (h - 1 - voxel.p.y()) + w * h * voxel.z);
+      auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
       maxLeftDelta = std::max(
           maxLeftDelta, std::abs(conc[arrayIndex] - initConc[arrayIndex]));
     }
@@ -1264,8 +1263,7 @@ TEST_CASE(
       if (x < mid + 2) {
         continue;
       }
-      auto arrayIndex = static_cast<std::size_t>(
-          voxel.p.x() + w * (h - 1 - voxel.p.y()) + w * h * voxel.z);
+      auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
       double v = conc[arrayIndex];
       sum += v;
       sumSq += v * v;
@@ -1297,7 +1295,8 @@ TEST_CASE(
               (w > 1) ? static_cast<double>(x) / static_cast<double>(w - 1)
                       : 0.0;
           const double dSmooth = 10 * t * t * (3.0 - 2.0 * t);
-          const auto arrayIndex = x + w * (h - 1 - y) + w * h * z;
+          const auto arrayIndex = common::voxelArrayIndex(
+              vol, static_cast<int>(x), static_cast<int>(y), z, true);
           diffArray[arrayIndex] = dSmooth;
         }
       }
@@ -1347,8 +1346,7 @@ TEST_CASE(
     double sumSqRef = 0.0;
     double maxAbsDiff = 0.0;
     for (const auto &voxel : comp->getVoxels()) {
-      auto arrayIndex = static_cast<std::size_t>(
-          voxel.p.x() + w * (h - 1 - voxel.p.y()) + w * h * voxel.z);
+      auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
       const double diff = p[arrayIndex] - d[arrayIndex];
       sumSqDiff += diff * diff;
       sumSqRef += d[arrayIndex] * d[arrayIndex];

--- a/gui/dialogs/dialogimagedata.cpp
+++ b/gui/dialogs/dialogimagedata.cpp
@@ -123,13 +123,8 @@ std::size_t
 DialogImageData::pointToArrayIndex(const sme::common::Voxel &voxel) const {
   // NOTE: order of concentration array is [ (x=0,y=0), (x=1,y=0), ... ]
   // NOTE: (0,0) point is at bottom-left
-  // NOTE: QImage has (0,0) point at top-left, so flip y-coord here
-  auto w{static_cast<std::size_t>(imgs.volume().width())};
-  auto h{static_cast<std::size_t>(imgs.volume().height())};
-  auto x{static_cast<std::size_t>(voxel.p.x())};
-  auto y{static_cast<std::size_t>(voxel.p.y())};
-  auto z{voxel.z};
-  return (x + w * (h - 1 - y) + w * h * z);
+  // NOTE: QImage has (0,0) point at top-left
+  return sme::common::voxelArrayIndex(imgs.volume(), voxel, true);
 }
 
 void DialogImageData::importArray(

--- a/sme/src/sme_species.cpp
+++ b/sme/src/sme_species.cpp
@@ -4,6 +4,7 @@
 
 #include "sme/model.hpp"
 #include "sme/model_types.hpp"
+#include "sme/voxel.hpp"
 #include "sme_common.hpp"
 #include "sme_species.hpp"
 #include <nanobind/stl/string.h>
@@ -161,7 +162,8 @@ void Species::setImageDiffusionConstant(
   for (std::size_t z = 0; z < v.shape(0); z++) {
     for (std::size_t y = 0; y < v.shape(1); y++) {
       for (std::size_t x = 0; x < v.shape(2); x++) {
-        auto sampledFieldIndex = x + w * (h - 1 - y) + w * h * z;
+        auto sampledFieldIndex = ::sme::common::voxelArrayIndex(
+            size, static_cast<int>(x), static_cast<int>(y), z, true);
         sampledFieldDiffusion[sampledFieldIndex] = v(z, y, x);
       }
     }
@@ -226,7 +228,8 @@ void Species::setImageInitialConcentration(
   for (std::size_t z = 0; z < v.shape(0); z++) {
     for (std::size_t y = 0; y < v.shape(1); y++) {
       for (std::size_t x = 0; x < v.shape(2); x++) {
-        auto sampledFieldIndex = x + w * (h - 1 - y) + w * h * z;
+        auto sampledFieldIndex = ::sme::common::voxelArrayIndex(
+            size, static_cast<int>(x), static_cast<int>(y), z, true);
         sampledFieldConcentration[sampledFieldIndex] = v(z, y, x);
       }
     }


### PR DESCRIPTION
- add voxelArrayIndex and toVoxelIndex helper functions
- use them instead of existing inline / ad-hoc implementations
