### PR TITLE
Use isotropic diffusion operator in Pixel when possible

### DIFF
--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -10,6 +10,7 @@
 #include "sme/symbolic.hpp"
 #include <QImage>
 #include <QPoint>
+#include <array>
 #include <cstddef>
 #include <limits>
 #include <string>
@@ -50,6 +51,8 @@ private:
   std::vector<double> s3;
   // diffusion constants (D) per voxel for each species
   std::vector<std::vector<double>> diffConstants;
+  // diffusion constants (D/dx^2, D/dy^2, D/dz^2) per species
+  std::vector<std::array<double, 3>> diffConstantsUniform;
   const geometry::Compartment *comp;
   std::size_t nPixels;
   std::size_t nSpecies;
@@ -61,12 +64,14 @@ private:
   double dx2{1.0};
   double dy2{1.0};
   double dz2{1.0};
+  bool useUniformDiffusionOperator{false};
 
 public:
   explicit SimCompartment(
       const model::Model &doc, const geometry::Compartment *compartment,
       std::vector<std::string> sIds, bool doCSE = true, unsigned optLevel = 3,
       bool timeDependent = false, bool spaceDependent = false,
+      bool useUniformDiffusionOperator = false,
       const std::map<std::string, double, std::less<>> &substitutions = {});
 
   // dcdt = result of applying diffusion operator to conc

--- a/core/simulate/src/pixelsim_t.cpp
+++ b/core/simulate/src/pixelsim_t.cpp
@@ -17,4 +17,33 @@ TEST_CASE("PixelSim", "[core/simulate/pixelsim][core/"
     pixelSim.run(1, -1, []() { return true; });
     REQUIRE(pixelSim.errorMessage() == "Simulation stopped early");
   }
+  SECTION("Uniform diffusion operator matches spatial array diffusion") {
+    auto mUniform{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    auto mArray{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    for (const auto &speciesId : {"slow", "fast"}) {
+      auto *field = mArray.getSpecies().getField(speciesId);
+      REQUIRE(field != nullptr);
+      field->setDiffusionConstant(field->getDiffusionConstant());
+    }
+    for (auto *m : {&mUniform, &mArray}) {
+      auto &options{m->getSimulationSettings().options};
+      options.pixel.enableMultiThreading = false;
+      options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+      options.pixel.maxTimestep = 1e-3;
+    }
+    std::vector<std::string> comps{"circle"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim simUniform(mUniform, comps, specs);
+    simulate::PixelSim simArray(mArray, comps, specs);
+    REQUIRE(simUniform.errorMessage().empty());
+    REQUIRE(simArray.errorMessage().empty());
+    simUniform.run(1e-3, -1.0, {});
+    simArray.run(1e-3, -1.0, {});
+    const auto &cUniform = simUniform.getConcentrations(0);
+    const auto &cArray = simArray.getConcentrations(0);
+    REQUIRE(cUniform.size() == cArray.size());
+    for (std::size_t i = 0; i < cUniform.size(); ++i) {
+      REQUIRE(cUniform[i] == dbl_approx(cArray[i]));
+    }
+  }
 }


### PR DESCRIPTION
- if all species have constant diffusion constants
  - use the simplified form of the diffusion operator
  - diffusion constant is a single double rather than an array defined for every voxel
  - this is the original implementation from before spatially varying diffusion was supported
- otherwise
  - use the form that supports spatially varying diffusion constants
