### PR TITLE
Minor GUI widget fixes

### DIFF
--- a/gui/widgets/plotwrapper.cpp
+++ b/gui/widgets/plotwrapper.cpp
@@ -159,6 +159,9 @@ void PlotWrapper::clear() {
 }
 
 double PlotWrapper::xValue(const QMouseEvent *event) const {
+  if (plot->graphCount() == 0) {
+    return 0.0;
+  }
   const auto &pos{event->position()};
   double key;
   double val;

--- a/gui/widgets/qlabelmousetracker.cpp
+++ b/gui/widgets/qlabelmousetracker.cpp
@@ -80,6 +80,10 @@ QRgb QLabelMouseTracker::getColor() const { return color; }
 int QLabelMouseTracker::getMaskIndex() const { return maskIndex; }
 
 QPointF QLabelMouseTracker::getRelativePosition() const {
+  if (image.empty() || pixmap.isNull() || pixmap.width() == 0 ||
+      pixmap.height() == 0) {
+    return {};
+  }
   auto xRelPos{static_cast<double>(currentVoxel.p.x()) /
                static_cast<double>(image[currentVoxel.z].width())};
   auto yRelPos{static_cast<double>(currentVoxel.p.y()) /

--- a/gui/widgets/qlabelslice.cpp
+++ b/gui/widgets/qlabelslice.cpp
@@ -11,9 +11,9 @@ QLabelSlice::QLabelSlice(QWidget *parent) : QLabel(parent) {
 void QLabelSlice::setImage(const QImage &img, bool invertYAxis) {
   flipYAxis = invertYAxis;
   slicePixels.clear();
+  imgOriginal = img.convertToFormat(QImage::Format_RGB32);
   slicePixels.reserve(static_cast<std::size_t>(imgOriginal.width()) +
                       static_cast<std::size_t>(imgOriginal.height()));
-  imgOriginal = img.convertToFormat(QImage::Format_RGB32);
   if (flipYAxis) {
     imgOriginal = imgOriginal.flipped(Qt::Orientation::Vertical);
   }
@@ -24,6 +24,7 @@ void QLabelSlice::setImage(const QImage &img, bool invertYAxis) {
   if (this->width() < minImageWidth) {
     this->resize(minImageWidth, minImageWidth);
   }
+  resizeImage(this->size());
 }
 
 const QImage &QLabelSlice::getImage() const { return imgSliced; }

--- a/gui/widgets/qplaintextmathedit.cpp
+++ b/gui/widgets/qplaintextmathedit.cpp
@@ -192,7 +192,15 @@ void QPlainTextMathEdit::removeFunction(const std::string &functionId) {
 
 void QPlainTextMathEdit::setConstants(
     const std::vector<sme::model::IdNameValue> &constants) {
+  auto oldConsts = consts;
   consts.clear();
+  for (const auto &c : oldConsts) {
+    if (auto iter = mapVarsToDisplayNames.find(c.first);
+        iter != mapVarsToDisplayNames.end()) {
+      mapDisplayNamesToVars.erase(iter->second);
+      mapVarsToDisplayNames.erase(iter);
+    }
+  }
   consts.reserve(constants.size());
   for (const auto &c : constants) {
     consts.emplace_back(c.id, c.value);
@@ -342,7 +350,7 @@ std::pair<std::string, QString>
 QPlainTextMathEdit::displayNamesToVariables(const std::string &expr) const {
   const auto &varMap = mapDisplayNamesToVars;
   const auto &funcMap = mapDisplayNamesToFuncs;
-  if (varMap.empty()) {
+  if (varMap.empty() && funcMap.empty()) {
     return {expr, ""};
   }
   return substitute(expr, varMap, funcMap);

--- a/gui/widgets/qvoxelrenderer.cpp
+++ b/gui/widgets/qvoxelrenderer.cpp
@@ -129,7 +129,10 @@ void QVoxelRenderer::mousePressEvent(QMouseEvent *ev) {
     return;
   }
   auto *interactor = renderWindow->GetInteractor();
-  auto *picker = interactor->GetPicker();
+  auto *picker = interactor != nullptr ? interactor->GetPicker() : nullptr;
+  if (picker == nullptr) {
+    return;
+  }
   const auto *pos = interactor->GetEventPosition();
   if (picker->Pick(pos[0], pos[1], 0, renderer)) {
     std::array<double, 3> picked{};
@@ -143,7 +146,7 @@ void QVoxelRenderer::mousePressEvent(QMouseEvent *ev) {
         x < dim[0]) {
       static constexpr vtkIdType stride = 4;
       auto idx =
-          stride * static_cast<vtkIdType>(z * dim[1] * dim[0] + y * dim[1] + x);
+          stride * static_cast<vtkIdType>(z * dim[1] * dim[0] + y * dim[0] + x);
       SPDLOG_DEBUG("Index in imageDataArray: {}", idx);
       auto col =
           qRgb(imageDataArray->GetValue(idx), imageDataArray->GetValue(idx + 1),
@@ -186,5 +189,7 @@ void QVoxelRenderer::cmbClippingPlaneNormal_currentTextChanged(
   double dz;
   imageData->GetSpacing(dx, dy, dz);
   maxClippingPlaneOrigin = x * dim[0] * dx + y * dim[1] * dy + z * dim[2] * dz;
-  slideClippingPlaneOrigin_valueChanged(slideClippingPlaneOrigin->value());
+  if (slideClippingPlaneOrigin != nullptr) {
+    slideClippingPlaneOrigin_valueChanged(slideClippingPlaneOrigin->value());
+  }
 }


### PR DESCRIPTION
- Fix voxel pick indexing and add null guards for picker/slider
- Refresh QLabelSlice image sizing and pixmap on setImage
- Keep function substitution when no variables are defined
- Cleanly update constant mappings in math editor
- Guard plot xValue when no graphs exist
- Sync mask flip and add empty-state guard for relative position
