### PR TITLE
Add option to import gmsh meshed geometry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+## Project overview
+
+Spatial Model Editor is a GUI editor to create, edit and simulate spatial SBML models of bio-chemical reactions. Simulation uses the dune-copasi FEM solver on a triangular mesh, or a voxel-based finite difference solver. Written in C++20, cross-platform (Linux, Windows, Mac). Also has Python and CLI interfaces.
+
+## Repo structure
+
+Key folders:
+- `core/` — main library code (mesh, model, simulate)
+- `gui/` — GUI code (widgets, dialogs, tabs)
+- `sme/` — Python bindings
+- `app/` — GUI app binary
+- `cli/` — command-line interface
+- `test/` — test binaries
+- `docs/` — documentation
+- `ext/` — external library submodules (ignore this folder)
+
+Implementation, test, and benchmark code for a component are co-located: `X.hpp`, `X.cpp`, `X_t.cpp`, and optionally `X_bench.cpp`.
+
+## Building and testing
+
+All commands run from `build-sme-release/`:
+
+```bash
+ninja                                           # build
+ninja test                                      # run all non-gui tests in parallel
+./test/tests "[tagname]"                        # run a subset of catch2 tests
+xvfb-run -a bash -c 'jwm & sleep 1 && ./test/tests "[gui]"'   # run GUI tests headlessly on Linux
+xvfb-run -a bash -c 'jwm & sleep 1 && ./test/tests "TestName"' # run a specific GUI test
+```
+
+Python tests from `build-sme-release/sme`:
+```bash
+python -m pytest ../../sme/test
+```
+
+For segfault debugging, use `build-sme-asan/`:
+```bash
+ASAN_OPTIONS="halt_on_error=0" ninja            # build with ASAN
+./test/tests "[tagname]"                        # re-run to see ASAN output
+```
+
+## Code style and conventions
+
+- C++20
+- Formatting: run `prek run -a` (install with `pip install prek` if needed)
+- Tests use Catch2
+- Every PR should include meaningful tests
+- Update `CHANGELOG.md` and user docs for user-visible changes

--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -291,6 +291,21 @@ struct free_deleter {
 };
 template <typename T> using unique_C_ptr = std::unique_ptr<T, free_deleter>;
 
+/**
+ * @brief Temporarily set the global locale to C and restore it on scope exit
+ */
+class ScopedCLocale {
+public:
+  ScopedCLocale()
+      : previousLocale(std::locale::global(std::locale::classic())) {}
+  ~ScopedCLocale() { std::locale::global(previousLocale); }
+  ScopedCLocale(const ScopedCLocale &) = delete;
+  ScopedCLocale &operator=(const ScopedCLocale &) = delete;
+
+private:
+  std::locale previousLocale;
+};
+
 // C-locale versions of isalpha, isdigit, etc.
 inline bool isalpha(char c) { return std::isalpha(c, std::locale::classic()); }
 

--- a/core/common/src/serialization.cpp
+++ b/core/common/src/serialization.cpp
@@ -3,6 +3,7 @@
 #include "sme/model_settings.hpp"
 #include "sme/simulate_data.hpp"
 #include "sme/simulate_options.hpp"
+#include "sme/utils.hpp"
 #include "sme/xml_annotation.hpp"
 #include <cereal/archives/binary.hpp>
 #include <cereal/archives/xml.hpp>
@@ -111,7 +112,7 @@ bool exportSmeFile(const std::string &filename,
 
 std::string toXml(const model::Settings &sbmlAnnotation) {
   std::string s;
-  std::locale userLocale = std::locale::global(std::locale::classic());
+  ScopedCLocale scopedCLocale;
   std::stringstream ss;
   try {
     cereal::XMLOutputArchive ar(ss);
@@ -129,7 +130,6 @@ std::string toXml(const model::Settings &sbmlAnnotation) {
   for (std::size_t i = 2; i + 2 < lines.size(); ++i) {
     s.append(lines[i]).append("\n");
   }
-  std::locale::global(userLocale);
   return s;
 }
 
@@ -138,7 +138,7 @@ model::Settings fromXml(const std::string &xml) {
   // hack until
   // https://github.com/spatial-model-editor/spatial-model-editor/issues/535 is
   // resolved: (cereal relies on strtod to read doubles and assumes C locale)
-  std::locale userLocale = std::locale::global(std::locale::classic());
+  ScopedCLocale scopedCLocale;
   // re-insert header & footer
   // todo: do this in a less fragile way
   std::string fullXml{R"(<?xml version="1.0" encoding="utf-8"?><cereal>)"};
@@ -153,7 +153,6 @@ model::Settings fromXml(const std::string &xml) {
                 e.what());
     return {};
   }
-  std::locale::global(userLocale);
   return sbmlAnnotation;
 }
 

--- a/core/mesh/include/sme/gmsh.hpp
+++ b/core/mesh/include/sme/gmsh.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "sme/image_stack.hpp"
+#include <QString>
+#include <array>
+#include <optional>
+#include <vector>
+
+namespace sme::mesh {
+
+struct GMSHTetrahedron {
+  std::array<std::size_t, 4> vertexIndices{};
+  int physicalTag{1};
+};
+
+struct GMSHMesh {
+  std::vector<common::VoxelF> vertices{};
+  std::vector<GMSHTetrahedron> tetrahedra{};
+};
+
+/**
+ * @brief Read a Gmsh v2 mesh into a reusable in-memory mesh object
+ *
+ * @param[in] filename path to a gmsh v2 ascii ``.msh`` file
+ * @returns parsed mesh, or empty optional on failure
+ */
+[[nodiscard]] std::optional<GMSHMesh> readGMSHMesh(const QString &filename);
+
+/**
+ * @brief Voxelize an in-memory GMSHMesh into an ImageStack
+ *
+ * Tetrahedra are grouped by physical tag and each compartment is assigned a
+ * default color from common::indexedColors() in ascending physical-tag order.
+ *
+ * @param[in] mesh mesh object from readGMSHMesh
+ * @param[in] maxVoxelsPerDimension max voxels for the largest image dimension
+ * @param[in] includeBackground if false, unassigned voxels are filled using
+ * nearest assigned compartment voxels
+ * @returns an RGB32 ImageStack, or an empty ImageStack on failure
+ */
+[[nodiscard]] common::ImageStack
+voxelizeGMSHMesh(const GMSHMesh &mesh, int maxVoxelsPerDimension = 50,
+                 bool includeBackground = true);
+
+} // namespace sme::mesh

--- a/core/mesh/src/CMakeLists.txt
+++ b/core/mesh/src/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   PRIVATE boundaries.cpp
           boundary.cpp
           contour_map.cpp
+          gmsh.cpp
           interior_point.cpp
           line_simplifier.cpp
           mesh2d.cpp
@@ -18,6 +19,7 @@ if(BUILD_TESTING)
     PUBLIC boundaries_t.cpp
            boundary_t.cpp
            contour_map_t.cpp
+           gmsh_t.cpp
            interior_point_t.cpp
            line_simplifier_t.cpp
            mesh2d_t.cpp

--- a/core/mesh/src/gmsh.cpp
+++ b/core/mesh/src/gmsh.cpp
@@ -1,0 +1,412 @@
+#include "sme/gmsh.hpp"
+#include "sme/logger.hpp"
+#include "sme/utils.hpp"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <dune/common/exceptions.hh>
+#include <dune/grid/common/mcmgmapper.hh>
+#include <dune/grid/common/rangegenerators.hh>
+#include <dune/grid/io/file/gmshreader.hh>
+#include <dune/grid/uggrid.hh>
+#include <limits>
+#include <map>
+#include <optional>
+#include <vector>
+
+namespace sme::mesh {
+
+namespace {
+
+struct Point3d {
+  double x{};
+  double y{};
+  double z{};
+};
+
+[[nodiscard]] Point3d toPoint3d(const common::VoxelF &v) {
+  return {v.p.x(), v.p.y(), v.z};
+}
+
+[[nodiscard]] std::optional<std::array<double, 9>>
+inverse3x3(const std::array<double, 9> &m) {
+  const double det = m[0] * (m[4] * m[8] - m[5] * m[7]) -
+                     m[1] * (m[3] * m[8] - m[5] * m[6]) +
+                     m[2] * (m[3] * m[7] - m[4] * m[6]);
+  constexpr double minAbsDet{1e-18};
+  if (std::abs(det) < minAbsDet) {
+    return std::nullopt;
+  }
+  const double invDet = 1.0 / det;
+  std::array<double, 9> inv{};
+  inv[0] = invDet * (m[4] * m[8] - m[5] * m[7]);
+  inv[1] = invDet * (m[2] * m[7] - m[1] * m[8]);
+  inv[2] = invDet * (m[1] * m[5] - m[2] * m[4]);
+  inv[3] = invDet * (m[5] * m[6] - m[3] * m[8]);
+  inv[4] = invDet * (m[0] * m[8] - m[2] * m[6]);
+  inv[5] = invDet * (m[2] * m[3] - m[0] * m[5]);
+  inv[6] = invDet * (m[3] * m[7] - m[4] * m[6]);
+  inv[7] = invDet * (m[1] * m[6] - m[0] * m[7]);
+  inv[8] = invDet * (m[0] * m[4] - m[1] * m[3]);
+  return inv;
+}
+
+[[nodiscard]] bool pointInsideTetrahedron(const Point3d &p,
+                                          const std::array<Point3d, 4> &v,
+                                          const std::array<double, 9> &invM) {
+  const Point3d r{p.x - v[0].x, p.y - v[0].y, p.z - v[0].z};
+  const double l1 = invM[0] * r.x + invM[1] * r.y + invM[2] * r.z;
+  const double l2 = invM[3] * r.x + invM[4] * r.y + invM[5] * r.z;
+  const double l3 = invM[6] * r.x + invM[7] * r.y + invM[8] * r.z;
+  const double l0 = 1.0 - l1 - l2 - l3;
+  constexpr double tol = 1e-10;
+  return l0 >= -tol && l1 >= -tol && l2 >= -tol && l3 >= -tol &&
+         l0 <= 1.0 + tol && l1 <= 1.0 + tol && l2 <= 1.0 + tol &&
+         l3 <= 1.0 + tol;
+}
+
+[[nodiscard]] int getImageDimension(double extent, double maxExtent,
+                                    int maxVoxelsPerDimension) {
+  if (maxVoxelsPerDimension <= 1 || maxExtent <= 0.0) {
+    return 1;
+  }
+  return std::clamp(
+      static_cast<int>(maxVoxelsPerDimension * extent / maxExtent), 1,
+      maxVoxelsPerDimension);
+}
+
+[[nodiscard]] std::pair<int, int> voxelIndexRange(double minCoord,
+                                                  double maxCoord,
+                                                  double lowerBound,
+                                                  double extent, int nVoxels) {
+  if (nVoxels <= 1 || extent <= 0.0) {
+    return {0, 0};
+  }
+  const double scale = static_cast<double>(nVoxels) / extent;
+  const double lower = scale * (minCoord - lowerBound) - 0.5;
+  const double upper = scale * (maxCoord - lowerBound) - 0.5;
+  const int iMin =
+      std::clamp(static_cast<int>(std::ceil(lower)), 0, nVoxels - 1);
+  const int iMax =
+      std::clamp(static_cast<int>(std::floor(upper)), 0, nVoxels - 1);
+  return {iMin, iMax};
+}
+
+[[nodiscard]] double voxelCenterCoordinate(int index, double lowerBound,
+                                           double extent, int nVoxels) {
+  if (nVoxels <= 1 || extent <= 0.0) {
+    return lowerBound;
+  }
+  return lowerBound + extent * (0.5 + static_cast<double>(index)) /
+                          static_cast<double>(nVoxels);
+}
+
+[[nodiscard]] double voxelSize(double extent, int nVoxels) {
+  if (extent <= 0.0 || nVoxels <= 0) {
+    return 1.0;
+  }
+  return extent / static_cast<double>(nVoxels);
+}
+
+[[nodiscard]] std::size_t flatIndex(int x, int y, int z, int nx, int ny) {
+  return static_cast<std::size_t>(x + nx * (y + ny * z));
+}
+
+void fillNullVoxelsWithNearestColor(common::ImageStack &images,
+                                    QRgb nullColor) {
+  const auto vol = images.volume();
+  const int nx = vol.width();
+  const int ny = vol.height();
+  const int nz = static_cast<int>(vol.depth());
+  if (nx <= 0 || ny <= 0 || nz <= 0) {
+    return;
+  }
+
+  struct VoxelIndex {
+    int x{};
+    int y{};
+    int z{};
+  };
+
+  std::deque<VoxelIndex> queue;
+  std::vector<uint8_t> visited(vol.nVoxels(), 0);
+  std::vector<QRgb> nearestColor(vol.nVoxels(), nullColor);
+
+  for (int z = 0; z < nz; ++z) {
+    for (int y = 0; y < ny; ++y) {
+      for (int x = 0; x < nx; ++x) {
+        const auto color = images[static_cast<std::size_t>(z)].pixel(x, y);
+        if (color == nullColor) {
+          continue;
+        }
+        const auto i = flatIndex(x, y, z, nx, ny);
+        visited[i] = 1;
+        nearestColor[i] = color;
+        queue.push_back({x, y, z});
+      }
+    }
+  }
+  if (queue.empty()) {
+    return;
+  }
+
+  constexpr std::array<VoxelIndex, 6> offsets{
+      VoxelIndex{-1, 0, 0}, VoxelIndex{1, 0, 0},  VoxelIndex{0, -1, 0},
+      VoxelIndex{0, 1, 0},  VoxelIndex{0, 0, -1}, VoxelIndex{0, 0, 1}};
+
+  while (!queue.empty()) {
+    const auto voxel = queue.front();
+    queue.pop_front();
+    const auto i = flatIndex(voxel.x, voxel.y, voxel.z, nx, ny);
+    const auto color = nearestColor[i];
+    for (const auto &offset : offsets) {
+      const int x = voxel.x + offset.x;
+      const int y = voxel.y + offset.y;
+      const int z = voxel.z + offset.z;
+      if (x < 0 || x >= nx || y < 0 || y >= ny || z < 0 || z >= nz) {
+        continue;
+      }
+      const auto j = flatIndex(x, y, z, nx, ny);
+      if (visited[j] != 0) {
+        continue;
+      }
+      visited[j] = 1;
+      nearestColor[j] = color;
+      queue.push_back({x, y, z});
+    }
+  }
+
+  for (int z = 0; z < nz; ++z) {
+    for (int y = 0; y < ny; ++y) {
+      for (int x = 0; x < nx; ++x) {
+        auto &img = images[static_cast<std::size_t>(z)];
+        if (img.pixel(x, y) != nullColor) {
+          continue;
+        }
+        const auto i = flatIndex(x, y, z, nx, ny);
+        img.setPixel(x, y, nearestColor[i]);
+      }
+    }
+  }
+}
+
+void fillRemainingNullVoxels(common::ImageStack &images, QRgb nullColor,
+                             QRgb fallbackColor) {
+  const auto vol = images.volume();
+  for (std::size_t z = 0; z < vol.depth(); ++z) {
+    for (int y = 0; y < vol.height(); ++y) {
+      for (int x = 0; x < vol.width(); ++x) {
+        auto &img = images[z];
+        if (img.pixel(x, y) == nullColor) {
+          img.setPixel(x, y, fallbackColor);
+        }
+      }
+    }
+  }
+}
+
+} // namespace
+
+std::optional<GMSHMesh> readGMSHMesh(const QString &filename) {
+  using Grid = Dune::UGGrid<3>;
+  common::ScopedCLocale scopedCLocale;
+  std::vector<int> boundaryToPhysicalEntity;
+  std::vector<int> elementToPhysicalEntity;
+  std::unique_ptr<Grid> grid;
+  try {
+    grid = Dune::GmshReader<Grid>::read(filename.toStdString(),
+                                        boundaryToPhysicalEntity,
+                                        elementToPhysicalEntity,
+                                        false, // verbose
+                                        false  // insertBoundarySegments
+    );
+  } catch (const Dune::Exception &e) {
+    SPDLOG_ERROR("Failed to parse gmsh file '{}': {}", filename.toStdString(),
+                 e.what());
+    return std::nullopt;
+  }
+  if (grid == nullptr || elementToPhysicalEntity.empty()) {
+    SPDLOG_ERROR("No 3d elements found in gmsh file '{}'",
+                 filename.toStdString());
+    return std::nullopt;
+  }
+
+  auto gridView = grid->leafGridView();
+  if (gridView.size(0) == 0) {
+    SPDLOG_ERROR("Empty grid in gmsh file '{}'", filename.toStdString());
+    return std::nullopt;
+  }
+
+  using GridView = decltype(gridView);
+  Dune::MultipleCodimMultipleGeomTypeMapper<GridView> vertexMapper(
+      gridView, Dune::mcmgVertexLayout());
+  Dune::MultipleCodimMultipleGeomTypeMapper<GridView> elementMapper(
+      gridView, Dune::mcmgElementLayout());
+
+  GMSHMesh mesh;
+  mesh.vertices.resize(vertexMapper.size());
+  for (const auto &vertex : vertices(gridView)) {
+    auto i = vertexMapper.index(vertex);
+    auto p = vertex.geometry().corner(0);
+    mesh.vertices[i] = {p[0], p[1], p[2]};
+  }
+
+  mesh.tetrahedra.reserve(gridView.size(0));
+  for (const auto &element : elements(gridView)) {
+    const auto iElement =
+        static_cast<std::size_t>(elementMapper.index(element));
+    if (iElement >= elementToPhysicalEntity.size()) {
+      SPDLOG_ERROR("Element index mismatch while reading '{}'",
+                   filename.toStdString());
+      return std::nullopt;
+    }
+    const auto &geo = element.geometry();
+    if (geo.type().isSimplex() && geo.corners() == 4) {
+      GMSHTetrahedron tet;
+      tet.physicalTag = elementToPhysicalEntity[iElement];
+      for (int i = 0; i < 4; ++i) {
+        tet.vertexIndices[static_cast<std::size_t>(i)] =
+            vertexMapper.subIndex(element, i, 3);
+      }
+      mesh.tetrahedra.push_back(tet);
+    }
+  }
+
+  if (mesh.vertices.empty() || mesh.tetrahedra.empty()) {
+    SPDLOG_ERROR("No tetrahedra found in gmsh file '{}'",
+                 filename.toStdString());
+    return std::nullopt;
+  }
+  return mesh;
+}
+
+common::ImageStack voxelizeGMSHMesh(const GMSHMesh &mesh,
+                                    int maxVoxelsPerDimension,
+                                    bool includeBackground) {
+  if (mesh.vertices.empty() || mesh.tetrahedra.empty()) {
+    return {};
+  }
+
+  std::vector<int> compartmentTags;
+  compartmentTags.reserve(mesh.tetrahedra.size());
+  for (const auto &tet : mesh.tetrahedra) {
+    if (std::ranges::find(compartmentTags, tet.physicalTag) ==
+        std::end(compartmentTags)) {
+      compartmentTags.push_back(tet.physicalTag);
+    }
+  }
+  std::ranges::sort(compartmentTags);
+  if (compartmentTags.empty()) {
+    return {};
+  }
+
+  std::map<int, QRgb> tagToColor;
+  for (std::size_t i = 0; i < compartmentTags.size(); ++i) {
+    tagToColor[compartmentTags[i]] = common::indexedColors()[i].rgb();
+  }
+
+  Point3d meshMin{std::numeric_limits<double>::max(),
+                  std::numeric_limits<double>::max(),
+                  std::numeric_limits<double>::max()};
+  Point3d meshMax{std::numeric_limits<double>::lowest(),
+                  std::numeric_limits<double>::lowest(),
+                  std::numeric_limits<double>::lowest()};
+  for (const auto &v : mesh.vertices) {
+    auto p = toPoint3d(v);
+    meshMin.x = std::min(meshMin.x, p.x);
+    meshMin.y = std::min(meshMin.y, p.y);
+    meshMin.z = std::min(meshMin.z, p.z);
+    meshMax.x = std::max(meshMax.x, p.x);
+    meshMax.y = std::max(meshMax.y, p.y);
+    meshMax.z = std::max(meshMax.z, p.z);
+  }
+
+  const double width = std::max(0.0, meshMax.x - meshMin.x);
+  const double height = std::max(0.0, meshMax.y - meshMin.y);
+  const double depth = std::max(0.0, meshMax.z - meshMin.z);
+  const double maxExtent = std::max({width, height, depth});
+  const int nMax = std::max(maxVoxelsPerDimension, 1);
+  const int nx = getImageDimension(width, maxExtent, nMax);
+  const int ny = getImageDimension(height, maxExtent, nMax);
+  const int nz = getImageDimension(depth, maxExtent, nMax);
+
+  common::ImageStack images({nx, ny, static_cast<std::size_t>(nz)},
+                            QImage::Format_RGB32);
+  const QRgb nullColor{qRgb(0, 0, 0)};
+  images.fill(nullColor);
+  images.setVoxelSize(
+      {voxelSize(width, nx), voxelSize(height, ny), voxelSize(depth, nz)});
+
+  for (const auto &tet : mesh.tetrahedra) {
+    std::array<Point3d, 4> vertices;
+    for (std::size_t i = 0; i < vertices.size(); ++i) {
+      if (tet.vertexIndices[i] >= mesh.vertices.size()) {
+        SPDLOG_ERROR("Invalid tetrahedron vertex index {}",
+                     tet.vertexIndices[i]);
+        return {};
+      }
+      vertices[i] = toPoint3d(mesh.vertices[tet.vertexIndices[i]]);
+    }
+    Point3d bboxMin = vertices[0];
+    Point3d bboxMax = vertices[0];
+    for (std::size_t i = 1; i < vertices.size(); ++i) {
+      bboxMin.x = std::min(bboxMin.x, vertices[i].x);
+      bboxMin.y = std::min(bboxMin.y, vertices[i].y);
+      bboxMin.z = std::min(bboxMin.z, vertices[i].z);
+      bboxMax.x = std::max(bboxMax.x, vertices[i].x);
+      bboxMax.y = std::max(bboxMax.y, vertices[i].y);
+      bboxMax.z = std::max(bboxMax.z, vertices[i].z);
+    }
+    const std::array<double, 9> m{
+        vertices[1].x - vertices[0].x, vertices[2].x - vertices[0].x,
+        vertices[3].x - vertices[0].x, vertices[1].y - vertices[0].y,
+        vertices[2].y - vertices[0].y, vertices[3].y - vertices[0].y,
+        vertices[1].z - vertices[0].z, vertices[2].z - vertices[0].z,
+        vertices[3].z - vertices[0].z};
+    const auto invM = inverse3x3(m);
+    if (!invM.has_value()) {
+      continue;
+    }
+    auto [xMin, xMax] =
+        voxelIndexRange(bboxMin.x, bboxMax.x, meshMin.x, width, nx);
+    auto [yMin, yMax] =
+        voxelIndexRange(bboxMin.y, bboxMax.y, meshMin.y, height, ny);
+    auto [zMin, zMax] =
+        voxelIndexRange(bboxMin.z, bboxMax.z, meshMin.z, depth, nz);
+    auto colorIter = tagToColor.find(tet.physicalTag);
+    if (colorIter == tagToColor.cend()) {
+      return {};
+    }
+    if (xMin > xMax || yMin > yMax || zMin > zMax) {
+      continue;
+    }
+    for (int iz = zMin; iz <= zMax; ++iz) {
+      auto &img = images[static_cast<std::size_t>(iz)];
+      const double z = voxelCenterCoordinate(iz, meshMin.z, depth, nz);
+      for (int iy = yMin; iy <= yMax; ++iy) {
+        const double y = voxelCenterCoordinate(iy, meshMin.y, height, ny);
+        const int py = ny - 1 - iy;
+        for (int ix = xMin; ix <= xMax; ++ix) {
+          const double x = voxelCenterCoordinate(ix, meshMin.x, width, nx);
+          if (pointInsideTetrahedron({x, y, z}, vertices, *invM)) {
+            img.setPixel(ix, py, colorIter->second);
+          }
+        }
+      }
+    }
+  }
+
+  if (!includeBackground) {
+    fillNullVoxelsWithNearestColor(images, nullColor);
+    // Fallback for extreme undersampling where no voxel center lands in a tet.
+    fillRemainingNullVoxels(images, nullColor, tagToColor.begin()->second);
+  }
+
+  images.convertToIndexed();
+  return images;
+}
+
+} // namespace sme::mesh

--- a/core/mesh/src/gmsh_t.cpp
+++ b/core/mesh/src/gmsh_t.cpp
@@ -1,0 +1,320 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "sme/duneconverter.hpp"
+#include "sme/gmsh.hpp"
+#include "sme/utils.hpp"
+#include <QDir>
+#include <QFile>
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <locale>
+#include <map>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+
+using namespace sme;
+
+namespace {
+
+[[nodiscard]] QString writeTmpFile(const QString &filename,
+                                   const QString &contents) {
+  const auto path = QDir::current().filePath(filename);
+  QFile::remove(path);
+  QFile f(path);
+  if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    return {};
+  }
+  const auto bytes = contents.toUtf8();
+  if (f.write(bytes) != bytes.size()) {
+    return {};
+  }
+  return path;
+}
+
+class ScopedTestLocale {
+public:
+  explicit ScopedTestLocale(std::locale newLocale)
+      : previousLocale(std::locale::global(std::move(newLocale))) {}
+  ~ScopedTestLocale() { std::locale::global(previousLocale); }
+
+private:
+  std::locale previousLocale;
+};
+
+} // namespace
+
+TEST_CASE("Gmsh voxel import",
+          "[core/mesh/gmsh][core/mesh][core][mesh][gmsh]") {
+  SECTION("invalid file") {
+    auto filename = writeTmpFile("tmp_invalid.msh", "not a gmsh mesh");
+    REQUIRE(QFile::exists(filename));
+    auto gmshMesh = mesh::readGMSHMesh(filename);
+    REQUIRE(!gmshMesh.has_value());
+    common::ImageStack img;
+    if (gmshMesh.has_value()) {
+      img = mesh::voxelizeGMSHMesh(*gmshMesh, 20);
+    }
+    REQUIRE(img.empty());
+  }
+
+  SECTION("single tetrahedron uses first indexed color") {
+    const QString gmsh = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0 0 0
+2 1 0 0
+3 0 1 0
+4 0 0 1
+$EndNodes
+$Elements
+1
+1 4 2 7 7 1 2 3 4
+$EndElements
+)";
+    auto filename = writeTmpFile("tmp_single_tetra.msh", gmsh);
+    REQUIRE(QFile::exists(filename));
+    auto gmshMesh = mesh::readGMSHMesh(filename);
+    REQUIRE(gmshMesh.has_value());
+    REQUIRE(gmshMesh->vertices.size() == 4);
+    REQUIRE(gmshMesh->tetrahedra.size() == 1);
+
+    auto img = mesh::voxelizeGMSHMesh(*gmshMesh, 20);
+    REQUIRE(!img.empty());
+    REQUIRE(img.volume().width() == 20);
+    REQUIRE(img.volume().height() == 20);
+    REQUIRE(img.volume().depth() == 20);
+
+    const QRgb nullColor = qRgb(0, 0, 0);
+    const QRgb expectedColor = common::indexedColors()[0].rgb();
+    std::size_t nExpectedColorVoxels{0};
+    for (std::size_t z = 0; z < img.volume().depth(); ++z) {
+      for (int y = 0; y < img.volume().height(); ++y) {
+        for (int x = 0; x < img.volume().width(); ++x) {
+          const auto px = img[z].pixel(x, y);
+          if (px == nullColor) {
+            continue;
+          }
+          REQUIRE(px == expectedColor);
+          ++nExpectedColorVoxels;
+        }
+      }
+    }
+    REQUIRE(nExpectedColorVoxels > 0);
+
+    auto img2 = mesh::voxelizeGMSHMesh(*gmshMesh, 10);
+    REQUIRE(!img2.empty());
+    REQUIRE(img2.volume().width() == 10);
+    REQUIRE(img2.volume().height() == 10);
+    REQUIRE(img2.volume().depth() == 10);
+  }
+
+  SECTION("single tetrahedron parses under DE locale") {
+    std::optional<std::locale> deLocale;
+    for (const char *localeName : {"de_DE.UTF-8", "de_DE.utf8", "de_DE"}) {
+      try {
+        deLocale.emplace(localeName);
+        break;
+      } catch (const std::runtime_error &) {
+      }
+    }
+    if (!deLocale.has_value()) {
+      WARN("Skipping locale test, no DE locale available");
+      return;
+    }
+    ScopedTestLocale localeGuard(*deLocale);
+
+    const QString gmsh = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0 0 0
+2 1 0 0
+3 0 1 0
+4 0 0 1
+$EndNodes
+$Elements
+1
+1 4 2 7 7 1 2 3 4
+$EndElements
+)";
+    auto filename = writeTmpFile("tmp_single_tetra.msh", gmsh);
+    REQUIRE(QFile::exists(filename));
+    auto gmshMesh = mesh::readGMSHMesh(filename);
+    REQUIRE(gmshMesh.has_value());
+  }
+
+  SECTION("multiple compartments use indexed colors in ascending tag order") {
+    const QString gmsh = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+8
+1 0 0 0
+2 1 0 0
+3 0 1 0
+4 0 0 1
+5 3 0 0
+6 4 0 0
+7 3 1 0
+8 3 0 1
+$EndNodes
+$Elements
+2
+1 4 2 5 5 5 6 7 8
+2 4 2 2 2 1 2 3 4
+$EndElements
+)";
+    auto filename = writeTmpFile("tmp_two_tetra_compartments.msh", gmsh);
+    REQUIRE(QFile::exists(filename));
+    auto gmshMesh = mesh::readGMSHMesh(filename);
+    REQUIRE(gmshMesh.has_value());
+    REQUIRE(gmshMesh->vertices.size() == 8);
+    REQUIRE(gmshMesh->tetrahedra.size() == 2);
+    auto imgWithBackground = mesh::voxelizeGMSHMesh(*gmshMesh, 20, true);
+    REQUIRE(!imgWithBackground.empty());
+    REQUIRE(imgWithBackground.volume().width() == 20);
+    REQUIRE(imgWithBackground.volume().height() == 5);
+    REQUIRE(imgWithBackground.volume().depth() == 5);
+    auto imgWithoutBackground = mesh::voxelizeGMSHMesh(*gmshMesh, 20, false);
+    REQUIRE(!imgWithoutBackground.empty());
+
+    // a voxel inside the first compartment has the first indexed color
+    REQUIRE(imgWithBackground[1].pixel(1, 4) ==
+            common::indexedColors()[0].rgb());
+    REQUIRE(imgWithoutBackground[1].pixel(1, 4) ==
+            common::indexedColors()[0].rgb());
+    // voxel inside second compartment
+    REQUIRE(imgWithBackground[1].pixel(16, 4) ==
+            common::indexedColors()[1].rgb());
+    REQUIRE(imgWithoutBackground[1].pixel(16, 4) ==
+            common::indexedColors()[1].rgb());
+    // a voxel outside of the two compartments but closer to the first
+    // compartment
+    REQUIRE(imgWithBackground[4].pixel(1, 4) ==
+            qRgb(0, 0, 0)); // black if background is allowed
+    REQUIRE(imgWithoutBackground[4].pixel(1, 4) ==
+            common::indexedColors()[0].rgb()); // nearest compartment otherwise
+    // a voxel outside of the two compartments but closer to the second
+    // compartment
+    REQUIRE(imgWithBackground[4].pixel(16, 4) ==
+            qRgb(0, 0, 0)); // black if background is allowed
+    REQUIRE(imgWithoutBackground[4].pixel(16, 4) ==
+            common::indexedColors()[1].rgb()); // nearest compartment otherwise
+
+    REQUIRE(imgWithoutBackground.colorTable().size() == 2);
+    REQUIRE(imgWithBackground.colorTable().size() == 3);
+    REQUIRE(!imgWithoutBackground.colorTable().contains(qRgb(0, 0, 0)));
+    REQUIRE(imgWithBackground.colorTable().contains(qRgb(0, 0, 0)));
+  }
+
+  SECTION("round-trip via duneconverter gmsh export") {
+    constexpr double minMatchingFraction{0.80};
+    for (const auto &modelId :
+         {test::Mod::VerySimpleModel3D, test::Mod::SelKov3D,
+          test::Mod::FitzhughNagumo3D}) {
+      for (const bool includeBackground : {true, false}) {
+        CAPTURE(modelId);
+        CAPTURE(includeBackground);
+        auto model = test::getExampleModel(modelId);
+        const auto &original = model.getGeometry().getImages();
+        REQUIRE(!original.empty());
+        const auto originalVolume = original.volume();
+        const int nMax =
+            std::max({originalVolume.width(), originalVolume.height(),
+                      static_cast<int>(originalVolume.depth())});
+        std::map<QRgb, QRgb> originalToRoundTripColor;
+        const auto &compartmentColors = model.getCompartments().getColors();
+        const common::indexedColors indexedColors;
+        for (int i = 0; i < compartmentColors.size(); ++i) {
+          originalToRoundTripColor[compartmentColors[i]] =
+              indexedColors[static_cast<std::size_t>(i)].rgb();
+        }
+
+        const QString iniFilename = QDir::current().filePath("tmp_gmsh_rt.ini");
+        const QString gmshFilename =
+            QDir::current().filePath("tmp_gmsh_rt.msh");
+        QFile::remove(iniFilename);
+        QFile::remove(gmshFilename);
+        simulate::DuneConverter dc(model, {}, true, iniFilename);
+        (void)dc;
+        REQUIRE(QFile::exists(gmshFilename));
+
+        auto gmshMesh = mesh::readGMSHMesh(gmshFilename);
+        REQUIRE(gmshMesh.has_value());
+        auto roundTrip =
+            mesh::voxelizeGMSHMesh(*gmshMesh, nMax, includeBackground);
+        REQUIRE(!roundTrip.empty());
+
+        common::VoxelF meshMin{std::numeric_limits<double>::max(),
+                               std::numeric_limits<double>::max(),
+                               std::numeric_limits<double>::max()};
+        common::VoxelF meshMax{std::numeric_limits<double>::lowest(),
+                               std::numeric_limits<double>::lowest(),
+                               std::numeric_limits<double>::lowest()};
+        for (const auto &v : gmshMesh->vertices) {
+          meshMin.p.rx() = std::min(meshMin.p.x(), v.p.x());
+          meshMin.p.ry() = std::min(meshMin.p.y(), v.p.y());
+          meshMin.z = std::min(meshMin.z, v.z);
+          meshMax.p.rx() = std::max(meshMax.p.x(), v.p.x());
+          meshMax.p.ry() = std::max(meshMax.p.y(), v.p.y());
+          meshMax.z = std::max(meshMax.z, v.z);
+        }
+        const double w = meshMax.p.x() - meshMin.p.x();
+        const double h = meshMax.p.y() - meshMin.p.y();
+        const double d = meshMax.z - meshMin.z;
+        const auto roundVol = roundTrip.volume();
+        const auto origin = model.getGeometry().getPhysicalOrigin();
+        const auto voxelSize = model.getGeometry().getVoxelSize();
+
+        std::size_t nSame = 0;
+        std::size_t nTotal = roundVol.nVoxels();
+        for (std::size_t z = 0; z < roundVol.depth(); ++z) {
+          double pz = meshMin.z + d * (0.5 + static_cast<double>(z)) /
+                                      static_cast<double>(roundVol.depth());
+          auto oz = static_cast<std::size_t>(
+              common::toVoxelIndex(pz, origin.z, voxelSize.depth(),
+                                   static_cast<int>(originalVolume.depth())));
+          for (int y = 0; y < roundVol.height(); ++y) {
+            double pyBottom = static_cast<double>(roundVol.height() - 1 - y);
+            double py =
+                meshMin.p.y() +
+                h * (0.5 + pyBottom) / static_cast<double>(roundVol.height());
+            int oyBottom = common::toVoxelIndex(
+                py, origin.p.y(), voxelSize.height(), originalVolume.height());
+            int oy = originalVolume.height() - 1 - oyBottom;
+            for (int x = 0; x < roundVol.width(); ++x) {
+              double px =
+                  meshMin.p.x() + w * (0.5 + static_cast<double>(x)) /
+                                      static_cast<double>(roundVol.width());
+              int ox = common::toVoxelIndex(px, origin.p.x(), voxelSize.width(),
+                                            originalVolume.width());
+              auto originalColor = original[oz].pixel(ox, oy);
+              auto mappedColorIter =
+                  originalToRoundTripColor.find(originalColor);
+              auto expectedRoundColor = originalColor;
+              if (mappedColorIter != originalToRoundTripColor.end()) {
+                expectedRoundColor = mappedColorIter->second;
+              }
+              if (roundTrip[z].pixel(x, y) == expectedRoundColor) {
+                ++nSame;
+              }
+            }
+          }
+        }
+        CAPTURE(nSame);
+        CAPTURE(nTotal);
+        const double matchingFraction =
+            static_cast<double>(nSame) / static_cast<double>(nTotal);
+        CAPTURE(matchingFraction);
+        CAPTURE(minMatchingFraction);
+        REQUIRE(matchingFraction >= minMatchingFraction);
+      }
+    }
+  }
+}

--- a/core/simulate/src/dunegrid_t.cpp
+++ b/core/simulate/src/dunegrid_t.cpp
@@ -69,9 +69,8 @@ TEST_CASE("DUNE grid",
 
       // generate dune grid with Dune::Copasi::make_multi_domain_grid
       // note: requires C locale
-      std::locale userLocale = std::locale::global(std::locale::classic());
+      common::ScopedCLocale scopedCLocale;
       auto gmshGrid{Dune::Copasi::make_multi_domain_grid<Grid2d>(config)};
-      std::locale::global(userLocale);
 
       // compare grids
       auto nCompartments = grid->maxSubDomainIndex();
@@ -191,9 +190,8 @@ TEST_CASE("DUNE grid",
 
       // generate dune grid with Dune::Copasi::make_multi_domain_grid
       // note: requires C locale
-      std::locale userLocale = std::locale::global(std::locale::classic());
+      common::ScopedCLocale scopedCLocale;
       auto gmshGrid{Dune::Copasi::make_multi_domain_grid<Grid3d>(config)};
-      std::locale::global(userLocale);
 
       // compare grids
       auto nCompartments{grid->maxSubDomainIndex()};

--- a/gui/dialogs/CMakeLists.txt
+++ b/gui/dialogs/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(
           dialoggeometryimage.ui
           dialogimportanalyticgeometry.cpp
           dialogimportanalyticgeometry.ui
+          dialogimportgeometrygmsh.cpp
+          dialogimportgeometrygmsh.ui
           dialogimage.cpp
           dialogimage.ui
           dialogimageslice.cpp
@@ -52,6 +54,7 @@ if(BUILD_TESTING)
            dialogexport_t.cpp
            dialoggeometryimage_t.cpp
            dialogimportanalyticgeometry_t.cpp
+           dialogimportgeometrygmsh_t.cpp
            dialogimage_t.cpp
            dialogimageslice_t.cpp
            dialogmeshingoptions_t.cpp

--- a/gui/dialogs/dialogimportgeometrygmsh.cpp
+++ b/gui/dialogs/dialogimportgeometrygmsh.cpp
@@ -1,0 +1,121 @@
+#include "dialogimportgeometrygmsh.hpp"
+#include "ui_dialogimportgeometrygmsh.h"
+#include <QGuiApplication>
+#include <QPushButton>
+#include <algorithm>
+
+DialogImportGeometryGmsh::DialogImportGeometryGmsh(int maxVoxelsPerDimension,
+                                                   const QString &filename,
+                                                   QWidget *parent)
+    : QDialog(parent), ui{std::make_unique<Ui::DialogImportGeometryGmsh>()} {
+  ui->setupUi(this);
+
+  ui->lblImage->setZSlider(ui->slideZIndex);
+  ui->lblImage->displayGrid(ui->chkGrid->isChecked());
+  ui->lblImage->displayScale(ui->chkScale->isChecked());
+  ui->lblImage->setAspectRatioMode(Qt::AspectRatioMode::KeepAspectRatio);
+  ui->spinMaxDimension->setValue(std::max(1, maxVoxelsPerDimension));
+
+  connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+          &DialogImportGeometryGmsh::accept);
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &DialogImportGeometryGmsh::reject);
+  connect(ui->spinMaxDimension, qOverload<int>(&QSpinBox::valueChanged), this,
+          &DialogImportGeometryGmsh::spinMaxDimension_valueChanged);
+  connect(ui->chkIncludeBackground, &QCheckBox::checkStateChanged, this,
+          &DialogImportGeometryGmsh::chkIncludeBackground_stateChanged);
+  connect(ui->chkGrid, &QCheckBox::checkStateChanged, this,
+          &DialogImportGeometryGmsh::chkGrid_stateChanged);
+  connect(ui->chkScale, &QCheckBox::checkStateChanged, this,
+          &DialogImportGeometryGmsh::chkScale_stateChanged);
+
+  ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+  loadMesh(filename);
+}
+
+DialogImportGeometryGmsh::~DialogImportGeometryGmsh() {
+  if (ui != nullptr) {
+    disconnect(ui->spinMaxDimension, nullptr, this, nullptr);
+    disconnect(ui->chkIncludeBackground, nullptr, this, nullptr);
+    disconnect(ui->chkGrid, nullptr, this, nullptr);
+    disconnect(ui->chkScale, nullptr, this, nullptr);
+    disconnect(ui->buttonBox, nullptr, this, nullptr);
+  }
+}
+
+const sme::common::ImageStack &DialogImportGeometryGmsh::getImage() const {
+  return image;
+}
+
+void DialogImportGeometryGmsh::spinMaxDimension_valueChanged(
+    [[maybe_unused]] int value) {
+  voxelizeMesh();
+}
+
+void DialogImportGeometryGmsh::chkIncludeBackground_stateChanged(
+    [[maybe_unused]] int state) {
+  voxelizeMesh();
+}
+
+void DialogImportGeometryGmsh::chkGrid_stateChanged(int state) {
+  ui->lblImage->displayGrid(state == Qt::Checked);
+}
+
+void DialogImportGeometryGmsh::chkScale_stateChanged(int state) {
+  ui->lblImage->displayScale(state == Qt::Checked);
+}
+
+void DialogImportGeometryGmsh::setStatusError(const QString &message) {
+  ui->lblStatus->setStyleSheet("font-weight: bold; color: red");
+  ui->lblStatus->setText(message);
+  ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+}
+
+void DialogImportGeometryGmsh::setStatusInfo(const QString &message) {
+  ui->lblStatus->setStyleSheet({});
+  ui->lblStatus->setText(message);
+}
+
+void DialogImportGeometryGmsh::loadMesh(const QString &filename) {
+  mesh.reset();
+  image = {};
+  ui->lblImage->setImage(image);
+
+  if (filename.isEmpty()) {
+    return;
+  }
+
+  QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+  mesh = sme::mesh::readGMSHMesh(filename);
+  QGuiApplication::restoreOverrideCursor();
+  if (!mesh.has_value()) {
+    setStatusError(QString("Failed to parse Gmsh file '%1'").arg(filename));
+    return;
+  }
+
+  voxelizeMesh();
+}
+
+void DialogImportGeometryGmsh::voxelizeMesh() {
+  if (!mesh.has_value()) {
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    return;
+  }
+
+  QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+  image = sme::mesh::voxelizeGMSHMesh(*mesh, ui->spinMaxDimension->value(),
+                                      ui->chkIncludeBackground->isChecked());
+  QGuiApplication::restoreOverrideCursor();
+  if (image.empty()) {
+    setStatusError("Failed to voxelize mesh");
+    return;
+  }
+
+  ui->lblImage->setImage(image);
+  ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+  auto vol = image.volume();
+  setStatusInfo(QString("Voxelized geometry: %1 x %2 x %3")
+                    .arg(vol.width())
+                    .arg(vol.height())
+                    .arg(vol.depth()));
+}

--- a/gui/dialogs/dialogimportgeometrygmsh.hpp
+++ b/gui/dialogs/dialogimportgeometrygmsh.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "sme/gmsh.hpp"
+#include <QDialog>
+#include <memory>
+
+namespace Ui {
+class DialogImportGeometryGmsh;
+}
+
+class DialogImportGeometryGmsh : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit DialogImportGeometryGmsh(int maxVoxelsPerDimension = 50,
+                                    const QString &filename = {},
+                                    QWidget *parent = nullptr);
+  ~DialogImportGeometryGmsh() override;
+
+  [[nodiscard]] const sme::common::ImageStack &getImage() const;
+
+private:
+  std::unique_ptr<Ui::DialogImportGeometryGmsh> ui;
+  std::optional<sme::mesh::GMSHMesh> mesh;
+  sme::common::ImageStack image;
+
+  void spinMaxDimension_valueChanged(int value);
+  void chkIncludeBackground_stateChanged(int state);
+  void chkGrid_stateChanged(int state);
+  void chkScale_stateChanged(int state);
+
+  void setStatusError(const QString &message);
+  void setStatusInfo(const QString &message);
+  void loadMesh(const QString &filename);
+  void voxelizeMesh();
+};

--- a/gui/dialogs/dialogimportgeometrygmsh.ui
+++ b/gui/dialogs/dialogimportgeometrygmsh.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogImportGeometryGmsh</class>
+ <widget class="QDialog" name="DialogImportGeometryGmsh">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>760</width>
+    <height>620</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import geometry from Gmsh</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblMaxDimension">
+       <property name="text">
+        <string>Largest dimension:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="spinMaxDimension">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>4096</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="lblMaxDimensionUnits">
+       <property name="text">
+        <string>voxels</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkIncludeBackground">
+       <property name="text">
+        <string>Include background voxels</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="3">
+      <widget class="QLabel" name="lblStatus">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="3">
+      <widget class="QLabelMouseTracker" name="lblImage" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="3">
+      <widget class="QSlider" name="slideZIndex">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="tickPosition">
+        <enum>QSlider::TicksBothSides</enum>
+       </property>
+       <property name="tickInterval">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="chkGrid">
+       <property name="text">
+        <string>Show &amp;grid</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="chkScale">
+       <property name="text">
+        <string>Show &amp;scale</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QLabelMouseTracker</class>
+   <extends>QWidget</extends>
+   <header>qlabelmousetracker.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/gui/dialogs/dialogimportgeometrygmsh_t.cpp
+++ b/gui/dialogs/dialogimportgeometrygmsh_t.cpp
@@ -1,0 +1,116 @@
+#include "catch_wrapper.hpp"
+#include "dialogimportgeometrygmsh.hpp"
+#include "qt_test_utils.hpp"
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QPushButton>
+#include <QSpinBox>
+#include <set>
+
+using namespace sme::test;
+
+namespace {
+
+struct DialogImportGeometryGmshWidgets {
+  explicit DialogImportGeometryGmshWidgets(
+      const DialogImportGeometryGmsh *dialog) {
+    GET_DIALOG_WIDGET(QSpinBox, spinMaxDimension);
+    GET_DIALOG_WIDGET(QCheckBox, chkIncludeBackground);
+    GET_DIALOG_WIDGET(QDialogButtonBox, buttonBox);
+  }
+
+  QSpinBox *spinMaxDimension{};
+  QCheckBox *chkIncludeBackground{};
+  QDialogButtonBox *buttonBox{};
+};
+
+std::size_t countUniqueColors(const sme::common::ImageStack &img) {
+  std::set<QRgb> colors;
+  for (std::size_t z = 0; z < img.volume().depth(); ++z) {
+    for (int y = 0; y < img.volume().height(); ++y) {
+      for (int x = 0; x < img.volume().width(); ++x) {
+        colors.insert(img[z].pixel(x, y));
+      }
+    }
+  }
+  return colors.size();
+}
+
+QString writeTmpFile(const QString &filename, const QString &contents) {
+  QFile::remove(filename);
+  QFile f(filename);
+  if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    return {};
+  }
+  if (const auto bytes = contents.toUtf8(); f.write(bytes) != bytes.size()) {
+    return {};
+  }
+  return filename;
+}
+
+} // namespace
+
+TEST_CASE(
+    "DialogImportGeometryGmsh",
+    "[gui/dialogs/importgeometrygmsh][gui/dialogs][gui][importgeometrygmsh]") {
+  SECTION("invalid file keeps ok disabled") {
+    auto filename =
+        writeTmpFile("tmp_invalid_gmsh_for_dialog.msh", "not a gmsh mesh");
+    REQUIRE(QFile::exists(filename));
+
+    DialogImportGeometryGmsh dia(20, filename);
+    dia.show();
+    waitFor(&dia);
+    DialogImportGeometryGmshWidgets widgets(&dia);
+
+    REQUIRE(dia.getImage().empty());
+    REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+            false);
+
+    QFile::remove(filename);
+  }
+
+  SECTION("valid file voxelizes and updates when resolution changes") {
+    const QString gmsh = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0 0 0
+2 1 0 0
+3 0 1 0
+4 0 0 1
+$EndNodes
+$Elements
+1
+1 4 2 7 7 1 2 3 4
+$EndElements
+)";
+
+    auto filename = writeTmpFile("tmp_single_tetra_for_dialog.msh", gmsh);
+    REQUIRE(QFile::exists(filename));
+
+    DialogImportGeometryGmsh dia(20, filename);
+    dia.show();
+    waitFor(&dia);
+    DialogImportGeometryGmshWidgets widgets(&dia);
+
+    REQUIRE(!dia.getImage().empty());
+    REQUIRE(widgets.buttonBox->button(QDialogButtonBox::Ok)->isEnabled() ==
+            true);
+    REQUIRE(dia.getImage().volume().width() == 20);
+    REQUIRE(dia.getImage().volume().height() == 20);
+    REQUIRE(dia.getImage().volume().depth() == 20);
+    REQUIRE(countUniqueColors(dia.getImage()) == 2);
+
+    widgets.chkIncludeBackground->setChecked(false);
+    REQUIRE(countUniqueColors(dia.getImage()) == 1);
+    widgets.spinMaxDimension->setValue(10);
+    REQUIRE(dia.getImage().volume().width() == 10);
+    REQUIRE(dia.getImage().volume().height() == 10);
+    REQUIRE(dia.getImage().volume().depth() == 10);
+
+    QFile::remove(filename);
+  }
+}

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "dialogcoordinates.hpp"
 #include "dialoggeometryimage.hpp"
 #include "dialogimportanalyticgeometry.hpp"
+#include "dialogimportgeometrygmsh.hpp"
 #include "dialogmeshingoptions.hpp"
 #include "dialogoptimize.hpp"
 #include "dialogoptsetup.hpp"
@@ -33,6 +34,7 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QWhatsThis>
+#include <algorithm>
 #include <optional>
 #include <spdlog/spdlog.h>
 
@@ -187,6 +189,9 @@ void MainWindow::setupConnections() {
 
   connect(ui->actionGeometry_from_image, &QAction::triggered, this,
           &MainWindow::actionGeometry_from_image_triggered);
+
+  connect(ui->actionGeometry_from_gmsh, &QAction::triggered, this,
+          &MainWindow::actionGeometry_from_gmsh_triggered);
 
   connect(ui->menuExample_geometry_image, &QMenu::triggered, this,
           &MainWindow::menuExample_geometry_image_triggered);
@@ -512,6 +517,29 @@ void MainWindow::actionGeometry_from_image_triggered() {
   if (auto img{getImageFromUser(this, "Import geometry from image")};
       !img.empty()) {
     importGeometryImage(img);
+  }
+}
+
+void MainWindow::actionGeometry_from_gmsh_triggered() {
+  if (!isValidModel()) {
+    return;
+  }
+  QString filename =
+      QFileDialog::getOpenFileName(this, "Import geometry from Gmsh mesh", "",
+                                   "Gmsh mesh (*.msh);; All files (*.*)");
+  if (filename.isEmpty()) {
+    return;
+  }
+  int maxVoxelsPerDimension{50};
+  const auto &images = model.getGeometry().getImages();
+  if (!images.empty()) {
+    const auto volume = images.volume();
+    maxVoxelsPerDimension = std::max(
+        {volume.width(), volume.height(), static_cast<int>(volume.depth())});
+  }
+  DialogImportGeometryGmsh dialog(maxVoxelsPerDimension, filename, this);
+  if (dialog.exec() == QDialog::Accepted && !dialog.getImage().empty()) {
+    importGeometryImage(dialog.getImage());
   }
 }
 

--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -65,6 +65,7 @@ private:
   // Import menu actions
   void actionGeometry_from_model_triggered();
   void actionGeometry_from_image_triggered();
+  void actionGeometry_from_gmsh_triggered();
   void menuExample_geometry_image_triggered(const QAction *action);
 
   // Tools menu actions

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -366,6 +366,7 @@
      <addaction name="action_four_compartments_150x100"/>
     </widget>
     <addaction name="actionGeometry_from_model"/>
+    <addaction name="actionGeometry_from_gmsh"/>
     <addaction name="actionGeometry_from_image"/>
     <addaction name="menuExample_geometry_image"/>
    </widget>
@@ -590,6 +591,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+G</string>
+   </property>
+  </action>
+  <action name="actionGeometry_from_gmsh">
+   <property name="text">
+    <string>Geometry from g&amp;msh...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+G</string>
    </property>
   </action>
   <action name="actionSet_spatial_coordinates">

--- a/gui/mainwindow_t.cpp
+++ b/gui/mainwindow_t.cpp
@@ -357,6 +357,17 @@ TEST_CASE("MainWindow: geometry", tags) {
       QFile::remove("x.xml");
     }
   }
+  SECTION("import geometry from gmsh") {
+    MainWindow w;
+    w.show();
+    waitFor(&w);
+    openBuiltInModel(w);
+    ModalWidgetTimer mwt;
+    mwt.addUserAction({"Esc"}, false);
+    mwt.start();
+    sendKeyEvents(&w, {"Ctrl+Shift+G"});
+    REQUIRE(mwt.getResult() == "QFileDialog::AcceptOpen");
+  }
   SECTION("built-in SBML model, change geometry image zoom") {
     MainWindow w;
     w.show();


### PR DESCRIPTION
- add import -> import gmsh mesh to toolbar
- add dialog to convert the mesh to voxels
  - user chooses number of voxels in largest dimension
  - and if there should be background voxels or if every voxel should be part of a compartment in the mesh

Also

- dune mesh reader assumes C locale
- add RAII helper for setting C locale within a scope and use throughout code base
