### PR TITLE
Add species storage term

### DIFF
--- a/core/model/include/sme/model_settings.hpp
+++ b/core/model/include/sme/model_settings.hpp
@@ -76,6 +76,7 @@ struct Settings {
   std::vector<QRgb> sampledFieldColors{};
   std::map<std::string, std::vector<double>> speciesDiffusionConstantArrays{};
   std::map<std::string, std::string> speciesAnalyticDiffusionConstants{};
+  std::map<std::string, double> speciesStorageValues{};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -104,6 +105,13 @@ struct Settings {
          CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors),
          CEREAL_NVP(speciesDiffusionConstantArrays),
          CEREAL_NVP(speciesAnalyticDiffusionConstants));
+    } else if (version == 5) {
+      ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
+         CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColors),
+         CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors),
+         CEREAL_NVP(speciesDiffusionConstantArrays),
+         CEREAL_NVP(speciesAnalyticDiffusionConstants),
+         CEREAL_NVP(speciesStorageValues));
     }
   }
 };
@@ -113,4 +121,4 @@ struct Settings {
 CEREAL_CLASS_VERSION(sme::model::MeshParameters, 1);
 CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 1);
 CEREAL_CLASS_VERSION(sme::model::SimulationSettings, 1);
-CEREAL_CLASS_VERSION(sme::model::Settings, 4);
+CEREAL_CLASS_VERSION(sme::model::Settings, 5);

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -75,6 +75,8 @@ public:
   [[nodiscard]] bool getIsSpatial(const QString &id) const;
   void setDiffusionConstant(const QString &id, double diffusionConstant);
   [[nodiscard]] double getDiffusionConstant(const QString &id) const;
+  void setStorage(const QString &id, double storageValue);
+  [[nodiscard]] double getStorage(const QString &id) const;
   [[nodiscard]] SpatialDataType
   getDiffusionConstantType(const QString &id) const;
   [[nodiscard]] SpatialDataType

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -272,6 +272,14 @@ ModelSpecies::ModelSpecies(libsbml::Model *model,
     const auto *ssp = static_cast<const libsbml::SpatialSpeciesPlugin *>(
         spec->getPlugin("spatial"));
     field.setIsSpatial(ssp->getIsSpatial());
+    if (!sbmlAnnotation->speciesStorageValues.contains(id.toStdString())) {
+      sbmlAnnotation->speciesStorageValues[id.toStdString()] = 1.0;
+    } else if (sbmlAnnotation->speciesStorageValues[id.toStdString()] <= 0.0) {
+      SPDLOG_WARN("Invalid non-positive storage value for species '{}' - "
+                  "resetting to 1",
+                  id.toStdString());
+      sbmlAnnotation->speciesStorageValues[id.toStdString()] = 1.0;
+    }
     const auto *param = getOrCreateDiffusionConstantParameter(sbmlModel, id);
     if (param->isSetValue()) {
       // set uniform diffusion constant from parameter value if provided
@@ -346,6 +354,7 @@ QString ModelSpecies::add(const QString &name, const QString &compartmentId) {
   sbmlAnnotation->speciesColors[sId] = color;
   setIsSpatial(id, true);
   setDiffusionConstant(id, 1.0);
+  setStorage(id, 1.0);
   setInitialConcentration(id, 0.0);
   return newName;
 }
@@ -372,6 +381,7 @@ void ModelSpecies::remove(const QString &id) {
   sbmlAnnotation->speciesColors.erase(sId);
   sbmlAnnotation->speciesDiffusionConstantArrays.erase(sId);
   sbmlAnnotation->speciesAnalyticDiffusionConstants.erase(sId);
+  sbmlAnnotation->speciesStorageValues.erase(sId);
   compartmentIds.removeAt(i);
   removeInitialAssignment(sId.c_str());
   fields.erase(fields.begin() +
@@ -546,6 +556,26 @@ double ModelSpecies::getDiffusionConstant(const QString &id) const {
     return param->getValue();
   }
   return 0.0;
+}
+
+void ModelSpecies::setStorage(const QString &id, double storageValue) {
+  if (storageValue <= 0.0) {
+    SPDLOG_WARN("Ignoring non-positive storage value {} for species '{}'",
+                storageValue, id.toStdString());
+    return;
+  }
+  hasUnsavedChanges = true;
+  sbmlAnnotation->speciesStorageValues[id.toStdString()] = storageValue;
+}
+
+double ModelSpecies::getStorage(const QString &id) const {
+  if (const auto iter =
+          sbmlAnnotation->speciesStorageValues.find(id.toStdString());
+      iter != sbmlAnnotation->speciesStorageValues.cend() &&
+      iter->second > 0.0) {
+    return iter->second;
+  }
+  return 1.0;
 }
 
 SpatialDataType

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -464,4 +464,23 @@ TEST_CASE("SBML species",
       REQUIRE(concentration[i] == dbl_approx(correct_conc(voxels[i])));
     }
   }
+  SECTION("Storage values") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &s{m.getSpecies()};
+    REQUIRE(s.getStorage("A_c1") == dbl_approx(1.0));
+    s.setStorage("A_c1", 2.5);
+    REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
+    // ignore invalid values
+    s.setStorage("A_c1", 0.0);
+    REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
+    s.setStorage("A_c1", -4.0);
+    REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
+    // persists via SBML annotations
+    auto xml{m.getXml().toStdString()};
+    model::Model m2;
+    m2.importSBMLString(xml);
+    REQUIRE(m2.getSpecies().getStorage("A_c1") == dbl_approx(2.5));
+    // unknown species defaults to 1
+    REQUIRE(m2.getSpecies().getStorage("does_not_exist") == dbl_approx(1.0));
+  }
 }

--- a/core/model/src/xml_annotation_t.cpp
+++ b/core/model/src/xml_annotation_t.cpp
@@ -37,6 +37,7 @@ TEST_CASE("XML Annotations",
     optCost.targetValues = {1.0, 3.0, 5.0};
     auto &optParam{optimizeOptions.optParams.emplace_back()};
     optParam.name = "myOptParam";
+    settings.speciesStorageValues["A"] = 2.5;
     // todo: populate all fields above
 
     model::setSbmlAnnotation(model, settings);
@@ -67,6 +68,8 @@ TEST_CASE("XML Annotations",
     REQUIRE(newOptimizeOptions.optCosts[0].targetValues[2] == dbl_approx(5.0));
     REQUIRE(newOptimizeOptions.optParams.size() == 1);
     REQUIRE(newOptimizeOptions.optParams[0].name == "myOptParam");
+    REQUIRE(newSettings.speciesStorageValues.size() == 1);
+    REQUIRE(newSettings.speciesStorageValues["A"] == dbl_approx(2.5));
 
     // change options, save & write to file
     newSimulationSettings.times.push_back({7, 0.33});
@@ -75,6 +78,7 @@ TEST_CASE("XML Annotations",
     newOptimizeOptions.optAlgorithm.population = 4;
     newOptimizeOptions.optCosts.emplace_back().name = "optCost2";
     newOptimizeOptions.optParams[0].name = "newOptParamName";
+    newSettings.speciesStorageValues["A"] = 1.22;
     model::setSbmlAnnotation(model, newSettings);
     libsbml::writeSBMLToFile(doc.get(), "tmpxmlsettings.xml");
 
@@ -108,6 +112,8 @@ TEST_CASE("XML Annotations",
     REQUIRE(optimizeOptions2.optCosts[1].targetValues.empty());
     REQUIRE(optimizeOptions2.optParams.size() == 1);
     REQUIRE(optimizeOptions2.optParams[0].name == "newOptParamName");
+    REQUIRE(settings2.speciesStorageValues.size() == 1);
+    REQUIRE(settings2.speciesStorageValues["A"] == dbl_approx(1.22));
   }
   SECTION("Invalid settings annotations") {
     auto doc{getTestSbmlDoc("ABtoC-invalid-annotation")};
@@ -120,5 +126,6 @@ TEST_CASE("XML Annotations",
     REQUIRE(settings.optimizeOptions.optCosts.empty());
     REQUIRE(settings.optimizeOptions.optParams.empty());
     REQUIRE(settings.speciesColors.empty());
+    REQUIRE(settings.speciesStorageValues.empty());
   }
 }

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -234,7 +234,8 @@ static void addCompartment(
     }
 
     // Factor to multiply d/dt term by in PDE
-    ini.addValue("storage.expression", "1");
+    double storageValue = model.getSpecies().getStorage(name);
+    ini.addValue("storage.expression", storageValue, doublePrecision);
 
     // reactions
     ini.addValue("reaction.expression", pde.getRHS()[i].c_str());

--- a/core/simulate/src/duneconverter_t.cpp
+++ b/core/simulate/src/duneconverter_t.cpp
@@ -41,6 +41,17 @@ TEST_CASE("DUNE: DuneConverter",
     REQUIRE(symEq(*line++, "reaction.jacobian.C.expression = 0"));
     REQUIRE(symEq(*line++, "cross_diffusion.C.expression = 25"));
   }
+  SECTION("ABtoC model with non-default storage") {
+    auto s{getExampleModel(Mod::ABtoC)};
+    s.getSpecies().setStorage("C", 2.5);
+    simulate::DuneConverter dc(s, {}, true, {}, 14);
+    QStringList ini = dc.getIniFile().split("\n");
+    auto line = find_line("[model.scalar_field.C]", ini);
+    REQUIRE(*line++ == "[model.scalar_field.C]");
+    REQUIRE(*line++ == "compartment = comp");
+    REQUIRE(*line++ == "initial.expression = 0");
+    REQUIRE(*line++ == "storage.expression = 2.5");
+  }
   SECTION("brusselator model") {
     auto s{getExampleModel(Mod::Brusselator)};
     simulate::DuneConverter dc(s);

--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -33,6 +33,11 @@ void PixelSim::calculateDcdt() {
   }
   for (auto &sim : simCompartments) {
     sim->spatiallyAverageDcdt();
+    if (useTBB) {
+      sim->applyStorage_tbb();
+    } else {
+      sim->applyStorage();
+    }
   }
 }
 

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -88,6 +88,32 @@ void SimCompartment::spatiallyAverageDcdt() {
   }
 }
 
+void SimCompartment::applyStorage(std::size_t begin, std::size_t end) {
+  for (std::size_t i = begin; i < end; ++i) {
+    const std::size_t ix{i * nSpecies};
+    for (std::size_t is = 0; is < nSpecies; ++is) {
+      dcdt[ix + is] *= invStorage[is];
+    }
+  }
+}
+
+void SimCompartment::applyStorage() {
+  if (!hasNonUnitStorage) {
+    return;
+  }
+  applyStorage(0, nPixels);
+}
+
+void SimCompartment::applyStorage_tbb() {
+  if (!hasNonUnitStorage) {
+    return;
+  }
+  tbbParallelFor(nPixels,
+                 [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
+                   applyStorage(r.begin(), r.end());
+                 });
+}
+
 // Forwards Euler stability bound for dimensionless diffusion constant {D/dx^2,
 // D/dy^2, D/dz^2}
 static double calculateMaxStableTimestep(
@@ -114,6 +140,16 @@ SimCompartment::SimCompartment(
   dz2 = voxelSize.depth() * voxelSize.depth();
   for (const auto &s : speciesIds) {
     const auto *field = doc.getSpecies().getField(s.c_str());
+    double storageValue = doc.getSpecies().getStorage(s.c_str());
+    if (storageValue <= 0.0) {
+      throw PixelSimImplError(
+          "Invalid non-positive storage value for species '" + s + "'");
+    }
+    double invStorageValue = 1.0 / storageValue;
+    invStorage.push_back(invStorageValue);
+    if (invStorageValue != 1.0) {
+      hasNonUnitStorage = true;
+    }
     if (useUniformDiffusionOperator) {
       const auto &diffArray = field->getDiffusionConstant();
       double d = diffArray.empty() ? 0.0 : diffArray.front();
@@ -121,8 +157,12 @@ SimCompartment::SimCompartment(
           {d / dx2, d / dy2, d / dz2}); // dimensionless diffusion
       maxStableTimestep =
           std::min(maxStableTimestep,
-                   calculateMaxStableTimestep(diffConstantsUniform.back()));
-      SPDLOG_DEBUG("  - adding species: {}, diff constant {}", s, d);
+                   calculateMaxStableTimestep(
+                       {diffConstantsUniform.back()[0] * invStorageValue,
+                        diffConstantsUniform.back()[1] * invStorageValue,
+                        diffConstantsUniform.back()[2] * invStorageValue}));
+      SPDLOG_DEBUG("  - adding species: {}, diff constant {}, storage {}", s, d,
+                   storageValue);
     } else {
       // store diffusion constant per voxel
       diffConstants.push_back(field->getDiffusionConstant());
@@ -133,10 +173,13 @@ SimCompartment::SimCompartment(
       double maxD{diffConstants.back().empty()
                       ? 0.0
                       : common::max(diffConstants.back())};
-      maxStableTimestep = std::min(
-          maxStableTimestep,
-          calculateMaxStableTimestep({maxD / dx2, maxD / dy2, maxD / dz2}));
-      SPDLOG_DEBUG("  - adding species: {}, diff constant (max) {}", s, maxD);
+      maxStableTimestep =
+          std::min(maxStableTimestep,
+                   calculateMaxStableTimestep({maxD * invStorageValue / dx2,
+                                               maxD * invStorageValue / dy2,
+                                               maxD * invStorageValue / dz2}));
+      SPDLOG_DEBUG("  - adding species: {}, diff constant (max) {}, storage {}",
+                   s, maxD, storageValue);
     }
     fields.push_back(field);
     speciesNames.push_back(doc.getSpecies().getName(s.c_str()).toStdString());
@@ -159,6 +202,7 @@ SimCompartment::SimCompartment(
   }
   if (timeDependent) {
     speciesIds.push_back("time");
+    invStorage.push_back(1.0);
     if (useUniformDiffusionOperator) {
       diffConstantsUniform.push_back({0.0, 0.0, 0.0});
     } else {
@@ -168,12 +212,14 @@ SimCompartment::SimCompartment(
   }
   if (spaceDependent) {
     speciesIds.push_back(doc.getParameters().getSpatialCoordinates().x.id);
+    invStorage.push_back(1.0);
     if (useUniformDiffusionOperator) {
       diffConstantsUniform.push_back({0.0, 0.0, 0.0});
     } else {
       diffConstants.emplace_back(nPixels, 0.0);
     }
     speciesIds.push_back(doc.getParameters().getSpatialCoordinates().y.id);
+    invStorage.push_back(1.0);
     if (useUniformDiffusionOperator) {
       diffConstantsUniform.push_back({0.0, 0.0, 0.0});
     } else {
@@ -184,6 +230,7 @@ SimCompartment::SimCompartment(
     // dependent reaction terms will not be imported - as most likely this
     // affects no-one.
     speciesIds.push_back(doc.getParameters().getSpatialCoordinates().z.id);
+    invStorage.push_back(1.0);
     if (useUniformDiffusionOperator) {
       diffConstantsUniform.push_back({0.0, 0.0, 0.0});
     } else {

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -53,6 +53,8 @@ private:
   std::vector<std::vector<double>> diffConstants;
   // diffusion constants (D/dx^2, D/dy^2, D/dz^2) per species
   std::vector<std::array<double, 3>> diffConstantsUniform;
+  // inverse storage term (1 / S) per species
+  std::vector<double> invStorage;
   const geometry::Compartment *comp;
   std::size_t nPixels;
   std::size_t nSpecies;
@@ -65,6 +67,7 @@ private:
   double dy2{1.0};
   double dz2{1.0};
   bool useUniformDiffusionOperator{false};
+  bool hasNonUnitStorage{false};
 
 public:
   explicit SimCompartment(
@@ -81,6 +84,9 @@ public:
   void evaluateReactionsAndDiffusion();
   void evaluateReactionsAndDiffusion_tbb();
   void spatiallyAverageDcdt();
+  void applyStorage(std::size_t begin, std::size_t end);
+  void applyStorage();
+  void applyStorage_tbb();
   void doForwardsEulerTimestep(double dt, std::size_t begin, std::size_t end);
   void doForwardsEulerTimestep(double dt);
   void doForwardsEulerTimestep_tbb(double dt);

--- a/core/simulate/src/pixelsim_t.cpp
+++ b/core/simulate/src/pixelsim_t.cpp
@@ -46,4 +46,33 @@ TEST_CASE("PixelSim", "[core/simulate/pixelsim][core/"
       REQUIRE(cUniform[i] == dbl_approx(cArray[i]));
     }
   }
+  SECTION("Storage scales dcdt for species") {
+    auto mDefault{getExampleModel(Mod::ABtoC)};
+    auto mStorage{getExampleModel(Mod::ABtoC)};
+    mStorage.getSpecies().setStorage("C", 2.0);
+    for (auto *m : {&mDefault, &mStorage}) {
+      auto &options{m->getSimulationSettings().options};
+      options.pixel.enableMultiThreading = false;
+      options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+      options.pixel.maxTimestep = 1e-3;
+    }
+    std::vector<std::string> comps{"comp"};
+    std::vector<std::vector<std::string>> specs{{"A", "B", "C"}};
+    simulate::PixelSim simDefault(mDefault, comps, specs);
+    simulate::PixelSim simStorage(mStorage, comps, specs);
+    REQUIRE(simDefault.errorMessage().empty());
+    REQUIRE(simStorage.errorMessage().empty());
+    simDefault.run(1e-3, -1.0, {});
+    simStorage.run(1e-3, -1.0, {});
+    const auto &dcdtDefault = simDefault.getDcdt(0);
+    const auto &dcdtStorage = simStorage.getDcdt(0);
+    REQUIRE(dcdtDefault.size() == dcdtStorage.size());
+    for (std::size_t i = 0; i < dcdtDefault.size() / 3; ++i) {
+      // A and B unchanged as only C has non-unit storage
+      REQUIRE(dcdtStorage[i * 3] == dbl_approx(dcdtDefault[i * 3]));
+      REQUIRE(dcdtStorage[i * 3 + 1] == dbl_approx(dcdtDefault[i * 3 + 1]));
+      REQUIRE(dcdtStorage[i * 3 + 2] ==
+              dbl_approx(0.5 * dcdtDefault[i * 3 + 2]));
+    }
+  }
 }

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -955,118 +955,133 @@ TEST_CASE("Simulate: single-compartment-diffusion-3d, spherical geometry",
                                           "exp((-1/36) * (x^2 + y^2 + z^2))");
   auto voxel_volume{s.getGeometry().getVoxelSize().volume()};
   REQUIRE(voxel_volume == dbl_approx(initial_voxel_volume));
+  auto run3dDiffusionCase = [&](double slowStorage, double fastStorage,
+                                double pixelMaxRelErr, double pixelAvgRelErr,
+                                double duneMaxRelErr, double duneAvgRelErr) {
+    s.getSpecies().setStorage("slow", slowStorage);
+    s.getSpecies().setStorage("fast", fastStorage);
 
-  // check fields have correct compartments
-  const auto *slow{s.getSpecies().getField("slow")};
-  REQUIRE(slow->getCompartment()->getId() == "cube");
-  REQUIRE(slow->getId() == "slow");
-  const auto *fast{s.getSpecies().getField("fast")};
-  REQUIRE(fast->getCompartment()->getId() == "cube");
-  REQUIRE(fast->getId() == "fast");
+    // check fields have correct compartments
+    const auto *slow{s.getSpecies().getField("slow")};
+    REQUIRE(slow->getCompartment()->getId() == "cube");
+    REQUIRE(slow->getId() == "slow");
+    const auto *fast{s.getSpecies().getField("fast")};
+    REQUIRE(fast->getCompartment()->getId() == "cube");
+    REQUIRE(fast->getId() == "fast");
 
-  // check total initial species amount matches analytic value
-  double analytic_total = sigma2 * pi * std::sqrt(sigma2 * pi);
-  for (const auto &c : {slow->getConcentration(), fast->getConcentration()}) {
-    CAPTURE(analytic_total);
-    CAPTURE(std::abs(voxel_volume * common::sum(c)));
-    REQUIRE(std::abs(voxel_volume * common::sum(c) - analytic_total) /
-                analytic_total <
-            epsilon);
-  }
-
-  // check initial distribution matches analytic one
-  for (const auto &f : {slow, fast}) {
-    double D = f->getDiffusionConstant()[0];
-    double t0 = sigma2 / 4.0 / D;
-    double maxRelErr = 0;
-    for (std::size_t i = 0; i < f->getCompartment()->nVoxels(); ++i) {
-      const auto &v{f->getCompartment()->getVoxel(i)};
-      auto physicalPoint{s.getGeometry().getPhysicalPoint(v)};
-      double c = analytic_3d(physicalPoint, 0, D, t0);
-      double relErr = std::abs(f->getConcentration()[i] - c) / c;
-      maxRelErr = std::max(maxRelErr, relErr);
-    }
-    CAPTURE(f->getDiffusionConstant()[0]);
-    REQUIRE(maxRelErr < epsilon);
-  }
-
-  auto &options{s.getSimulationSettings().options};
-  options.pixel.maxErr = {std::numeric_limits<double>::max(), 0.01};
-  options.dune.dt = 1.0;
-  options.dune.maxDt = 1.0;
-  options.dune.minDt = 0.5;
-  // make a fine mesh for dune
-  s.getGeometry().getMesh3d()->setCompartmentMaxCellVolume(0, 4);
-  for (auto simType :
-       {simulate::SimulatorType::Pixel, simulate::SimulatorType::DUNE}) {
-    // relative error on integral of initial concentration over all pixels:
-    double initialRelativeError{1e-9};
-    // largest relative error of any pixel after simulation:
-    double evolvedMaxRelativeError{0.030};
-    // average of relative errors of all pixels after simulation:
-    double evolvedAvgRelativeError{0.010};
-    if (simType == simulate::SimulatorType::DUNE) {
-      // increase allowed error for dune simulation
-      initialRelativeError = 0.03;
-      evolvedMaxRelativeError = 0.40;
-      evolvedAvgRelativeError = 0.10;
-    }
-    s.getSimulationSettings().simulatorType = simType;
-    s.getSimulationData().clear();
-
-    // integrate & compare
-    simulate::Simulation sim(s);
-    double t = 10.0;
-    for (std::size_t step = 0; step < 2; ++step) {
-      sim.doTimesteps(t);
-      for (auto speciesIndex : {0u, 1u}) {
-        // check total species amount is conserved
-        auto c = sim.getConc(step + 1, 0, speciesIndex);
-        double totalC = voxel_volume * common::sum(c);
-        double relErr = std::abs(totalC - analytic_total) / analytic_total;
-        CAPTURE(simType);
-        CAPTURE(speciesIndex);
-        CAPTURE(sim.getTimePoints().back());
-        CAPTURE(totalC);
-        CAPTURE(analytic_total);
-        REQUIRE(relErr < initialRelativeError);
-      }
+    // check total initial species amount matches analytic value
+    double analytic_total = sigma2 * pi * std::sqrt(sigma2 * pi);
+    for (const auto &c : {slow->getConcentration(), fast->getConcentration()}) {
+      CAPTURE(analytic_total);
+      CAPTURE(std::abs(voxel_volume * common::sum(c)));
+      REQUIRE(std::abs(voxel_volume * common::sum(c) - analytic_total) /
+                  analytic_total <
+              epsilon);
     }
 
-    // check new distribution matches analytic_3d one
-    std::vector<double> D{slow->getDiffusionConstant()[0],
-                          fast->getDiffusionConstant()[0]};
-    std::size_t timeIndex = sim.getTimePoints().size() - 1;
-    t = sim.getTimePoints().back();
-    for (auto speciesIndex : {0u, 1u}) {
-      double t0 = sigma2 / 4.0 / D[speciesIndex];
-      auto conc = sim.getConc(timeIndex, 0, speciesIndex);
-      double maxRelErr{0};
-      double avgRelErr{0};
-      std::size_t count{0};
-      for (std::size_t i = 0; i < slow->getCompartment()->nVoxels(); ++i) {
-        const auto &v{slow->getCompartment()->getVoxel(i)};
-        // only check part within a radius of 16 units from centre to avoid
-        // boundary effects: analytic solution is in infinite volume
+    // check initial distribution matches analytic one
+    for (const auto &f : {slow, fast}) {
+      double D = f->getDiffusionConstant()[0];
+      double t0 = sigma2 / 4.0 / D;
+      double maxRelErr = 0;
+      for (std::size_t i = 0; i < f->getCompartment()->nVoxels(); ++i) {
+        const auto &v{f->getCompartment()->getVoxel(i)};
         auto physicalPoint{s.getGeometry().getPhysicalPoint(v)};
-        if (std::pow(physicalPoint.p.x(), 2) +
-                std::pow(physicalPoint.p.y(), 2) +
-                std::pow(physicalPoint.z, 2) <
-            16 * 16) {
-          double c_analytic =
-              analytic_3d(physicalPoint, t, D[speciesIndex], t0);
-          double relErr = std::abs(conc[i] - c_analytic) / c_analytic;
-          avgRelErr += relErr;
-          ++count;
-          maxRelErr = std::max(maxRelErr, relErr);
+        double c = analytic_3d(physicalPoint, 0, D, t0);
+        double relErr = std::abs(f->getConcentration()[i] - c) / c;
+        maxRelErr = std::max(maxRelErr, relErr);
+      }
+      CAPTURE(f->getDiffusionConstant()[0]);
+      REQUIRE(maxRelErr < epsilon);
+    }
+
+    auto &options{s.getSimulationSettings().options};
+    options.pixel.maxErr = {std::numeric_limits<double>::max(), 0.01};
+    options.dune.dt = 1.0;
+    options.dune.maxDt = 1.0;
+    options.dune.minDt = 0.5;
+    // make a fine mesh for dune
+    s.getGeometry().getMesh3d()->setCompartmentMaxCellVolume(0, 4);
+    for (auto simType :
+         {simulate::SimulatorType::Pixel, simulate::SimulatorType::DUNE}) {
+      // relative error on integral of initial concentration over all pixels:
+      double initialRelativeError{1e-9};
+      // largest relative error of any pixel after simulation:
+      double evolvedMaxRelativeError{pixelMaxRelErr};
+      // average of relative errors of all pixels after simulation:
+      double evolvedAvgRelativeError{pixelAvgRelErr};
+      if (simType == simulate::SimulatorType::DUNE) {
+        // increase allowed error for dune simulation
+        initialRelativeError = 0.03;
+        evolvedMaxRelativeError = duneMaxRelErr;
+        evolvedAvgRelativeError = duneAvgRelErr;
+      }
+      s.getSimulationSettings().simulatorType = simType;
+      s.getSimulationData().clear();
+
+      // integrate & compare
+      simulate::Simulation sim(s);
+      double t = 10.0;
+      for (std::size_t step = 0; step < 2; ++step) {
+        sim.doTimesteps(t);
+        for (auto speciesIndex : {0u, 1u}) {
+          // check total species amount is conserved
+          auto c = sim.getConc(step + 1, 0, speciesIndex);
+          double totalC = voxel_volume * common::sum(c);
+          double relErr = std::abs(totalC - analytic_total) / analytic_total;
+          CAPTURE(simType);
+          CAPTURE(speciesIndex);
+          CAPTURE(sim.getTimePoints().back());
+          CAPTURE(totalC);
+          CAPTURE(analytic_total);
+          REQUIRE(relErr < initialRelativeError);
         }
       }
-      avgRelErr /= static_cast<double>(count);
-      CAPTURE(simType);
-      CAPTURE(t);
-      REQUIRE(maxRelErr < evolvedMaxRelativeError);
-      REQUIRE(avgRelErr < evolvedAvgRelativeError);
+
+      // check new distribution matches analytic_3d one
+      std::vector<double> D{slow->getDiffusionConstant()[0],
+                            fast->getDiffusionConstant()[0]};
+      std::vector<double> storage{slowStorage, fastStorage};
+      std::size_t timeIndex = sim.getTimePoints().size() - 1;
+      t = sim.getTimePoints().back();
+      for (auto speciesIndex : {0u, 1u}) {
+        double t0 = sigma2 / 4.0 / D[speciesIndex];
+        auto conc = sim.getConc(timeIndex, 0, speciesIndex);
+        double maxRelErr{0};
+        double avgRelErr{0};
+        std::size_t count{0};
+        for (std::size_t i = 0; i < slow->getCompartment()->nVoxels(); ++i) {
+          const auto &v{slow->getCompartment()->getVoxel(i)};
+          // only check part within a radius of 16 units from centre to avoid
+          // boundary effects: analytic solution is in infinite volume
+          auto physicalPoint{s.getGeometry().getPhysicalPoint(v)};
+          if (std::pow(physicalPoint.p.x(), 2) +
+                  std::pow(physicalPoint.p.y(), 2) +
+                  std::pow(physicalPoint.z, 2) <
+              16 * 16) {
+            double c_analytic = analytic_3d(
+                physicalPoint, t / storage[speciesIndex], D[speciesIndex], t0);
+            double relErr = std::abs(conc[i] - c_analytic) / c_analytic;
+            avgRelErr += relErr;
+            ++count;
+            maxRelErr = std::max(maxRelErr, relErr);
+          }
+        }
+        avgRelErr /= static_cast<double>(count);
+        CAPTURE(simType);
+        CAPTURE(t);
+        CAPTURE(storage[speciesIndex]);
+        REQUIRE(maxRelErr < evolvedMaxRelativeError);
+        REQUIRE(avgRelErr < evolvedAvgRelativeError);
+      }
     }
+  };
+
+  SECTION("unit storage") {
+    run3dDiffusionCase(1.0, 1.0, 0.030, 0.010, 0.40, 0.10);
+  }
+  SECTION("non-unit storage") {
+    run3dDiffusionCase(2.0, 3.0, 0.040, 0.015, 0.75, 0.20);
   }
 }
 
@@ -1814,6 +1829,40 @@ TEST_CASE("Reactions depend on x, y, t",
     constexpr double maxAllowedRelDiff{1e-7};
     s.getSpecies().remove("A");
     s.getSpecies().remove("B");
+    simulate::Simulation simPixel{s};
+    simPixel.doTimesteps(dt, 1);
+    REQUIRE(simPixel.errorMessage().empty());
+    REQUIRE(simPixel.getNCompletedTimesteps() == 2);
+    s.getSimulationData().clear();
+    s.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
+    simulate::Simulation simDune{s};
+    simDune.doTimesteps(dt, 1);
+    CAPTURE(simDune.errorMessage());
+    REQUIRE(simDune.errorMessage().empty());
+    REQUIRE(simDune.getNCompletedTimesteps() == 2);
+    auto p{simPixel.getConc(1, 0, 0)};
+    auto d{simDune.getConc(1, 0, 0)};
+    REQUIRE(p.size() == d.size());
+    double maxAbsDiff{0};
+    double maxRelDiff{0};
+    for (std::size_t i = 0; i < p.size(); ++i) {
+      maxAbsDiff = std::max(maxAbsDiff, std::abs(p[i] - d[i]));
+      maxRelDiff = std::max(maxRelDiff, std::abs(p[i] - d[i]) /
+                                            (std::abs(p[i] + d[i] + eps)));
+    }
+    CAPTURE(maxAbsDiff);
+    CAPTURE(maxRelDiff);
+    REQUIRE(maxAbsDiff < maxAllowedAbsDiff);
+    REQUIRE(maxRelDiff < maxAllowedRelDiff);
+  }
+  SECTION("reaction with t-dependence and non-unit storage") {
+    // fairly tight tolerance, as solution is spatially uniform, so mesh vs
+    // pixel geometry is not a factor when comparing Pixel and Dune here
+    constexpr double maxAllowedAbsDiff{1e-10};
+    constexpr double maxAllowedRelDiff{1e-7};
+    s.getSpecies().remove("A");
+    s.getSpecies().remove("B");
+    s.getSpecies().setStorage("C", 2.0);
     simulate::Simulation simPixel{s};
     simPixel.doTimesteps(dt, 1);
     REQUIRE(simPixel.errorMessage().empty());

--- a/docs/quickstart/species.rst
+++ b/docs/quickstart/species.rst
@@ -17,7 +17,11 @@ At the top, you can rename the species or assign it to a different compartment. 
 Two more properties of a species are of primary importance.
 
 :Initial concentration:
-   This can be set to a constant value, an analytic expression over the spatial coordinates `x` and `y` (and `z` for 3D images) or it can be derived from an image that's loaded from disk, in the .png format for 2D domains, and as .tiff file for 3D domains.
+   This can be set in three ways:
+
+   * Uniform: a single scalar value everywhere in the compartment.
+   * Analytic: an expression in the spatial coordinates (`x`, `y`, and `z` for 3D models).
+   * Image: a sampled field loaded from image data, giving a per-voxel value.
 
 :Diffusion constant: The presence of a diffusion term
 
@@ -25,7 +29,7 @@ Two more properties of a species are of primary importance.
 
          \nabla \cdot \left( D \nabla c_{i} \right)
 
-   is assumed by default (see the `documentation on the mathematical formulation <../reference/maths.html>`_ for more details). The diffusion constant can be set in three ways:
+   is assumed by default (see the `documentation on the mathematical formulation <../reference/maths.html>`_ for more details). The diffusion constant can also be set in three ways:
 
    * Uniform: a single scalar value everywhere in the compartment.
    * Analytic: an expression in the spatial coordinates (`x`, `y`, and `z` for 3D models).
@@ -34,6 +38,18 @@ Two more properties of a species are of primary importance.
    In all cases, `D` is isotropic (scalar, not tensor). If you don't want diffusion to be present, set `D = 0`.
 
 With the definition of these two elements, the species is fully defined and can be used in the next steps of the model definition.
+
+:Storage coefficient (Advanced):
+   In the species `Advanced` section, you can set a positive, dimensionless storage coefficient :math:`S`.
+   This scales the species time derivative in the PDE:
+
+   .. math::
+
+      S_i \frac{\partial c_i}{\partial t} = \nabla \cdot \left( D_i \nabla c_i \right) + R_i
+
+   The default is :math:`S=1`, which gives the standard reaction-diffusion form.
+   Larger :math:`S` values make concentration changes slower in time, while values between 0 and 1 make them faster.
+
 
 .. note::
    Take care to get the units correct. All quantities are assumed to have certain SI units, which are noted next to the input field for the respective quantity. For example, the diffusion constant could have units of :math: `cm^2/s`. For more on units, `see here <../reference/units.html>`_.

--- a/docs/reference/maths.rst
+++ b/docs/reference/maths.rst
@@ -8,20 +8,28 @@ The system of PDEs that we simulate in each compartment is the three-dimensional
 
 .. math::
 
-   \frac{\partial c_s}{\partial t} = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
+   S_s \frac{\partial c_s}{\partial t} = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
 
 where
 
 * :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y, z)` and time :math:`t`
 * :math:`D_s` is the (possibly spatially varying) scalar diffusion constant for species :math:`s`
 * :math:`R_s` is the reaction term for species :math:`s`
+* :math:`S_s` is the species storage coefficient (dimensionless, positive, default :math:`1`)
 
 and we assume that
 
 * the diffusion constant :math:`D_s` is isotropic (a scalar, not a tensor)
 * the reaction term :math:`R_s` is a function that can depend on the concentrations of other species in the model, but only locally, i.e. the concentrations at the same spatial coordinate.
 
-If :math:`D_s` is constant in space, this reduces to :math:`D_s \nabla^2 c_s + R_s`.
+Equivalently,
+
+.. math::
+
+   \frac{\partial c_s}{\partial t} = \frac{1}{S_s}\left(\nabla \cdot \left( D_s \nabla c_s \right) + R_s\right)
+
+If :math:`D_s` is constant in space, this reduces to
+:math:`\frac{1}{S_s}\left(D_s \nabla^2 c_s + R_s\right)`.
 
 Compartment Reactions
 ---------------------

--- a/docs/reference/pixel.rst
+++ b/docs/reference/pixel.rst
@@ -59,11 +59,12 @@ The concentration is defined as a 3d array of values :math:`c_{i,j,k}`,
 where the value with index :math:`(i,j,k)` corresponds to the concentration
 at the spatial point :math:`(x = i \delta x, y = j \delta y, z = k \delta z)`.
 
-For diffusion constants that vary in space, the diffusion term is written in conservative form
+For diffusion constants that vary in space, the diffusion term is written in conservative form.
+With species storage coefficient :math:`S>0`, the PDE is
 
 .. math::
 
-   \frac{\partial c}{\partial t} = \nabla \cdot \left( D(\mathbf{x}) \nabla c \right) + R
+   S\frac{\partial c}{\partial t} = \nabla \cdot \left( D(\mathbf{x}) \nabla c \right) + R
 
 and discretized using face fluxes with arithmetic averaging of :math:`D` at neighbouring voxels.
 For one species in voxel :math:`(i,j,k)`:
@@ -71,11 +72,12 @@ For one species in voxel :math:`(i,j,k)`:
 .. math::
 
    \begin{eqnarray}
-   \left[\nabla \cdot \left( D \nabla c \right)\right]_{i,j,k}
-   & = & \frac{D^x_{i+1/2,j,k}(c_{i+1,j,k}-c_{i,j,k}) - D^x_{i-1/2,j,k}(c_{i,j,k}-c_{i-1,j,k})}{\delta x^2} \\
+   \frac{dc_{i,j,k}}{dt}
+   & = & \frac{1}{S}\left(
+   \frac{D^x_{i+1/2,j,k}(c_{i+1,j,k}-c_{i,j,k}) - D^x_{i-1/2,j,k}(c_{i,j,k}-c_{i-1,j,k})}{\delta x^2} \right.\\
    & & + \frac{D^y_{i,j+1/2,k}(c_{i,j+1,k}-c_{i,j,k}) - D^y_{i,j-1/2,k}(c_{i,j,k}-c_{i,j-1,k})}{\delta y^2} \\
-   & & + \frac{D^z_{i,j,k+1/2}(c_{i,j,k+1}-c_{i,j,k}) - D^z_{i,j,k-1/2}(c_{i,j,k}-c_{i,j,k-1})}{\delta z^2} \\
-   & & + \mathcal{O}(\delta x^2)+\mathcal{O}(\delta y^2)+\mathcal{O}(\delta z^2)
+   & & + \left.\frac{D^z_{i,j,k+1/2}(c_{i,j,k+1}-c_{i,j,k}) - D^z_{i,j,k-1/2}(c_{i,j,k}-c_{i,j,k-1})}{\delta z^2}
+   + R_{i,j,k}\right)
    \end{eqnarray}
 
 with face diffusion constants
@@ -98,7 +100,7 @@ For one species, start from
 
 .. math::
 
-   \frac{\partial c}{\partial t} = \nabla \cdot (D \nabla c) + R
+   S\frac{\partial c}{\partial t} = \nabla \cdot (D \nabla c) + R
 
 1. Integrate over one voxel :math:`V_{i,j,k}`
 
@@ -109,7 +111,7 @@ Assumptions:
 
 .. math::
 
-   \int_{V_{i,j,k}}\frac{\partial c}{\partial t}\,dV
+   S\int_{V_{i,j,k}}\frac{\partial c}{\partial t}\,dV
    =
    \int_{V_{i,j,k}}\nabla\cdot(D\nabla c)\,dV
    +
@@ -135,9 +137,9 @@ Then
 
 .. math::
 
-   \int_{V_{i,j,k}}\frac{\partial c}{\partial t}\,dV
+   S\int_{V_{i,j,k}}\frac{\partial c}{\partial t}\,dV
    \approx
-   \delta x\,\delta y\,\delta z\;\frac{d c_{i,j,k}}{dt}
+   S\delta x\,\delta y\,\delta z\;\frac{d c_{i,j,k}}{dt}
 
 .. math::
 
@@ -179,11 +181,11 @@ Substituting the face fluxes into the surface-balance form and dividing by
 .. math::
 
    \begin{aligned}
-   \frac{d c_{i,j,k}}{dt} =\;&
+   \frac{d c_{i,j,k}}{dt} =\;& \frac{1}{S}\Bigg[
    \frac{D^x_{i+1/2,j,k}(c_{i+1,j,k}-c_{i,j,k}) - D^x_{i-1/2,j,k}(c_{i,j,k}-c_{i-1,j,k})}{\delta x^2} \\
    &+ \frac{D^y_{i,j+1/2,k}(c_{i,j+1,k}-c_{i,j,k}) - D^y_{i,j-1/2,k}(c_{i,j,k}-c_{i,j-1,k})}{\delta y^2} \\
    &+ \frac{D^z_{i,j,k+1/2}(c_{i,j,k+1}-c_{i,j,k}) - D^z_{i,j,k-1/2}(c_{i,j,k}-c_{i,j,k-1})}{\delta z^2}
-   + R_{i,j,k}
+   + R_{i,j,k}\Bigg]
    \end{aligned}
 
 where :math:`R_{i,j,k}` is the cell-centered reaction term.
@@ -285,9 +287,10 @@ above which the system becomes unstable:
 
 .. math::
 
-   \delta t \leq  \frac{1}{2 D_{\max} \left(\frac{1}{\delta x^2}+\frac{1}{\delta y^2}+\frac{1}{\delta z^2}\right)}
+   \delta t \leq  \frac{S}{2 D_{\max} \left(\frac{1}{\delta x^2}+\frac{1}{\delta y^2}+\frac{1}{\delta z^2}\right)}
 
-where :math:`D_{\max}` is the largest diffusion constant value over all voxels for the species.
+where :math:`D_{\max}` is the largest diffusion constant value over all voxels for the species,
+and :math:`S` is that species' storage coefficient.
 
 So if the user selects a timestep larger than this,
 the simulator automatically reduces it to the above value to avoid the system becoming unstable.

--- a/docs/reference/units.rst
+++ b/docs/reference/units.rst
@@ -32,6 +32,8 @@ All quantities in the model have units that can be written as some combination o
     - have units of amount / membrane-area / time, i.e. ``amount`` / ``length`` / ``length`` / ``time``
 - diffusion constants
     - have units of `area / time`, i.e. ``length`` * ``length`` / ``time``
+- species storage coefficients
+    - are dimensionless (unitless)
 
 More information
 ----------------

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -64,6 +64,14 @@ TabSpecies::TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
           &TabSpecies::btnEditAnalyticDiffusionConstant_clicked);
   connect(ui->btnEditImageDiffusionConstant, &QPushButton::clicked, this,
           &TabSpecies::btnEditImageDiffusionConstant_clicked);
+  connect(ui->btnSpeciesAdvanced, &QToolButton::toggled, this,
+          [this](bool expanded) {
+            ui->btnSpeciesAdvanced->setArrowType(expanded ? Qt::DownArrow
+                                                          : Qt::RightArrow);
+            ui->wgtSpeciesAdvanced->setVisible(expanded);
+          });
+  connect(ui->txtStorage, &QLineEdit::editingFinished, this,
+          &TabSpecies::txtStorage_editingFinished);
   connect(ui->btnChangeSpeciesColor, &QPushButton::clicked, this,
           &TabSpecies::btnChangeSpeciesColor_clicked);
 }
@@ -110,6 +118,8 @@ void TabSpecies::enableWidgets(bool enable) {
   ui->btnEditAnalyticDiffusionConstant->setEnabled(enable);
   ui->radDiffusionConstantImage->setEnabled(enable);
   ui->btnEditImageDiffusionConstant->setEnabled(enable);
+  ui->btnSpeciesAdvanced->setEnabled(enable);
+  ui->txtStorage->setEnabled(enable);
   ui->btnChangeSpeciesColor->setEnabled(enable);
 }
 
@@ -199,6 +209,9 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
     ui->radDiffusionConstantAnalytic->setChecked(true);
   }
   radDiffusionConstant_toggled();
+  // storage
+  ui->txtStorage->setText(
+      QString::number(model.getSpecies().getStorage(currentSpeciesId)));
   // color
   lblSpeciesColorPixmap.fill(model.getSpecies().getColor(currentSpeciesId));
   ui->lblSpeciesColor->setPixmap(lblSpeciesColorPixmap);
@@ -412,6 +425,19 @@ void TabSpecies::btnEditImageDiffusionConstant_clicked() {
   } catch (const std::invalid_argument &e) {
     QMessageBox::warning(this, "Error editing diffusion image", e.what());
   }
+}
+
+void TabSpecies::txtStorage_editingFinished() {
+  bool ok{false};
+  double storage = ui->txtStorage->text().toDouble(&ok);
+  if (!ok || storage <= 0.0) {
+    ui->txtStorage->setText(
+        QString::number(model.getSpecies().getStorage(currentSpeciesId)));
+    return;
+  }
+  SPDLOG_INFO("setting storage value of Species {} to {}",
+              currentSpeciesId.toStdString(), storage);
+  model.getSpecies().setStorage(currentSpeciesId, storage);
 }
 
 void TabSpecies::btnChangeSpeciesColor_clicked() {

--- a/gui/tabs/tabspecies.hpp
+++ b/gui/tabs/tabspecies.hpp
@@ -51,5 +51,6 @@ private:
   void txtDiffusionConstant_editingFinished();
   void btnEditAnalyticDiffusionConstant_clicked();
   void btnEditImageDiffusionConstant_clicked();
+  void txtStorage_editingFinished();
   void btnChangeSpeciesColor_clicked();
 };

--- a/gui/tabs/tabspecies.ui
+++ b/gui/tabs/tabspecies.ui
@@ -508,6 +508,58 @@
            </property>
           </widget>
          </item>
+         <item row="13" column="0" colspan="8">
+          <widget class="QToolButton" name="btnSpeciesAdvanced">
+           <property name="text">
+            <string>Advanced</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <property name="arrowType">
+            <enum>Qt::RightArrow</enum>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="0" colspan="8">
+          <widget class="QWidget" name="wgtSpeciesAdvanced" native="true">
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayoutAdvancedSpecies">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblStorage">
+              <property name="text">
+               <string>Storage:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtStorage">
+              <property name="toolTip">
+               <string>Storage coefficient that multiplies this species time derivative</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="lblStorageUnits">
+              <property name="text">
+               <string>dimensionless</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -10,6 +10,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QToolButton>
 #include <QTreeWidget>
 
 using namespace sme::test;
@@ -76,6 +77,10 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
   auto *btnEditImageDiffusionConstant{
       tab.findChild<QPushButton *>("btnEditImageDiffusionConstant")};
   REQUIRE(btnEditImageDiffusionConstant != nullptr);
+  auto *btnSpeciesAdvanced{tab.findChild<QToolButton *>("btnSpeciesAdvanced")};
+  REQUIRE(btnSpeciesAdvanced != nullptr);
+  auto *txtStorage{tab.findChild<QLineEdit *>("txtStorage")};
+  REQUIRE(txtStorage != nullptr);
 
   auto *btnChangeSpeciesColor{
       tab.findChild<QPushButton *>("btnChangeSpeciesColor")};
@@ -98,6 +103,7 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(radDiffusionConstantAnalytic->isEnabled() == false);
     REQUIRE(radDiffusionConstantImage->isEnabled() == false);
     REQUIRE(txtDiffusionConstant->isEnabled() == false);
+    REQUIRE(txtStorage->text() == "1");
     // edit name
     txtSpeciesName->setFocus();
     sendKeyEvents(txtSpeciesName, {" ", "!", "Enter"});
@@ -173,13 +179,20 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     sendKeyEvents(listSpecies, {"Up"});
     sendKeyEvents(listSpecies, {"Down"});
     REQUIRE(txtDiffusionConstant->text() == "9");
+    // expand advanced settings and edit storage value
+    sendMouseClick(btnSpeciesAdvanced);
+    txtStorage->setFocus();
+    sendKeyEvents(txtStorage, {"End", "Backspace", "2", "Enter"});
+    sendKeyEvents(listSpecies, {"Up"});
+    sendKeyEvents(listSpecies, {"Down"});
+    REQUIRE(txtStorage->text() == "2");
     // click change species color, then cancel
     mwt.addUserAction({"Esc"});
     mwt.start();
     sendMouseClick(btnChangeSpeciesColor);
     // edit name
     txtSpeciesName->setFocus();
-    sendKeyEvents(txtSpeciesName, {"B", "Q", "Tab"});
+    sendKeyEvents(txtSpeciesName, {"B", "Q", "Enter"});
     REQUIRE(listSpecies->currentItem()->text(0) == "B_outBQ");
     REQUIRE(listSpecies->currentItem()->parent()->text(0) == "Outside");
     // change species location


### PR DESCRIPTION
- gui
  - add "advanced" section with storage term to TabSpecies
- dune-copasi
  - set `storage.expression`
- pixel
  - divide dc/dt for a species by its storage value if not 1
  - include this term in the stability bounds estimate
- model
  - add species storage to model settings
  - add setter/getter to ModelSpecies: returns 1 by default
- resolves #1113
