### PR TITLE
Add basic support for zero storage species to Pixel

### DIFF
--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -274,8 +274,8 @@ ModelSpecies::ModelSpecies(libsbml::Model *model,
     field.setIsSpatial(ssp->getIsSpatial());
     if (!sbmlAnnotation->speciesStorageValues.contains(id.toStdString())) {
       sbmlAnnotation->speciesStorageValues[id.toStdString()] = 1.0;
-    } else if (sbmlAnnotation->speciesStorageValues[id.toStdString()] <= 0.0) {
-      SPDLOG_WARN("Invalid non-positive storage value for species '{}' - "
+    } else if (sbmlAnnotation->speciesStorageValues[id.toStdString()] < 0.0) {
+      SPDLOG_WARN("Invalid negative storage value for species '{}' - "
                   "resetting to 1",
                   id.toStdString());
       sbmlAnnotation->speciesStorageValues[id.toStdString()] = 1.0;
@@ -559,8 +559,8 @@ double ModelSpecies::getDiffusionConstant(const QString &id) const {
 }
 
 void ModelSpecies::setStorage(const QString &id, double storageValue) {
-  if (storageValue <= 0.0) {
-    SPDLOG_WARN("Ignoring non-positive storage value {} for species '{}'",
+  if (storageValue < 0.0) {
+    SPDLOG_WARN("Ignoring negative storage value {} for species '{}'",
                 storageValue, id.toStdString());
     return;
   }
@@ -572,7 +572,7 @@ double ModelSpecies::getStorage(const QString &id) const {
   if (const auto iter =
           sbmlAnnotation->speciesStorageValues.find(id.toStdString());
       iter != sbmlAnnotation->speciesStorageValues.cend() &&
-      iter->second > 0.0) {
+      iter->second >= 0.0) {
     return iter->second;
   }
   return 1.0;

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -470,12 +470,23 @@ TEST_CASE("SBML species",
     REQUIRE(s.getStorage("A_c1") == dbl_approx(1.0));
     s.setStorage("A_c1", 2.5);
     REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
-    // ignore invalid values
+    // S=0 is now valid
     s.setStorage("A_c1", 0.0);
+    REQUIRE(s.getStorage("A_c1") == dbl_approx(0.0));
+    // restore to positive for remaining tests
+    s.setStorage("A_c1", 2.5);
     REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
+    // ignore negative values
     s.setStorage("A_c1", -4.0);
     REQUIRE(s.getStorage("A_c1") == dbl_approx(2.5));
-    // persists via SBML annotations
+    // S=0 persists via SBML annotations
+    s.setStorage("A_c1", 0.0);
+    auto xml0{m.getXml().toStdString()};
+    model::Model m0;
+    m0.importSBMLString(xml0);
+    REQUIRE(m0.getSpecies().getStorage("A_c1") == dbl_approx(0.0));
+    // positive value persists via SBML annotations
+    s.setStorage("A_c1", 2.5);
     auto xml{m.getXml().toStdString()};
     model::Model m2;
     m2.importSBMLString(xml);

--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -18,6 +18,75 @@
 
 namespace sme::simulate {
 
+void PixelSim::solveZeroStorageConstraints() {
+  if (!hasAnyZeroStorageSpecies) {
+    return;
+  }
+  constexpr std::size_t maxIterations{100};
+  double nextRelaxDt = maxRelaxStableTimestep;
+  auto computeResidual = [this]() {
+    for (auto &sim : simCompartments) {
+      if (useTBB) {
+        sim->evaluateReactionsAndDiffusion_tbb();
+      } else {
+        sim->evaluateReactionsAndDiffusion();
+      }
+    }
+    for (auto &sim : simMembranes) {
+      sim->evaluateReactions();
+    }
+    for (auto &sim : simCompartments) {
+      sim->spatiallyAverageDcdt();
+    }
+  };
+  for (std::size_t iter = 0; iter < maxIterations; ++iter) {
+    // stage 1: evaluate residual
+    computeResidual();
+    // check convergence (both absolute and relative residual)
+    PixelIntegratorError residual{0.0, 0.0};
+    for (const auto &sim : simCompartments) {
+      auto compRes = sim->getZeroStorageResidual(epsilon);
+      residual.abs = std::max(residual.abs, compRes.abs);
+      residual.rel = std::max(residual.rel, compRes.rel);
+    }
+    if (residual.abs < errMax.abs && residual.rel < errMax.rel) {
+      return;
+    }
+    // adaptive RK212 step
+    double dt = nextRelaxDt;
+    // substep 1: save old, c += dt * dcdt for zero-storage species
+    for (auto &sim : simCompartments) {
+      sim->doRelaxSubstep1(dt);
+    }
+    // stage 2: evaluate residual at updated state
+    computeResidual();
+    // substep 2: c = 0.5*old + 0.5*c + 0.5*dt*dcdt (second-order)
+    for (auto &sim : simCompartments) {
+      sim->doRelaxSubstep2(dt);
+    }
+    // error estimate and adaptive timestep
+    PixelIntegratorError err{0.0, 0.0};
+    for (const auto &sim : simCompartments) {
+      auto compErr = sim->calculateRelaxError(epsilon);
+      err.rel = std::max(err.rel, compErr.rel);
+      err.abs = std::max(err.abs, compErr.abs);
+    }
+    double errFactor = std::min(errMax.abs / (err.abs + 1e-300),
+                                errMax.rel / (err.rel + 1e-300));
+    errFactor = std::sqrt(errFactor); // RK2 order
+    nextRelaxDt = std::min(0.95 * dt * errFactor, maxRelaxStableTimestep);
+    if (err.abs > errMax.abs || err.rel > errMax.rel) {
+      // error too large: undo step and retry with smaller dt
+      for (auto &sim : simCompartments) {
+        sim->undoRelaxStep();
+      }
+    }
+  }
+  SPDLOG_WARN("Zero-storage constraint solver did not converge after {} "
+              "iterations",
+              maxIterations);
+}
+
 void PixelSim::calculateDcdt() {
   // calculate dcd/dt in all compartments
   for (auto &sim : simCompartments) {
@@ -43,6 +112,7 @@ void PixelSim::calculateDcdt() {
 
 void PixelSim::doRK101(double dt) {
   // RK1(0)1: Forwards Euler, no error estimate
+  solveZeroStorageConstraints();
   calculateDcdt();
   for (auto &sim : simCompartments) {
     if (useTBB) {
@@ -57,6 +127,7 @@ void PixelSim::doRK212(double dt) {
   // RK2(1)2: Heun / Modified Euler, with embedded forwards Euler error
   // estimate Shu-Osher form used here taken from eq(2.15) of
   // https://doi.org/10.1016/0021-9991(88)90177-5
+  solveZeroStorageConstraints();
   calculateDcdt();
   for (auto &sim : simCompartments) {
     if (useTBB) {
@@ -65,6 +136,7 @@ void PixelSim::doRK212(double dt) {
       sim->doRK212Substep1(dt);
     }
   }
+  solveZeroStorageConstraints();
   calculateDcdt();
   for (auto &sim : simCompartments) {
     if (useTBB) {
@@ -129,6 +201,7 @@ void PixelSim::doRK435(double dt) {
 
 void PixelSim::doRKSubstep(double dt, double g1, double g2, double g3,
                            double beta, double delta) {
+  solveZeroStorageConstraints();
   calculateDcdt();
   for (auto &sim : simCompartments) {
     if (useTBB) {
@@ -260,6 +333,17 @@ PixelSim::PixelSim(
           spaceDependent, allUniformDiffusion, substitutions));
       maxStableTimestep = std::min(
           maxStableTimestep, simCompartments.back()->getMaxStableTimestep());
+      if (simCompartments.back()->getHasZeroStorageSpecies()) {
+        hasAnyZeroStorageSpecies = true;
+        maxRelaxStableTimestep =
+            std::min(maxRelaxStableTimestep,
+                     simCompartments.back()->getMaxRelaxStableTimestep());
+      }
+    }
+    if (hasAnyZeroStorageSpecies &&
+        maxRelaxStableTimestep == std::numeric_limits<double>::max()) {
+      // all zero-storage species have D=0: use fallback dt
+      maxRelaxStableTimestep = 1.0;
     }
     // add membranes
     for (const auto &membrane : doc.getMembranes().getMembranes()) {

--- a/core/simulate/src/pixelsim.hpp
+++ b/core/simulate/src/pixelsim.hpp
@@ -31,6 +31,7 @@ private:
   const model::Model &doc;
   double maxStableTimestep{std::numeric_limits<double>::max()};
   void calculateDcdt();
+  void solveZeroStorageConstraints();
   void doRK101(double dt);
   void doRK212(double dt);
   void doRK323(double dt);
@@ -40,6 +41,8 @@ private:
   double doRKAdaptive(double dtMax);
   std::size_t discardedSteps{0};
   PixelIntegratorType integrator;
+  bool hasAnyZeroStorageSpecies{false};
+  double maxRelaxStableTimestep{std::numeric_limits<double>::max()};
   PixelIntegratorError errMax;
   double maxTimestep{std::numeric_limits<double>::max()};
   double nextTimestep{1e-7};

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -141,26 +141,46 @@ SimCompartment::SimCompartment(
   for (const auto &s : speciesIds) {
     const auto *field = doc.getSpecies().getField(s.c_str());
     double storageValue = doc.getSpecies().getStorage(s.c_str());
-    if (storageValue <= 0.0) {
-      throw PixelSimImplError(
-          "Invalid non-positive storage value for species '" + s + "'");
+    if (storageValue < 0.0) {
+      throw PixelSimImplError("Invalid negative storage value for species '" +
+                              s + "'");
     }
-    double invStorageValue = 1.0 / storageValue;
-    invStorage.push_back(invStorageValue);
-    if (invStorageValue != 1.0) {
+    if (storageValue == 0.0) {
+      // Zero-storage species: algebraic constraint, not time-evolution
+      invStorage.push_back(0.0);
       hasNonUnitStorage = true;
+      hasZeroStorageSpecies = true;
+      zeroStorageSpeciesIndices.push_back(invStorage.size() - 1);
+    } else {
+      double invStorageValue = 1.0 / storageValue;
+      invStorage.push_back(invStorageValue);
+      if (invStorageValue != 1.0) {
+        hasNonUnitStorage = true;
+      }
     }
     if (useUniformDiffusionOperator) {
       const auto &diffArray = field->getDiffusionConstant();
       double d = diffArray.empty() ? 0.0 : diffArray.front();
       diffConstantsUniform.push_back(
           {d / dx2, d / dy2, d / dz2}); // dimensionless diffusion
-      maxStableTimestep =
-          std::min(maxStableTimestep,
-                   calculateMaxStableTimestep(
-                       {diffConstantsUniform.back()[0] * invStorageValue,
-                        diffConstantsUniform.back()[1] * invStorageValue,
-                        diffConstantsUniform.back()[2] * invStorageValue}));
+      if (storageValue == 0.0) {
+        // Zero-storage: compute CFL-based max stable relaxation dt
+        if (d > 0.0) {
+          maxRelaxStableTimestep =
+              std::min(maxRelaxStableTimestep,
+                       calculateMaxStableTimestep({d / dx2, d / dy2, d / dz2}));
+        } else {
+          SPDLOG_WARN("Species '{}' has S=0 and D=0: pure algebraic constraint",
+                      s);
+        }
+      } else {
+        maxStableTimestep =
+            std::min(maxStableTimestep,
+                     calculateMaxStableTimestep(
+                         {diffConstantsUniform.back()[0] * invStorage.back(),
+                          diffConstantsUniform.back()[1] * invStorage.back(),
+                          diffConstantsUniform.back()[2] * invStorage.back()}));
+      }
       SPDLOG_DEBUG("  - adding species: {}, diff constant {}, storage {}", s, d,
                    storageValue);
     } else {
@@ -173,11 +193,22 @@ SimCompartment::SimCompartment(
       double maxD{diffConstants.back().empty()
                       ? 0.0
                       : common::max(diffConstants.back())};
-      maxStableTimestep =
-          std::min(maxStableTimestep,
-                   calculateMaxStableTimestep({maxD * invStorageValue / dx2,
-                                               maxD * invStorageValue / dy2,
-                                               maxD * invStorageValue / dz2}));
+      if (storageValue == 0.0) {
+        if (maxD > 0.0) {
+          maxRelaxStableTimestep = std::min(
+              maxRelaxStableTimestep,
+              calculateMaxStableTimestep({maxD / dx2, maxD / dy2, maxD / dz2}));
+        } else {
+          SPDLOG_WARN("Species '{}' has S=0 and D=0: pure algebraic constraint",
+                      s);
+        }
+      } else {
+        maxStableTimestep = std::min(
+            maxStableTimestep,
+            calculateMaxStableTimestep({maxD * invStorage.back() / dx2,
+                                        maxD * invStorage.back() / dy2,
+                                        maxD * invStorage.back() / dz2}));
+      }
       SPDLOG_DEBUG("  - adding species: {}, diff constant (max) {}, storage {}",
                    s, maxD, storageValue);
     }
@@ -241,6 +272,10 @@ SimCompartment::SimCompartment(
   // setup concentrations vector with initial values
   conc.resize(nSpecies * nPixels);
   dcdt.resize(conc.size(), 0.0);
+  if (hasZeroStorageSpecies) {
+    relaxOld.resize(conc.size());
+    relaxFirstOrder.resize(conc.size());
+  }
   auto origin{doc.getGeometry().getPhysicalOrigin()};
   auto concIter{conc.begin()};
   for (std::size_t ix = 0; ix < compartment->nVoxels(); ++ix) {
@@ -472,14 +507,20 @@ void SimCompartment::undoRKStep_tbb() {
 
 PixelIntegratorError SimCompartment::calculateRKError(double epsilon) const {
   PixelIntegratorError err{0.0, 0.0};
-  std::size_t n{conc.size()};
-  for (std::size_t i = 0; i < n; ++i) {
-    double localErr = std::abs(conc[i] - s2[i]);
-    err.abs = std::max(err.abs, localErr);
-    // average current and previous concentrations and add a (hopefully) small
-    // constant term to avoid dividing by c=0 issues
-    double localNorm = 0.5 * (conc[i] + s3[i] + epsilon);
-    err.rel = std::max(err.rel, localErr / localNorm);
+  for (std::size_t ix = 0; ix < nPixels; ++ix) {
+    for (std::size_t is = 0; is < nSpecies; ++is) {
+      // skip zero-storage species: they are algebraically determined
+      if (invStorage[is] == 0.0) {
+        continue;
+      }
+      std::size_t i = ix * nSpecies + is;
+      double localErr = std::abs(conc[i] - s2[i]);
+      err.abs = std::max(err.abs, localErr);
+      // average current and previous concentrations and add a (hopefully) small
+      // constant term to avoid dividing by c=0 issues
+      double localNorm = 0.5 * (conc[i] + s3[i] + epsilon);
+      err.rel = std::max(err.rel, localErr / localNorm);
+    }
   }
   return err;
 }
@@ -490,18 +531,23 @@ std::string SimCompartment::plotRKError(common::ImageStack &images,
   images = {imageSize, QImage::Format_RGB32};
   images.fill(0);
   std::size_t iSpecies{nSpecies + 1};
-  for (std::size_t i = 0; i < conc.size(); ++i) {
-    double localErr = std::abs(conc[i] - s2[i]);
-    double localNorm = 0.5 * (conc[i] + s3[i] + epsilon);
-    double pixelIntensity{localErr / localNorm / max};
-    auto red{static_cast<int>(255.0 * pixelIntensity)};
-    auto voxel{comp->getVoxel(i / nSpecies)};
-    auto oldRed{qRed(images[voxel.z].pixel(voxel.p))};
-    if (red > oldRed) {
-      images[voxel.z].setPixel(voxel.p, qRgb(red, 0, 0));
-      if (red > 254) {
-        // update index of species with largest error
-        iSpecies = i % nSpecies;
+  for (std::size_t ix = 0; ix < nPixels; ++ix) {
+    for (std::size_t is = 0; is < nSpecies; ++is) {
+      if (invStorage[is] == 0.0) {
+        continue;
+      }
+      std::size_t i = ix * nSpecies + is;
+      double localErr = std::abs(conc[i] - s2[i]);
+      double localNorm = 0.5 * (conc[i] + s3[i] + epsilon);
+      double pixelIntensity{localErr / localNorm / max};
+      auto red{static_cast<int>(255.0 * pixelIntensity)};
+      auto voxel{comp->getVoxel(ix)};
+      auto oldRed{qRed(images[voxel.z].pixel(voxel.p))};
+      if (red > oldRed) {
+        images[voxel.z].setPixel(voxel.p, qRgb(red, 0, 0));
+        if (red > 254) {
+          iSpecies = is;
+        }
       }
     }
   }
@@ -509,6 +555,73 @@ std::string SimCompartment::plotRKError(common::ImageStack &images,
     return speciesNames[iSpecies];
   }
   return {};
+}
+
+bool SimCompartment::getHasZeroStorageSpecies() const {
+  return hasZeroStorageSpecies;
+}
+
+double SimCompartment::getMaxRelaxStableTimestep() const {
+  return maxRelaxStableTimestep;
+}
+
+void SimCompartment::doRelaxSubstep1(double dt) {
+  for (std::size_t is : zeroStorageSpeciesIndices) {
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      std::size_t i = ix * nSpecies + is;
+      relaxOld[i] = conc[i];
+      conc[i] += dt * dcdt[i];
+    }
+  }
+}
+
+void SimCompartment::doRelaxSubstep2(double dt) {
+  for (std::size_t is : zeroStorageSpeciesIndices) {
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      std::size_t i = ix * nSpecies + is;
+      relaxFirstOrder[i] = conc[i];
+      conc[i] = 0.5 * relaxOld[i] + 0.5 * conc[i] + 0.5 * dt * dcdt[i];
+    }
+  }
+}
+
+void SimCompartment::undoRelaxStep() {
+  for (std::size_t is : zeroStorageSpeciesIndices) {
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      std::size_t i = ix * nSpecies + is;
+      conc[i] = relaxOld[i];
+    }
+  }
+}
+
+PixelIntegratorError SimCompartment::calculateRelaxError(double epsilon) const {
+  PixelIntegratorError err{0.0, 0.0};
+  for (std::size_t is : zeroStorageSpeciesIndices) {
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      std::size_t i = ix * nSpecies + is;
+      double localErr = std::abs(conc[i] - relaxFirstOrder[i]);
+      err.abs = std::max(err.abs, localErr);
+      // match convention in calculateRKError: average current and pre-step
+      double localNorm = 0.5 * (conc[i] + relaxOld[i] + epsilon);
+      err.rel = std::max(err.rel, localErr / localNorm);
+    }
+  }
+  return err;
+}
+
+PixelIntegratorError
+SimCompartment::getZeroStorageResidual(double epsilon) const {
+  PixelIntegratorError res{0.0, 0.0};
+  for (std::size_t is : zeroStorageSpeciesIndices) {
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      std::size_t i = ix * nSpecies + is;
+      double absRes = std::abs(dcdt[i]);
+      res.abs = std::max(res.abs, absRes);
+      double norm = std::abs(conc[i]) + epsilon;
+      res.rel = std::max(res.rel, absRes / norm);
+    }
+  }
+  return res;
 }
 
 const std::string &SimCompartment::getCompartmentId() const {

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -62,12 +62,17 @@ private:
   std::vector<std::string> speciesIds;
   std::vector<std::string> speciesNames;
   std::vector<std::size_t> nonSpatialSpeciesIndices;
+  std::vector<std::size_t> zeroStorageSpeciesIndices;
+  std::vector<double> relaxOld;
+  std::vector<double> relaxFirstOrder;
   double maxStableTimestep = std::numeric_limits<double>::max();
+  double maxRelaxStableTimestep = std::numeric_limits<double>::max();
   double dx2{1.0};
   double dy2{1.0};
   double dz2{1.0};
   bool useUniformDiffusionOperator{false};
   bool hasNonUnitStorage{false};
+  bool hasZeroStorageSpecies{false};
 
 public:
   explicit SimCompartment(
@@ -113,6 +118,14 @@ public:
   [[nodiscard]] PixelIntegratorError calculateRKError(double epsilon) const;
   std::string plotRKError(common::ImageStack &images, double epsilon,
                           double max) const;
+  [[nodiscard]] bool getHasZeroStorageSpecies() const;
+  [[nodiscard]] double getMaxRelaxStableTimestep() const;
+  void doRelaxSubstep1(double dt);
+  void doRelaxSubstep2(double dt);
+  void undoRelaxStep();
+  [[nodiscard]] PixelIntegratorError calculateRelaxError(double epsilon) const;
+  [[nodiscard]] PixelIntegratorError
+  getZeroStorageResidual(double epsilon) const;
   [[nodiscard]] const std::string &getCompartmentId() const;
   [[nodiscard]] const std::vector<std::string> &getSpeciesIds() const;
   [[nodiscard]] const std::vector<double> &getConcentrations() const;

--- a/core/simulate/src/pixelsim_t.cpp
+++ b/core/simulate/src/pixelsim_t.cpp
@@ -46,6 +46,87 @@ TEST_CASE("PixelSim", "[core/simulate/pixelsim][core/"
       REQUIRE(cUniform[i] == dbl_approx(cArray[i]));
     }
   }
+  SECTION("Zero-storage species: PixelSim accepts S=0") {
+    auto m{getExampleModel(Mod::ABtoC)};
+    m.getSpecies().setStorage("C", 0.0);
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.enableMultiThreading = false;
+    options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options.pixel.maxTimestep = 1e-3;
+    std::vector<std::string> comps{"comp"};
+    std::vector<std::vector<std::string>> specs{{"A", "B", "C"}};
+    simulate::PixelSim sim(m, comps, specs);
+    REQUIRE(sim.errorMessage().empty());
+    // run a single step - should not crash or error
+    sim.run(1e-3, -1.0, {});
+    REQUIRE(sim.errorMessage().empty());
+    // dcdt for zero-storage species C should be zero after applyStorage
+    const auto &dcdt = sim.getDcdt(0);
+    for (std::size_t i = 0; i < dcdt.size() / 3; ++i) {
+      REQUIRE(dcdt[i * 3 + 2] == dbl_approx(0.0));
+    }
+  }
+  SECTION("Zero-storage species with D=0: pure algebraic constraint") {
+    auto m{getExampleModel(Mod::ABtoC)};
+    m.getSpecies().setStorage("C", 0.0);
+    // set D=0 for C so constraint is purely algebraic: 0 = R(c)
+    m.getSpecies().setDiffusionConstant("C", 0.0);
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.enableMultiThreading = false;
+    options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options.pixel.maxTimestep = 1e-3;
+    std::vector<std::string> comps{"comp"};
+    std::vector<std::vector<std::string>> specs{{"A", "B", "C"}};
+    simulate::PixelSim sim(m, comps, specs);
+    REQUIRE(sim.errorMessage().empty());
+    // should not crash or produce errors
+    sim.run(1e-3, -1.0, {});
+    REQUIRE(sim.errorMessage().empty());
+    // dcdt for zero-storage species C should be zero after applyStorage
+    const auto &dcdt = sim.getDcdt(0);
+    for (std::size_t i = 0; i < dcdt.size() / 3; ++i) {
+      REQUIRE(dcdt[i * 3 + 2] == dbl_approx(0.0));
+    }
+  }
+  SECTION("Zero-storage species: constraint solver reduces residual") {
+    // Use SingleCompartmentDiffusion model with S=0 for "slow" species
+    // With S=0 and D>0, constraint solver should reduce the residual
+    // compared to having no constraint solver
+    auto m{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    m.getSpecies().setStorage("slow", 0.0);
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.enableMultiThreading = false;
+    options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options.pixel.maxTimestep = 1e-3;
+    std::vector<std::string> comps{"circle"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim sim(m, comps, specs);
+    REQUIRE(sim.errorMessage().empty());
+    // run several steps - constraint solver should run without errors
+    sim.run(0.01, -1.0, {});
+    REQUIRE(sim.errorMessage().empty());
+    // after simulation, the "slow" species concentration should be more
+    // spatially uniform than the initial non-uniform state
+    const auto &conc = sim.getConcentrations(0);
+    std::size_t nSpecies = 2;
+    std::size_t nPixels = conc.size() / nSpecies;
+    REQUIRE(nPixels > 1);
+    double minVal = conc[0];
+    double maxVal = conc[0];
+    for (std::size_t ix = 0; ix < nPixels; ++ix) {
+      double val = conc[ix * nSpecies + 0];
+      minVal = std::min(minVal, val);
+      maxVal = std::max(maxVal, val);
+    }
+    // the range should be reduced relative to max value
+    double relRange = (maxVal - minVal) / maxVal;
+    CAPTURE(minVal);
+    CAPTURE(maxVal);
+    CAPTURE(relRange);
+    if (maxVal > 1e-12) {
+      REQUIRE(relRange < 0.75);
+    }
+  }
   SECTION("Storage scales dcdt for species") {
     auto mDefault{getExampleModel(Mod::ABtoC)};
     auto mStorage{getExampleModel(Mod::ABtoC)};

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -1132,6 +1132,41 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "Simulate: zero-storage species, dune vs pixel",
+    "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel]") {
+  // With S=0 and D>0, the constraint 0 = div(D grad c) should give spatially
+  // uniform c. Both DUNE and Pixel should agree.
+  auto s{getTestModel("small-single-compartment-diffusion")};
+  s.getSpecies().setStorage("slow", 0.0);
+  auto &options{s.getSimulationSettings().options};
+  options.pixel.maxErr = {1e-12, 1e-12};
+  options.pixel.maxThreads = 2;
+  options.dune.dt = 0.5;
+  for (auto simulator :
+       {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
+    CAPTURE(simulator);
+    s.getSimulationData().clear();
+    s.getSimulationSettings().simulatorType = simulator;
+    auto sim = simulate::Simulation(s);
+    REQUIRE(sim.errorMessage().empty());
+    auto simSteps =
+        std::async(std::launch::async, &simulate::Simulation::doTimesteps, &sim,
+                   5.0, 1, -1.0);
+    REQUIRE(simSteps.get() >= 1);
+    REQUIRE(sim.errorMessage().empty());
+    auto timeIndex = sim.getTimePoints().size() - 1;
+    // zero-storage species "slow" (index 0) should be spatially uniform
+    auto conc = sim.getAvgMinMax(timeIndex, 0, 0);
+    CAPTURE(conc.min);
+    CAPTURE(conc.avg);
+    CAPTURE(conc.max);
+    REQUIRE(conc.avg > 1e-12);
+    REQUIRE(std::abs((conc.min - conc.avg) / conc.avg) < 1e-6);
+    REQUIRE(std::abs((conc.max - conc.avg) / conc.avg) < 1e-6);
+  }
+}
+
+TEST_CASE(
     "Simulate: spatially varying diffusion steady state",
     "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel]") {
   SECTION("many steps: both species end up equally & uniformly distributed") {

--- a/docs/quickstart/species.rst
+++ b/docs/quickstart/species.rst
@@ -40,7 +40,7 @@ Two more properties of a species are of primary importance.
 With the definition of these two elements, the species is fully defined and can be used in the next steps of the model definition.
 
 :Storage coefficient (Advanced):
-   In the species `Advanced` section, you can set a positive, dimensionless storage coefficient :math:`S`.
+   In the species `Advanced` section, you can set a non-negative, dimensionless storage coefficient :math:`S`.
    This scales the species time derivative in the PDE:
 
    .. math::
@@ -49,6 +49,10 @@ With the definition of these two elements, the species is fully defined and can 
 
    The default is :math:`S=1`, which gives the standard reaction-diffusion form.
    Larger :math:`S` values make concentration changes slower in time, while values between 0 and 1 make them faster.
+
+   Setting :math:`S=0` converts the equation into an algebraic constraint :math:`0 = \nabla \cdot (D \nabla c) + R`,
+   meaning the species concentration is determined by satisfying this constraint at each timestep
+   rather than being integrated in time.
 
 
 .. note::

--- a/docs/reference/maths.rst
+++ b/docs/reference/maths.rst
@@ -15,14 +15,23 @@ where
 * :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y, z)` and time :math:`t`
 * :math:`D_s` is the (possibly spatially varying) scalar diffusion constant for species :math:`s`
 * :math:`R_s` is the reaction term for species :math:`s`
-* :math:`S_s` is the species storage coefficient (dimensionless, positive, default :math:`1`)
+* :math:`S_s` is the species storage coefficient (dimensionless, non-negative, default :math:`1`)
 
 and we assume that
 
 * the diffusion constant :math:`D_s` is isotropic (a scalar, not a tensor)
 * the reaction term :math:`R_s` is a function that can depend on the concentrations of other species in the model, but only locally, i.e. the concentrations at the same spatial coordinate.
 
-Equivalently,
+When :math:`S_s = 0`, the equation becomes an algebraic constraint rather than a time-evolution equation:
+
+.. math::
+
+   0 = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
+
+The concentration of such a species is not integrated in time, but is instead determined at each timestep
+by satisfying this constraint. See the :doc:`pixel` documentation for details on how the Pixel solver handles this case.
+
+For :math:`S_s > 0`, the equation can equivalently be written as
 
 .. math::
 

--- a/docs/reference/pixel.rst
+++ b/docs/reference/pixel.rst
@@ -60,7 +60,7 @@ where the value with index :math:`(i,j,k)` corresponds to the concentration
 at the spatial point :math:`(x = i \delta x, y = j \delta y, z = k \delta z)`.
 
 For diffusion constants that vary in space, the diffusion term is written in conservative form.
-With species storage coefficient :math:`S>0`, the PDE is
+With species storage coefficient :math:`S \geq 0`, the PDE is
 
 .. math::
 
@@ -276,6 +276,8 @@ We use the embedded lower order solution to estimate the error at each timestep,
 
    An example of the difference between order p and order p-1 solutions from embedded schemes as a function of the stepsize. This quantity is a measure of the local integration error, and scales like :math:`h^p`
 
+.. _maximum-timestep:
+
 Maximum timestep
 ----------------
 
@@ -315,6 +317,61 @@ Membranes
 ^^^^^^^^^
 
 Reactions that take place between two compartments involve a flux across the membrane separating the two compartments. For each neighbouring pair of pixels from the two compartments, whose common boundary constitutes the membrane, the flux term is converted into a reaction term that creates or destroys the appropriate amount of species concentration in each pixel.
+
+Zero-storage species
+^^^^^^^^^^^^^^^^^^^^
+
+When a species has storage coefficient :math:`S = 0`, its PDE becomes an algebraic constraint:
+
+.. math::
+
+   0 = \nabla \cdot \left( D \nabla c \right) + R
+
+Rather than being integrated forward in time, the concentration of such a species must satisfy this constraint at every timestep. The Pixel solver handles this via operator splitting with adaptive pseudo-time relaxation.
+
+**Operator splitting.** Zero-storage species are excluded from the main Runge-Kutta time integration.
+Their ``dcdt`` is set to zero by the storage term (since :math:`1/S` is treated as zero),
+so the RK stepper leaves their concentrations unchanged.
+Instead, a separate constraint solver is called before each evaluation of the right-hand side
+(i.e. before each RK stage), ensuring that time-integrated species always see
+zero-storage concentrations that satisfy the constraint.
+
+**Adaptive pseudo-time relaxation.** The constraint is solved by introducing a fictitious time
+:math:`\tau` and integrating the pseudo-time equation
+
+.. math::
+
+   \frac{\partial c}{\partial \tau} = \nabla \cdot \left( D \nabla c \right) + R
+
+to steady state. This is done using the same embedded RK2(1)2 (Heun) integrator
+used for the main time integration, with adaptive step size control.
+The pseudo-timestep is bounded by the CFL stability condition:
+
+.. math::
+
+   \delta \tau \leq \frac{1}{2 D_{\max} \left(\frac{1}{\delta x^2}+\frac{1}{\delta y^2}+\frac{1}{\delta z^2}\right)}
+
+where :math:`D_{\max}` is the largest diffusion constant over all voxels for the zero-storage species.
+
+**Convergence criteria.** The relaxation iterations stop when the residual
+:math:`r = \nabla \cdot (D \nabla c) + R` is small enough.
+The same error tolerances (max absolute and max relative local error) configured for the
+main time integrator are used as convergence thresholds: the absolute residual
+must be below the configured max absolute error, and the relative residual
+(normalised by the species concentration) must be below the configured max relative error.
+A maximum of 100 iterations is allowed; if convergence is not reached, a warning is logged.
+
+**Error estimation.** Zero-storage species are excluded from the main RK error estimation,
+since they are not time-integrated and their accuracy is controlled by the constraint solver instead.
+
+**CFL bound.** Zero-storage species do not contribute to the maximum stable timestep
+for the main RK integrator, since the storage coefficient :math:`S` appears in the numerator of
+the CFL bound (see the :ref:`maximum-timestep` section).
+
+**Special case: D = 0 and S = 0.** When both diffusion and storage are zero,
+the constraint reduces to :math:`0 = R(c)`, a purely algebraic equation.
+The relaxation solver uses a fallback pseudo-timestep in this case,
+but convergence depends on the structure of :math:`R`.
 
 Non-spatial species
 ^^^^^^^^^^^^^^^^^^^

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -430,7 +430,7 @@ void TabSpecies::btnEditImageDiffusionConstant_clicked() {
 void TabSpecies::txtStorage_editingFinished() {
   bool ok{false};
   double storage = ui->txtStorage->text().toDouble(&ok);
-  if (!ok || storage <= 0.0) {
+  if (!ok || storage < 0.0) {
     ui->txtStorage->setText(
         QString::number(model.getSpecies().getStorage(currentSpeciesId)));
     return;


### PR DESCRIPTION
- when a species has zero storage, there is no dc/dt term
- in this case, we evaluate the residual for these species before each RK step
- then we treat the residual as a dc/dt term and do some RK iteration with adaptive RK2(1) timestepping
- once it gets close enough to zero (using the same abs/rel tolerances as for the timestepping) we stop
- this is repeated before every RK step, so that the algebraic equations are approximately correct at each RK step
- resolves #1116
