### PR TITLE
Add support for cross-diffusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ artifacts/*
 sme/test/__pycache__
 .cache
 .clangd
+.idea

--- a/core/model/include/sme/model_settings.hpp
+++ b/core/model/include/sme/model_settings.hpp
@@ -76,6 +76,8 @@ struct Settings {
   std::vector<QRgb> sampledFieldColors{};
   std::map<std::string, std::vector<double>> speciesDiffusionConstantArrays{};
   std::map<std::string, std::string> speciesAnalyticDiffusionConstants{};
+  std::map<std::string, std::map<std::string, std::string>>
+      speciesCrossDiffusionConstants{};
   std::map<std::string, double> speciesStorageValues{};
 
   template <class Archive>
@@ -111,7 +113,8 @@ struct Settings {
          CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors),
          CEREAL_NVP(speciesDiffusionConstantArrays),
          CEREAL_NVP(speciesAnalyticDiffusionConstants),
-         CEREAL_NVP(speciesStorageValues));
+         CEREAL_NVP(speciesStorageValues),
+         CEREAL_NVP(speciesCrossDiffusionConstants));
     }
   }
 };

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -52,6 +52,7 @@ private:
   void setFieldDiffAnalytic(
       geometry::Field &field, const std::string &expr,
       const std::map<std::string, double, std::less<>> &substitutions = {});
+  void removeInvalidCrossDiffusionConstants();
 
 public:
   ModelSpecies();
@@ -106,6 +107,16 @@ public:
   void setAnalyticDiffusionConstant(const QString &id,
                                     const QString &analyticExpression);
   [[nodiscard]] QString getAnalyticDiffusionConstant(const QString &id) const;
+  [[nodiscard]] bool
+  isValidCrossDiffusionExpression(const QString &id,
+                                  const QString &expression) const;
+  void setCrossDiffusionConstant(const QString &id, const QString &otherId,
+                                 const QString &expression);
+  void removeCrossDiffusionConstant(const QString &id, const QString &otherId);
+  [[nodiscard]] QString getCrossDiffusionConstant(const QString &id,
+                                                  const QString &otherId) const;
+  [[nodiscard]] std::map<std::string, std::string>
+  getCrossDiffusionConstants(const QString &id) const;
   [[nodiscard]] common::ImageStack
   getConcentrationImages(const QString &id) const;
   void setColor(const QString &id, QRgb color);

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -8,6 +8,7 @@
 #include "sme/model_parameters.hpp"
 #include "sme/model_reactions.hpp"
 #include "sme/simulate_data.hpp"
+#include "sme/symbolic.hpp"
 #include "sme/utils.hpp"
 #include "sme/xml_annotation.hpp"
 #include <QString>
@@ -304,6 +305,7 @@ ModelSpecies::ModelSpecies(libsbml::Model *model,
       field.importDiffusionConstant(iter->second);
     }
   }
+  removeInvalidCrossDiffusionConstants();
 }
 
 void ModelSpecies::setReactionsPtr(ModelReactions *reactions) {
@@ -381,6 +383,12 @@ void ModelSpecies::remove(const QString &id) {
   sbmlAnnotation->speciesColors.erase(sId);
   sbmlAnnotation->speciesDiffusionConstantArrays.erase(sId);
   sbmlAnnotation->speciesAnalyticDiffusionConstants.erase(sId);
+  sbmlAnnotation->speciesCrossDiffusionConstants.erase(sId);
+  for (auto &[targetSpeciesId, sourceSpeciesToExpr] :
+       sbmlAnnotation->speciesCrossDiffusionConstants) {
+    Q_UNUSED(targetSpeciesId);
+    sourceSpeciesToExpr.erase(sId);
+  }
   sbmlAnnotation->speciesStorageValues.erase(sId);
   compartmentIds.removeAt(i);
   removeInitialAssignment(sId.c_str());
@@ -392,6 +400,7 @@ void ModelSpecies::remove(const QString &id) {
     SPDLOG_INFO("Removing diffusion constant parameter '{}'", param->getId());
     param->removeFromParentAndDelete();
   }
+  removeInvalidCrossDiffusionConstants();
   SPDLOG_INFO("  - species {} removed", spec->getId());
 }
 
@@ -477,6 +486,7 @@ void ModelSpecies::setCompartment(const QString &id,
     }
     field.setUniformDiffusionConstant(uniformDiffusionConstant);
   }
+  removeInvalidCrossDiffusionConstants();
 }
 
 QString ModelSpecies::getCompartment(const QString &id) const {
@@ -711,6 +721,41 @@ void ModelSpecies::setFieldDiffAnalytic(
   field.setIsUniformDiffusionConstant(false);
 }
 
+void ModelSpecies::removeInvalidCrossDiffusionConstants() {
+  if (sbmlAnnotation == nullptr) {
+    return;
+  }
+  auto &crossDiffusion{sbmlAnnotation->speciesCrossDiffusionConstants};
+  for (auto targetSpeciesIt = crossDiffusion.begin();
+       targetSpeciesIt != crossDiffusion.end();) {
+    const QString targetSpeciesId{targetSpeciesIt->first.c_str()};
+    if (!ids.contains(targetSpeciesId)) {
+      targetSpeciesIt = crossDiffusion.erase(targetSpeciesIt);
+      continue;
+    }
+    const auto compartmentId{getCompartment(targetSpeciesId)};
+    auto &sourceSpeciesToExpr{targetSpeciesIt->second};
+    for (auto sourceSpeciesIt = sourceSpeciesToExpr.begin();
+         sourceSpeciesIt != sourceSpeciesToExpr.end();) {
+      const QString sourceSpeciesId{sourceSpeciesIt->first.c_str()};
+      const bool invalidPair{sourceSpeciesIt->second.empty() ||
+                             sourceSpeciesId == targetSpeciesId ||
+                             !ids.contains(sourceSpeciesId) ||
+                             getCompartment(sourceSpeciesId) != compartmentId};
+      if (invalidPair) {
+        sourceSpeciesIt = sourceSpeciesToExpr.erase(sourceSpeciesIt);
+      } else {
+        ++sourceSpeciesIt;
+      }
+    }
+    if (sourceSpeciesToExpr.empty()) {
+      targetSpeciesIt = crossDiffusion.erase(targetSpeciesIt);
+    } else {
+      ++targetSpeciesIt;
+    }
+  }
+}
+
 void ModelSpecies::updateAllAnalyticConcentrations() {
   for (auto &field : fields) {
     const auto analyticConcentration{
@@ -853,6 +898,99 @@ ModelSpecies::getAnalyticDiffusionConstant(const QString &id) const {
           id.toStdString());
       it != sbmlAnnotation->speciesAnalyticDiffusionConstants.cend()) {
     return it->second.c_str();
+  }
+  return {};
+}
+
+bool ModelSpecies::isValidCrossDiffusionExpression(
+    const QString &id, const QString &expression) const {
+  const auto compartmentId{getCompartment(id)};
+  if (compartmentId.isEmpty() || expression.trimmed().isEmpty()) {
+    return false;
+  }
+  const auto expr{expression.toStdString()};
+  if (mathStringToAST(expr, sbmlModel) == nullptr) {
+    return false;
+  }
+  auto inlinedExpr = inlineFunctions(expr, *modelFunctions);
+  inlinedExpr = inlineAssignments(inlinedExpr, sbmlModel);
+  std::vector<std::string> variableIds;
+  for (const auto &symbol : modelParameters->getSymbols({compartmentId})) {
+    variableIds.push_back(symbol.id);
+  }
+  return common::Symbolic(inlinedExpr, variableIds).isValid();
+}
+
+void ModelSpecies::setCrossDiffusionConstant(const QString &id,
+                                             const QString &otherId,
+                                             const QString &expression) {
+  if (id == otherId) {
+    SPDLOG_WARN("Ignoring cross-diffusion: species '{}' cannot depend on "
+                "itself",
+                id.toStdString());
+    return;
+  }
+  const auto idCompartment{getCompartment(id)};
+  if (idCompartment.isEmpty() || idCompartment != getCompartment(otherId)) {
+    SPDLOG_WARN("Ignoring cross-diffusion: species '{}' and '{}' are in "
+                "different compartments",
+                id.toStdString(), otherId.toStdString());
+    return;
+  }
+  const auto trimmedExpression{expression.trimmed()};
+  if (trimmedExpression.isEmpty() || trimmedExpression == "0" ||
+      trimmedExpression == "0.0") {
+    removeCrossDiffusionConstant(id, otherId);
+    return;
+  }
+  if (!isValidCrossDiffusionExpression(id, trimmedExpression)) {
+    SPDLOG_ERROR("Failed to parse cross-diffusion expression '{}'",
+                 trimmedExpression.toStdString());
+    return;
+  }
+  hasUnsavedChanges = true;
+  sbmlAnnotation->speciesCrossDiffusionConstants[id.toStdString()]
+                                                [otherId.toStdString()] =
+      trimmedExpression.toStdString();
+  removeInvalidCrossDiffusionConstants();
+}
+
+void ModelSpecies::removeCrossDiffusionConstant(const QString &id,
+                                                const QString &otherId) {
+  if (auto targetSpeciesIt =
+          sbmlAnnotation->speciesCrossDiffusionConstants.find(id.toStdString());
+      targetSpeciesIt != sbmlAnnotation->speciesCrossDiffusionConstants.end()) {
+    const auto erased{targetSpeciesIt->second.erase(otherId.toStdString()) >
+                      0U};
+    if (targetSpeciesIt->second.empty()) {
+      sbmlAnnotation->speciesCrossDiffusionConstants.erase(targetSpeciesIt);
+    }
+    if (erased) {
+      hasUnsavedChanges = true;
+    }
+  }
+}
+
+QString ModelSpecies::getCrossDiffusionConstant(const QString &id,
+                                                const QString &otherId) const {
+  if (auto targetSpeciesIt =
+          sbmlAnnotation->speciesCrossDiffusionConstants.find(id.toStdString());
+      targetSpeciesIt != sbmlAnnotation->speciesCrossDiffusionConstants.end()) {
+    if (auto sourceSpeciesIt =
+            targetSpeciesIt->second.find(otherId.toStdString());
+        sourceSpeciesIt != targetSpeciesIt->second.end()) {
+      return sourceSpeciesIt->second.c_str();
+    }
+  }
+  return {};
+}
+
+std::map<std::string, std::string>
+ModelSpecies::getCrossDiffusionConstants(const QString &id) const {
+  if (auto targetSpeciesIt =
+          sbmlAnnotation->speciesCrossDiffusionConstants.find(id.toStdString());
+      targetSpeciesIt != sbmlAnnotation->speciesCrossDiffusionConstants.end()) {
+    return targetSpeciesIt->second;
   }
   return {};
 }

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -494,4 +494,60 @@ TEST_CASE("SBML species",
     // unknown species defaults to 1
     REQUIRE(m2.getSpecies().getStorage("does_not_exist") == dbl_approx(1.0));
   }
+  SECTION("Cross-diffusion constants") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &s{m.getSpecies()};
+
+    REQUIRE(s.getCrossDiffusionConstants("B_c1").empty());
+    REQUIRE(s.getCrossDiffusionConstant("B_c1", "A_c1").isEmpty());
+    REQUIRE(s.isValidCrossDiffusionExpression("B_c1", "A_c1 + param"));
+    REQUIRE(!s.isValidCrossDiffusionExpression("B_c1", ""));
+    REQUIRE(!s.isValidCrossDiffusionExpression("B_c1", "A_c1 + *"));
+    REQUIRE(!s.isValidCrossDiffusionExpression("does_not_exist", "1"));
+
+    s.setCrossDiffusionConstant("B_c1", "A_c1", " 1 + A_c1 + param ");
+    REQUIRE(
+        symEq(s.getCrossDiffusionConstant("B_c1", "A_c1"), "1 + A_c1 + param"));
+    REQUIRE(s.getCrossDiffusionConstants("B_c1").size() == 1);
+
+    // invalid target/source pairs are ignored
+    s.setHasUnsavedChanges(false);
+    s.setCrossDiffusionConstant("B_c1", "B_c1", "2");
+    REQUIRE(s.getHasUnsavedChanges() == false);
+    s.setCrossDiffusionConstant("B_c1", "A_c2", "2");
+    REQUIRE(s.getCrossDiffusionConstants("B_c1").size() == 1);
+
+    // invalid expression is ignored
+    s.setCrossDiffusionConstant("B_c1", "A_c1", "A_c1 + *");
+    REQUIRE(
+        symEq(s.getCrossDiffusionConstant("B_c1", "A_c1"), "1 + A_c1 + param"));
+
+    // zero removes term
+    s.setCrossDiffusionConstant("B_c1", "A_c1", "0");
+    REQUIRE(s.getCrossDiffusionConstant("B_c1", "A_c1").isEmpty());
+    REQUIRE(s.getCrossDiffusionConstants("B_c1").empty());
+
+    // removing absent term is a no-op
+    s.setHasUnsavedChanges(false);
+    s.removeCrossDiffusionConstant("B_c1", "A_c1");
+    REQUIRE(s.getHasUnsavedChanges() == false);
+
+    // relocation removes invalid cross-compartment entries
+    s.setCrossDiffusionConstant("A_c2", "B_c2", "3");
+    s.setCrossDiffusionConstant("B_c2", "A_c2", "4");
+    REQUIRE(!s.getCrossDiffusionConstant("A_c2", "B_c2").isEmpty());
+    REQUIRE(!s.getCrossDiffusionConstant("B_c2", "A_c2").isEmpty());
+    s.setCompartment("A_c2", "c1");
+    REQUIRE(s.getCrossDiffusionConstant("A_c2", "B_c2").isEmpty());
+    REQUIRE(s.getCrossDiffusionConstant("B_c2", "A_c2").isEmpty());
+
+    // removing a species removes outgoing and incoming terms
+    s.setCrossDiffusionConstant("B_c1", "A_c1", "5");
+    s.setCrossDiffusionConstant("A_c1", "B_c1", "6");
+    REQUIRE(!s.getCrossDiffusionConstant("B_c1", "A_c1").isEmpty());
+    REQUIRE(!s.getCrossDiffusionConstant("A_c1", "B_c1").isEmpty());
+    s.remove("A_c1");
+    REQUIRE(s.getCrossDiffusionConstant("B_c1", "A_c1").isEmpty());
+    REQUIRE(s.getCrossDiffusionConstants("A_c1").empty());
+  }
 }

--- a/core/model/src/model_t.cpp
+++ b/core/model/src/model_t.cpp
@@ -174,6 +174,14 @@ TEST_CASE("SBML: import SBML doc without geometry",
       s.getSpecies().setDiffusionConstant("spec1c0", 0.999999);
       s.getSpecies().setDiffusionConstant("spec0c1", 23.1 + 1e-12);
       s.getSpecies().setAnalyticDiffusionConstant("spec1c0", "x+1");
+      s.getSpecies().setCrossDiffusionConstant("spec1c0", "spec0c0",
+                                               "spec0c0 + 1");
+      REQUIRE(
+          symEq(s.getSpecies().getCrossDiffusionConstant("spec1c0", "spec0c0"),
+                "spec0c0 + 1"));
+      REQUIRE(s.getSpecies()
+                  .getCrossDiffusionConstant("spec1c0", "spec0c1")
+                  .isEmpty());
       const auto spec1c0DiffusionBeforeInvalidExpr =
           s.getSpecies().getField("spec1c0")->getDiffusionConstant();
       s.getSpecies().setAnalyticDiffusionConstant("spec1c0", "x+(");
@@ -244,6 +252,12 @@ TEST_CASE("SBML: import SBML doc without geometry",
               model::SpatialDataType::Image);
       REQUIRE(symEq(s2.getSpecies().getAnalyticDiffusionConstant("spec1c0"),
                     "x + 1"));
+      REQUIRE(
+          symEq(s2.getSpecies().getCrossDiffusionConstant("spec1c0", "spec0c0"),
+                "spec0c0 + 1"));
+      REQUIRE(s2.getSpecies()
+                  .getCrossDiffusionConstant("spec1c0", "spec0c1")
+                  .isEmpty());
       REQUIRE(s2.getSpecies().getSampledFieldDiffusionConstant("spec0c1") ==
               spec0c1DiffArray);
     }

--- a/core/model/src/xml_annotation_t.cpp
+++ b/core/model/src/xml_annotation_t.cpp
@@ -1,4 +1,5 @@
 #include "catch_wrapper.hpp"
+#include "math_test_utils.hpp"
 #include "model_test_utils.hpp"
 #include "sme/simulate_options.hpp"
 #include "sme/xml_annotation.hpp"
@@ -38,6 +39,7 @@ TEST_CASE("XML Annotations",
     auto &optParam{optimizeOptions.optParams.emplace_back()};
     optParam.name = "myOptParam";
     settings.speciesStorageValues["A"] = 2.5;
+    settings.speciesCrossDiffusionConstants["A"]["B"] = "A + 1";
     // todo: populate all fields above
 
     model::setSbmlAnnotation(model, settings);
@@ -70,6 +72,8 @@ TEST_CASE("XML Annotations",
     REQUIRE(newOptimizeOptions.optParams[0].name == "myOptParam");
     REQUIRE(newSettings.speciesStorageValues.size() == 1);
     REQUIRE(newSettings.speciesStorageValues["A"] == dbl_approx(2.5));
+    REQUIRE(
+        symEq(newSettings.speciesCrossDiffusionConstants["A"]["B"], "A + 1"));
 
     // change options, save & write to file
     newSimulationSettings.times.push_back({7, 0.33});
@@ -79,6 +83,7 @@ TEST_CASE("XML Annotations",
     newOptimizeOptions.optCosts.emplace_back().name = "optCost2";
     newOptimizeOptions.optParams[0].name = "newOptParamName";
     newSettings.speciesStorageValues["A"] = 1.22;
+    newSettings.speciesCrossDiffusionConstants["A"]["B"] = "A + 2";
     model::setSbmlAnnotation(model, newSettings);
     libsbml::writeSBMLToFile(doc.get(), "tmpxmlsettings.xml");
 
@@ -114,6 +119,7 @@ TEST_CASE("XML Annotations",
     REQUIRE(optimizeOptions2.optParams[0].name == "newOptParamName");
     REQUIRE(settings2.speciesStorageValues.size() == 1);
     REQUIRE(settings2.speciesStorageValues["A"] == dbl_approx(1.22));
+    REQUIRE(symEq(settings2.speciesCrossDiffusionConstants["A"]["B"], "A + 2"));
   }
   SECTION("Invalid settings annotations") {
     auto doc{getTestSbmlDoc("ABtoC-invalid-annotation")};
@@ -127,5 +133,6 @@ TEST_CASE("XML Annotations",
     REQUIRE(settings.optimizeOptions.optParams.empty());
     REQUIRE(settings.speciesColors.empty());
     REQUIRE(settings.speciesStorageValues.empty());
+    REQUIRE(settings.speciesCrossDiffusionConstants.empty());
   }
 }

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -12,6 +12,7 @@
 #include "sme/model.hpp"
 #include "sme/pde.hpp"
 #include "sme/simulate_options.hpp"
+#include "sme/symbolic.hpp"
 #include "sme/tiff.hpp"
 #include "sme/utils.hpp"
 #include <QDir>
@@ -21,6 +22,7 @@
 #include <fstream>
 #include <memory>
 #include <numeric>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -92,6 +94,48 @@ static void addTimeStepping(IniFile &ini,
 static void addWriter(IniFile &ini) {
   ini.addSection("model", "writer.vtk");
   ini.addValue("path", "vtk");
+}
+
+static std::pair<std::string, std::vector<std::string>>
+getCrossDiffusionExpressionAndJacobian(
+    const model::Model &model, const std::string &expression,
+    const std::vector<std::string> &speciesIds,
+    const std::vector<std::string> &duneSpeciesIds,
+    const std::vector<std::string> &extraVariables,
+    const std::vector<std::string> &relabelledExtraVariables,
+    double speciesScaleFactor,
+    const std::map<std::string, double, std::less<>> &substitutions) {
+  std::vector<std::pair<std::string, double>> constants;
+  for (const auto &constant : model.getParameters().getGlobalConstants()) {
+    double value = constant.value;
+    if (auto it = substitutions.find(constant.id); it != substitutions.end()) {
+      value = it->second;
+    }
+    constants.emplace_back(constant.id, value);
+  }
+  auto inlinedExpression{model.inlineExpr(expression)};
+  auto variables{speciesIds};
+  variables.insert(variables.end(), extraVariables.cbegin(),
+                   extraVariables.cend());
+  common::Symbolic symbolicCrossDiffusion(inlinedExpression, variables,
+                                          constants);
+  if (!symbolicCrossDiffusion.isValid()) {
+    throw std::runtime_error(fmt::format(
+        "Invalid cross-diffusion expression '{}': {}", inlinedExpression,
+        symbolicCrossDiffusion.getErrorMessage()));
+  }
+  symbolicCrossDiffusion.rescale(speciesScaleFactor, extraVariables);
+  auto relabelledVariables{duneSpeciesIds};
+  relabelledVariables.insert(relabelledVariables.end(),
+                             relabelledExtraVariables.cbegin(),
+                             relabelledExtraVariables.cend());
+  symbolicCrossDiffusion.relabel(relabelledVariables);
+  std::vector<std::string> jacobianExpressions;
+  jacobianExpressions.reserve(duneSpeciesIds.size());
+  for (const auto &speciesId : duneSpeciesIds) {
+    jacobianExpressions.push_back(symbolicCrossDiffusion.diff(speciesId));
+  }
+  return {symbolicCrossDiffusion.inlinedExpr(), jacobianExpressions};
 }
 
 static void addCompartment(
@@ -259,6 +303,32 @@ static void addCompartment(
     } else {
       ini.addValue(QString("cross_diffusion.%1.expression").arg(duneName),
                    f->getDiffusionConstant()[0], doublePrecision);
+    }
+    // off-diagonal cross-diffusion terms and jacobians
+    for (std::size_t j = 0; j < nSpecies; ++j) {
+      if (j == i) {
+        continue;
+      }
+      const QString sourceSpeciesId{nonConstantSpecies[j].c_str()};
+      const auto crossDiffusionExpression{
+          model.getSpecies().getCrossDiffusionConstant(sId, sourceSpeciesId)};
+      if (crossDiffusionExpression.isEmpty()) {
+        continue;
+      }
+      auto [crossExpression, crossJacobian] =
+          getCrossDiffusionExpressionAndJacobian(
+              model, crossDiffusionExpression.toStdString(), nonConstantSpecies,
+              duneSpeciesNames, extraReactionVars, relabelledExtraReactionVars,
+              volOverL3, substitutions);
+      ini.addValue(QString("cross_diffusion.%1.expression")
+                       .arg(duneSpeciesNames[j].c_str()),
+                   crossExpression.c_str());
+      for (std::size_t k = 0; k < nSpecies; ++k) {
+        ini.addValue(
+            QString("cross_diffusion.%1.jacobian.%2.expression")
+                .arg(duneSpeciesNames[j].c_str(), duneSpeciesNames[k].c_str()),
+            crossJacobian[k].c_str());
+      }
     }
 
     // membrane flux terms

--- a/core/simulate/src/duneconverter_t.cpp
+++ b/core/simulate/src/duneconverter_t.cpp
@@ -52,6 +52,26 @@ TEST_CASE("DUNE: DuneConverter",
     REQUIRE(*line++ == "initial.expression = 0");
     REQUIRE(*line++ == "storage.expression = 2.5");
   }
+  SECTION("ABtoC model with off-diagonal cross-diffusion") {
+    auto s{getExampleModel(Mod::ABtoC)};
+    s.getSpecies().setCrossDiffusionConstant("C", "A", "2");
+    simulate::DuneConverter dc(s, {}, true, {}, 14);
+    QStringList ini = dc.getIniFile().split("\n");
+    auto line = find_line("[model.scalar_field.C]", ini);
+    REQUIRE(*line++ == "[model.scalar_field.C]");
+    REQUIRE(*line++ == "compartment = comp");
+    REQUIRE(*line++ == "initial.expression = 0");
+    REQUIRE(*line++ == "storage.expression = 1");
+    REQUIRE(symEq(*line++, "reaction.expression = 0.0001*A*B"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.A.expression = 0.0001*B"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.B.expression = 0.0001*A"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.C.expression = 0"));
+    REQUIRE(symEq(*line++, "cross_diffusion.C.expression = 25"));
+    REQUIRE(symEq(*line++, "cross_diffusion.A.expression = 2"));
+    REQUIRE(symEq(*line++, "cross_diffusion.A.jacobian.A.expression = 0"));
+    REQUIRE(symEq(*line++, "cross_diffusion.A.jacobian.B.expression = 0"));
+    REQUIRE(symEq(*line++, "cross_diffusion.A.jacobian.C.expression = 0"));
+  }
   SECTION("brusselator model") {
     auto s{getExampleModel(Mod::Brusselator)};
     simulate::DuneConverter dc(s);

--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -3,6 +3,7 @@
 #include "sme/geometry.hpp"
 #include "sme/logger.hpp"
 #include "sme/model.hpp"
+#include "sme/simple_symbolic.hpp"
 #include "sme/utils.hpp"
 #include <QElapsedTimer>
 #include <QString>
@@ -89,12 +90,15 @@ void PixelSim::solveZeroStorageConstraints() {
 
 void PixelSim::calculateDcdt() {
   // calculate dcd/dt in all compartments
+  maxStableTimestep = std::numeric_limits<double>::max();
   for (auto &sim : simCompartments) {
     if (useTBB) {
       sim->evaluateReactionsAndDiffusion_tbb();
     } else {
       sim->evaluateReactionsAndDiffusion();
     }
+    maxStableTimestep =
+        std::min(maxStableTimestep, sim->getMaxStableTimestep());
   }
   // membrane contribution to dc/dt
   for (auto &sim : simMembranes) {
@@ -110,17 +114,24 @@ void PixelSim::calculateDcdt() {
   }
 }
 
-void PixelSim::doRK101(double dt) {
+double PixelSim::doRK101(double dt) {
   // RK1(0)1: Forwards Euler, no error estimate
   solveZeroStorageConstraints();
   calculateDcdt();
+  dt = std::min(dt, maxStableTimestep);
   for (auto &sim : simCompartments) {
     if (useTBB) {
       sim->doForwardsEulerTimestep_tbb(dt);
     } else {
       sim->doForwardsEulerTimestep(dt);
     }
+    if (useTBB) {
+      sim->clampNegativeConcentrations_tbb();
+    } else {
+      sim->clampNegativeConcentrations();
+    }
   }
+  return dt;
 }
 
 void PixelSim::doRK212(double dt) {
@@ -279,6 +290,13 @@ double PixelSim::doRKAdaptive(double dtMax) {
       }
     }
   } while (err.abs > errMax.abs || err.rel > errMax.rel);
+  for (auto &sim : simCompartments) {
+    if (useTBB) {
+      sim->clampNegativeConcentrations_tbb();
+    } else {
+      sim->clampNegativeConcentrations();
+    }
+  }
   return dt;
 }
 
@@ -295,14 +313,43 @@ PixelSim::PixelSim(
     // check if reactions explicitly depend on time or space
     auto xId{doc.getParameters().getSpatialCoordinates().x.id};
     auto yId{doc.getParameters().getSpatialCoordinates().y.id};
-    bool timeDependent{doc.getReactions().dependOnVariable("time")};
+    auto zId{doc.getParameters().getSpatialCoordinates().z.id};
+    const auto crossDiffusionDependsOnVariable =
+        [this, &compartmentSpeciesIds](const std::string &variableId) {
+          for (const auto &speciesIds : compartmentSpeciesIds) {
+            for (const auto &targetSpeciesId : speciesIds) {
+              for (const auto &sourceSpeciesId : speciesIds) {
+                if (targetSpeciesId == sourceSpeciesId) {
+                  continue;
+                }
+                const auto expression =
+                    doc.getSpecies().getCrossDiffusionConstant(
+                        targetSpeciesId.c_str(), sourceSpeciesId.c_str());
+                if (expression.isEmpty()) {
+                  continue;
+                }
+                if (common::SimpleSymbolic::contains(expression.toStdString(),
+                                                     variableId)) {
+                  return true;
+                }
+              }
+            }
+          }
+          return false;
+        };
+    bool timeDependent{doc.getReactions().dependOnVariable("time") ||
+                       crossDiffusionDependsOnVariable("time")};
     if (timeDependent) {
       ++nExtraVars;
     }
     bool spaceDependent{doc.getReactions().dependOnVariable(xId.c_str()) ||
-                        doc.getReactions().dependOnVariable(yId.c_str())};
+                        doc.getReactions().dependOnVariable(yId.c_str()) ||
+                        doc.getReactions().dependOnVariable(zId.c_str()) ||
+                        crossDiffusionDependsOnVariable(xId) ||
+                        crossDiffusionDependsOnVariable(yId) ||
+                        crossDiffusionDependsOnVariable(zId)};
     if (spaceDependent) {
-      nExtraVars += 2;
+      nExtraVars += 3;
     }
     const bool allUniformDiffusion = [this, &compartmentSpeciesIds]() {
       for (const auto &speciesIds : compartmentSpeciesIds) {
@@ -420,7 +467,7 @@ std::size_t PixelSim::run(double time, double timeout_ms,
     double maxDt = std::min(maxTimestep, time - tNow);
     if (integrator == PixelIntegratorType::RK101) {
       double timestep = std::min(maxDt, maxStableTimestep);
-      doRK101(timestep);
+      timestep = doRK101(timestep);
       tNow += timestep;
     } else {
       tNow += doRKAdaptive(maxDt);

--- a/core/simulate/src/pixelsim.hpp
+++ b/core/simulate/src/pixelsim.hpp
@@ -32,7 +32,7 @@ private:
   double maxStableTimestep{std::numeric_limits<double>::max()};
   void calculateDcdt();
   void solveZeroStorageConstraints();
-  void doRK101(double dt);
+  double doRK101(double dt);
   void doRK212(double dt);
   void doRK323(double dt);
   void doRK435(double dt);

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -57,10 +57,11 @@ ReacExpr::ReacExpr(
     SPDLOG_TRACE("model reactions depend on space");
     extraVars.push_back(doc.getParameters().getSpatialCoordinates().x.id);
     extraVars.push_back(doc.getParameters().getSpatialCoordinates().y.id);
+    extraVars.push_back(doc.getParameters().getSpatialCoordinates().z.id);
   }
   Pde pde(&doc, speciesIDs, reactionIDs, {}, pdeScaleFactors, extraVars, {},
           substitutions);
-  // add dt/dt = 1 reaction term, and t,x,y "species"
+  // add dt/dt = 1 reaction term, and t,x,y,z "species"
   variables = speciesIDs;
   variables.insert(variables.end(), extraVars.cbegin(), extraVars.cend());
   expressions = pde.getRHS();
@@ -70,6 +71,7 @@ ReacExpr::ReacExpr(
   if (spaceDependent) {
     expressions.emplace_back("0"); // dx/dt = 0
     expressions.emplace_back("0"); // dy/dt = 0
+    expressions.emplace_back("0"); // dz/dt = 0
   }
 }
 
@@ -130,8 +132,10 @@ SimCompartment::SimCompartment(
     : comp{compartment}, nPixels{compartment->nVoxels()}, nSpecies{sIds.size()},
       compartmentId{compartment->getId()}, speciesIds{std::move(sIds)},
       useUniformDiffusionOperator{useUniformDiffusionOp} {
+  nPrimarySpecies = nSpecies;
   // get species in compartment
   speciesNames.reserve(nSpecies);
+  maxPrimaryDiagonalDiffusion.reserve(nSpecies);
   SPDLOG_DEBUG("compartment: {}", compartmentId);
   std::vector<const geometry::Field *> fields;
   const auto voxelSize{doc.getGeometry().getVoxelSize()};
@@ -183,6 +187,7 @@ SimCompartment::SimCompartment(
       }
       SPDLOG_DEBUG("  - adding species: {}, diff constant {}, storage {}", s, d,
                    storageValue);
+      maxPrimaryDiagonalDiffusion.push_back(d);
     } else {
       // store diffusion constant per voxel
       diffConstants.push_back(field->getDiffusionConstant());
@@ -211,6 +216,7 @@ SimCompartment::SimCompartment(
       }
       SPDLOG_DEBUG("  - adding species: {}, diff constant (max) {}, storage {}",
                    s, maxD, storageValue);
+      maxPrimaryDiagonalDiffusion.push_back(maxD);
     }
     fields.push_back(field);
     speciesNames.push_back(doc.getSpecies().getName(s.c_str()).toStdString());
@@ -269,6 +275,44 @@ SimCompartment::SimCompartment(
     }
     nSpecies += 3;
   }
+  // sparse cross-diffusion terms D_ij * grad(c_j), with i != j
+  std::vector<std::string> crossDiffusionExpressions;
+  for (std::size_t iTarget = 0; iTarget < nPrimarySpecies; ++iTarget) {
+    const QString targetSpeciesId{speciesIds[iTarget].c_str()};
+    for (std::size_t iSource = 0; iSource < nPrimarySpecies; ++iSource) {
+      if (iSource == iTarget) {
+        continue;
+      }
+      const QString sourceSpeciesId{speciesIds[iSource].c_str()};
+      const auto expression = doc.getSpecies().getCrossDiffusionConstant(
+          targetSpeciesId, sourceSpeciesId);
+      if (expression.isEmpty()) {
+        continue;
+      }
+      crossDiffusionExpressions.push_back(
+          doc.inlineExpr(expression.toStdString()));
+      crossDiffusionTerms.push_back({iTarget, iSource});
+    }
+  }
+  if (!crossDiffusionExpressions.empty()) {
+    std::vector<std::pair<std::string, double>> constants;
+    for (const auto &constant : doc.getParameters().getGlobalConstants()) {
+      double value = constant.value;
+      if (auto it = substitutions.find(constant.id);
+          it != substitutions.end()) {
+        value = it->second;
+      }
+      constants.emplace_back(constant.id, value);
+    }
+    if (!(symCrossDiffusion.parse(crossDiffusionExpressions, speciesIds,
+                                  constants) &&
+          symCrossDiffusion.compile(doCSE, optLevel))) {
+      throw PixelSimImplError(symCrossDiffusion.getErrorMessage());
+    }
+    hasCrossDiffusion = true;
+    crossDiffusionCoefficients.resize(nPixels * crossDiffusionTerms.size(),
+                                      0.0);
+  }
   // setup concentrations vector with initial values
   conc.resize(nSpecies * nPixels);
   dcdt.resize(conc.size(), 0.0);
@@ -303,6 +347,10 @@ SimCompartment::SimCompartment(
     }
   }
   assert(concIter == conc.end());
+  if (hasCrossDiffusion) {
+    evaluateCrossDiffusionCoefficients(0, nPixels);
+    updateCrossDiffusionMaxStableTimestep();
+  }
 }
 
 void SimCompartment::evaluateDiffusionOperator(std::size_t begin,
@@ -367,17 +415,135 @@ void SimCompartment::evaluateReactions(std::size_t begin, std::size_t end) {
   }
 }
 
+void SimCompartment::evaluateCrossDiffusionCoefficients(std::size_t begin,
+                                                        std::size_t end) {
+  if (!hasCrossDiffusion) {
+    return;
+  }
+  const auto nTerms{crossDiffusionTerms.size()};
+  for (std::size_t i = begin; i < end; ++i) {
+    symCrossDiffusion.eval(crossDiffusionCoefficients.data() + i * nTerms,
+                           conc.data() + i * nSpecies);
+  }
+}
+
+void SimCompartment::updateCrossDiffusionMaxStableTimestep() {
+  if (!hasCrossDiffusion || crossDiffusionTerms.empty()) {
+    return;
+  }
+  const auto nTerms{crossDiffusionTerms.size()};
+  std::vector<double> maxAbsCrossDiffusionByTerm(nTerms, 0.0);
+  for (std::size_t ix = 0; ix < nPixels; ++ix) {
+    const auto iBase{ix * nTerms};
+    for (std::size_t iTerm = 0; iTerm < nTerms; ++iTerm) {
+      maxAbsCrossDiffusionByTerm[iTerm] =
+          std::max(maxAbsCrossDiffusionByTerm[iTerm],
+                   std::abs(crossDiffusionCoefficients[iBase + iTerm]));
+    }
+  }
+  auto maxEffectiveDiffusion{maxPrimaryDiagonalDiffusion};
+  for (std::size_t iTerm = 0; iTerm < nTerms; ++iTerm) {
+    const auto &term{crossDiffusionTerms[iTerm]};
+    maxEffectiveDiffusion[term.targetSpeciesIndex] +=
+        maxAbsCrossDiffusionByTerm[iTerm];
+  }
+  maxStableTimestep = std::numeric_limits<double>::max();
+  for (std::size_t iTarget = 0; iTarget < nPrimarySpecies; ++iTarget) {
+    const double invStorageValue{invStorage[iTarget]};
+    if (invStorageValue == 0.0) {
+      continue;
+    }
+    const double maxEffectiveD{maxEffectiveDiffusion[iTarget]};
+    if (maxEffectiveD <= 0.0) {
+      continue;
+    }
+    maxStableTimestep = std::min(
+        maxStableTimestep,
+        calculateMaxStableTimestep({maxEffectiveD * invStorageValue / dx2,
+                                    maxEffectiveD * invStorageValue / dy2,
+                                    maxEffectiveD * invStorageValue / dz2}));
+  }
+}
+
+void SimCompartment::evaluateCrossDiffusionOperator(std::size_t begin,
+                                                    std::size_t end) {
+  if (!hasCrossDiffusion) {
+    return;
+  }
+  const auto nTerms{crossDiffusionTerms.size()};
+  for (std::size_t i = begin; i < end; ++i) {
+    const std::size_t ix{i * nSpecies};
+    const std::size_t iupx{comp->up_x(i)};
+    const std::size_t idnx{comp->dn_x(i)};
+    const std::size_t iupy{comp->up_y(i)};
+    const std::size_t idny{comp->dn_y(i)};
+    const std::size_t iupz{comp->up_z(i)};
+    const std::size_t idnz{comp->dn_z(i)};
+    const std::size_t ixUpx{iupx * nSpecies};
+    const std::size_t ixDnx{idnx * nSpecies};
+    const std::size_t ixUpy{iupy * nSpecies};
+    const std::size_t ixDny{idny * nSpecies};
+    const std::size_t ixUpz{iupz * nSpecies};
+    const std::size_t ixDnz{idnz * nSpecies};
+    for (std::size_t iTerm = 0; iTerm < nTerms; ++iTerm) {
+      const auto &term{crossDiffusionTerms[iTerm]};
+      const std::size_t target{term.targetSpeciesIndex};
+      const std::size_t source{term.sourceSpeciesIndex};
+      const double dCenter{crossDiffusionCoefficients[i * nTerms + iTerm]};
+      const double dUpx{crossDiffusionCoefficients[iupx * nTerms + iTerm]};
+      const double dDnx{crossDiffusionCoefficients[idnx * nTerms + iTerm]};
+      const double dUpy{crossDiffusionCoefficients[iupy * nTerms + iTerm]};
+      const double dDny{crossDiffusionCoefficients[idny * nTerms + iTerm]};
+      const double dUpz{crossDiffusionCoefficients[iupz * nTerms + iTerm]};
+      const double dDnz{crossDiffusionCoefficients[idnz * nTerms + iTerm]};
+      const double dxp{0.5 * (dCenter + dUpx) / dx2};
+      const double dxm{0.5 * (dCenter + dDnx) / dx2};
+      const double dyp{0.5 * (dCenter + dUpy) / dy2};
+      const double dym{0.5 * (dCenter + dDny) / dy2};
+      const double dzp{0.5 * (dCenter + dUpz) / dz2};
+      const double dzm{0.5 * (dCenter + dDnz) / dz2};
+      dcdt[ix + target] += dxp * (conc[ixUpx + source] - conc[ix + source]) -
+                           dxm * (conc[ix + source] - conc[ixDnx + source]) +
+                           dyp * (conc[ixUpy + source] - conc[ix + source]) -
+                           dym * (conc[ix + source] - conc[ixDny + source]) +
+                           dzp * (conc[ixUpz + source] - conc[ix + source]) -
+                           dzm * (conc[ix + source] - conc[ixDnz + source]);
+    }
+  }
+}
+
 void SimCompartment::evaluateReactionsAndDiffusion() {
   evaluateReactions(0, nPixels);
+  if (hasCrossDiffusion) {
+    evaluateCrossDiffusionCoefficients(0, nPixels);
+    updateCrossDiffusionMaxStableTimestep();
+  }
   evaluateDiffusionOperator(0, nPixels);
+  evaluateCrossDiffusionOperator(0, nPixels);
 }
 
 void SimCompartment::evaluateReactionsAndDiffusion_tbb() {
   tbbParallelFor(nPixels,
                  [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
                    evaluateReactions(r.begin(), r.end());
+                 });
+  if (hasCrossDiffusion) {
+    tbbParallelFor(nPixels,
+                   [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
+                     evaluateCrossDiffusionCoefficients(r.begin(), r.end());
+                   });
+    updateCrossDiffusionMaxStableTimestep();
+  }
+  tbbParallelFor(nPixels,
+                 [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
                    evaluateDiffusionOperator(r.begin(), r.end());
                  });
+  if (hasCrossDiffusion) {
+    tbbParallelFor(nPixels,
+                   [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
+                     evaluateCrossDiffusionOperator(r.begin(), r.end());
+                   });
+  }
 }
 
 void SimCompartment::doForwardsEulerTimestep(double dt, std::size_t begin,
@@ -395,6 +561,30 @@ void SimCompartment::doForwardsEulerTimestep_tbb(double dt) {
   tbbParallelFor(conc.size(),
                  [this, dt](const oneapi::tbb::blocked_range<std::size_t> &r) {
                    doForwardsEulerTimestep(dt, r.begin(), r.end());
+                 });
+}
+
+void SimCompartment::clampNegativeConcentrations(std::size_t begin,
+                                                 std::size_t end) {
+  for (std::size_t ix = begin; ix < end; ++ix) {
+    const std::size_t iOffset{ix * nSpecies};
+    for (std::size_t is = 0; is < nPrimarySpecies; ++is) {
+      auto &c{conc[iOffset + is]};
+      if (c < 0.0) {
+        c = 0.0;
+      }
+    }
+  }
+}
+
+void SimCompartment::clampNegativeConcentrations() {
+  clampNegativeConcentrations(0, nPixels);
+}
+
+void SimCompartment::clampNegativeConcentrations_tbb() {
+  tbbParallelFor(nPixels,
+                 [this](const oneapi::tbb::blocked_range<std::size_t> &r) {
+                   clampNegativeConcentrations(r.begin(), r.end());
                  });
 }
 

--- a/core/simulate/src/pixelsim_impl.hpp
+++ b/core/simulate/src/pixelsim_impl.hpp
@@ -42,13 +42,22 @@ struct ReacExpr {
 
 class SimCompartment {
 private:
+  struct CrossDiffusionTerm {
+    std::size_t targetSpeciesIndex{};
+    std::size_t sourceSpeciesIndex{};
+  };
   common::Symbolic sym;
+  common::Symbolic symCrossDiffusion;
   // species concentrations & corresponding dcdt values
   // ordering: ix, species
   std::vector<double> conc;
   std::vector<double> dcdt;
   std::vector<double> s2;
   std::vector<double> s3;
+  std::vector<CrossDiffusionTerm> crossDiffusionTerms;
+  // cross-diffusion coefficients D_ij(x, c, t) for each pixel and configured
+  // term (ordering: pixel, term)
+  std::vector<double> crossDiffusionCoefficients;
   // diffusion constants (D) per voxel for each species
   std::vector<std::vector<double>> diffConstants;
   // diffusion constants (D/dx^2, D/dy^2, D/dz^2) per species
@@ -63,6 +72,8 @@ private:
   std::vector<std::string> speciesNames;
   std::vector<std::size_t> nonSpatialSpeciesIndices;
   std::vector<std::size_t> zeroStorageSpeciesIndices;
+  std::size_t nPrimarySpecies{0};
+  std::vector<double> maxPrimaryDiagonalDiffusion;
   std::vector<double> relaxOld;
   std::vector<double> relaxFirstOrder;
   double maxStableTimestep = std::numeric_limits<double>::max();
@@ -73,6 +84,7 @@ private:
   bool useUniformDiffusionOperator{false};
   bool hasNonUnitStorage{false};
   bool hasZeroStorageSpecies{false};
+  bool hasCrossDiffusion{false};
 
 public:
   explicit SimCompartment(
@@ -86,6 +98,9 @@ public:
   void evaluateDiffusionOperator(std::size_t begin, std::size_t end);
   // dcdt += result of applying reaction expressions to conc
   void evaluateReactions(std::size_t begin, std::size_t end);
+  void evaluateCrossDiffusionCoefficients(std::size_t begin, std::size_t end);
+  void updateCrossDiffusionMaxStableTimestep();
+  void evaluateCrossDiffusionOperator(std::size_t begin, std::size_t end);
   void evaluateReactionsAndDiffusion();
   void evaluateReactionsAndDiffusion_tbb();
   void spatiallyAverageDcdt();
@@ -95,6 +110,9 @@ public:
   void doForwardsEulerTimestep(double dt, std::size_t begin, std::size_t end);
   void doForwardsEulerTimestep(double dt);
   void doForwardsEulerTimestep_tbb(double dt);
+  void clampNegativeConcentrations(std::size_t begin, std::size_t end);
+  void clampNegativeConcentrations();
+  void clampNegativeConcentrations_tbb();
   void doRKInit();
   void doRK212Substep1(double dt, std::size_t begin, std::size_t end);
   void doRK212Substep1(double dt);

--- a/core/simulate/src/pixelsim_t.cpp
+++ b/core/simulate/src/pixelsim_t.cpp
@@ -156,4 +156,99 @@ TEST_CASE("PixelSim", "[core/simulate/pixelsim][core/"
               dbl_approx(0.5 * dcdtDefault[i * 3 + 2]));
     }
   }
+  SECTION("Cross-diffusion vanishes for zero source gradient") {
+    auto mReference{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    auto mCross{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    // make source species spatially uniform so grad(source) = 0
+    mReference.getSpecies().setInitialConcentration("slow", 1.0);
+    mCross.getSpecies().setInitialConcentration("slow", 1.0);
+    mCross.getSpecies().setCrossDiffusionConstant("fast", "slow", "2");
+    for (auto *m : {&mReference, &mCross}) {
+      auto &options{m->getSimulationSettings().options};
+      options.pixel.enableMultiThreading = false;
+      options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+      options.pixel.maxTimestep = 1e-3;
+    }
+    std::vector<std::string> comps{"circle"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim simReference(mReference, comps, specs);
+    simulate::PixelSim simCross(mCross, comps, specs);
+    REQUIRE(simReference.errorMessage().empty());
+    REQUIRE(simCross.errorMessage().empty());
+    simReference.run(1e-3, -1.0, {});
+    simCross.run(1e-3, -1.0, {});
+    const auto &cReference = simReference.getConcentrations(0);
+    const auto &cCross = simCross.getConcentrations(0);
+    REQUIRE(cReference.size() == cCross.size());
+    for (std::size_t i = 0; i < cReference.size(); ++i) {
+      REQUIRE(cCross[i] == dbl_approx(cReference[i]));
+    }
+  }
+  SECTION("Cross-diffusion multithreaded path matches single-threaded") {
+    auto mSingle{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    auto mParallel{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    for (auto *m : {&mSingle, &mParallel}) {
+      m->getSpecies().setCrossDiffusionConstant("slow", "fast", "4 + fast");
+      m->getSpecies().setCrossDiffusionConstant("fast", "slow", "6 + slow");
+      auto &options{m->getSimulationSettings().options};
+      options.pixel.integrator = simulate::PixelIntegratorType::RK435;
+      options.pixel.maxTimestep = 1e-3;
+    }
+    mSingle.getSimulationSettings().options.pixel.enableMultiThreading = false;
+    mParallel.getSimulationSettings().options.pixel.enableMultiThreading = true;
+    mParallel.getSimulationSettings().options.pixel.maxThreads = 2;
+
+    std::vector<std::string> comps{"circle"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim simSingle(mSingle, comps, specs);
+    simulate::PixelSim simParallel(mParallel, comps, specs);
+    REQUIRE(simSingle.errorMessage().empty());
+    REQUIRE(simParallel.errorMessage().empty());
+    simSingle.run(5e-3, -1.0, {});
+    simParallel.run(5e-3, -1.0, {});
+    const auto &cSingle = simSingle.getConcentrations(0);
+    const auto &cParallel = simParallel.getConcentrations(0);
+    REQUIRE(cSingle.size() == cParallel.size());
+    for (std::size_t i = 0; i < cSingle.size(); ++i) {
+      REQUIRE(cParallel[i] == Catch::Approx(cSingle[i]).epsilon(1e-7));
+    }
+  }
+  SECTION("Cross-diffusion z-only dependence is supported in 3d") {
+    auto m{getExampleModel(Mod::SingleCompartmentDiffusion3D)};
+    m.getSpecies().setCrossDiffusionConstant("slow", "fast", "1 + z");
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options.pixel.maxTimestep = 1e-3;
+    std::vector<std::string> comps{"cube"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim sim(m, comps, specs);
+    REQUIRE(sim.errorMessage().empty());
+    REQUIRE(sim.getConcentrationPadding() == 3);
+    sim.run(1e-3, -1.0, {});
+    REQUIRE(sim.errorMessage().empty());
+  }
+  SECTION("RK101 timestep is capped by strong cross-diffusion terms") {
+    auto m{getExampleModel(Mod::SingleCompartmentDiffusion)};
+    m.getSpecies().setDiffusionConstant("slow", 0.0);
+    m.getSpecies().setDiffusionConstant("fast", 0.0);
+    m.getSpecies().setCrossDiffusionConstant("slow", "fast", "80");
+    m.getSpecies().setCrossDiffusionConstant("fast", "slow", "80");
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options.pixel.maxTimestep = 1e-2;
+    std::vector<std::string> comps{"circle"};
+    std::vector<std::vector<std::string>> specs{{"slow", "fast"}};
+    simulate::PixelSim sim(m, comps, specs);
+    REQUIRE(sim.errorMessage().empty());
+    const auto nSteps{sim.run(1e-2, -1.0, {})};
+    REQUIRE(sim.errorMessage().empty());
+    REQUIRE(nSteps > 1);
+    const auto &conc{sim.getConcentrations(0)};
+    double minConc{std::numeric_limits<double>::max()};
+    for (double c : conc) {
+      minConc = std::min(minConc, c);
+    }
+    CAPTURE(minConc);
+    REQUIRE(minConc >= 0.0);
+  }
 }

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -1958,6 +1958,58 @@ TEST_CASE("Reactions depend on x, y, t",
       REQUIRE(maxRelDiff < maxAllowedRelDiff);
     }
   }
+  SECTION("reaction with x,y,z-dependence") {
+    // looser tolerance: 3d mesh distorts results more than pixel geometry
+    constexpr double maxAllowedAbsDiff{0.01};
+    constexpr double maxAllowedRelDiff{0.08};
+    auto s3d{getExampleModel(Mod::VerySimpleModel3D)};
+    s3d.getReactions().setRateExpression("A_uptake", "0");
+    s3d.getReactions().setRateExpression("A_transport", "0");
+    s3d.getReactions().setRateExpression("B_transport", "0");
+    s3d.getReactions().setRateExpression("B_excretion", "0");
+    s3d.getReactions().setRateExpression("A_B_conversion", "x + y + z");
+    auto &options3d{s3d.getSimulationSettings().options};
+    options3d.dune.dt = dt;
+    options3d.dune.minDt = dt;
+    options3d.dune.maxDt = dt;
+    options3d.pixel.integrator = simulate::PixelIntegratorType::RK101;
+    options3d.pixel.maxErr = {std::numeric_limits<double>::max(),
+                              std::numeric_limits<double>::max()};
+    options3d.pixel.maxTimestep = dt;
+
+    s3d.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+    simulate::Simulation simPixel{s3d};
+    simPixel.doTimesteps(dt, 1);
+    REQUIRE(simPixel.errorMessage().empty());
+    REQUIRE(simPixel.getNCompletedTimesteps() == 2);
+
+    s3d.getSimulationData().clear();
+    s3d.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
+    simulate::Simulation simDune{s3d};
+    simDune.doTimesteps(dt, 1);
+    CAPTURE(simDune.errorMessage());
+    REQUIRE(simDune.errorMessage().empty());
+    REQUIRE(simDune.getNCompletedTimesteps() == 2);
+
+    const auto compartmentIndex{
+        common::element_index(simPixel.getCompartmentIds(), std::string{"c3"})};
+    const auto speciesIndex{common::element_index(
+        simPixel.getSpeciesIds(compartmentIndex), std::string{"A_c3"})};
+    auto p{simPixel.getConc(1, compartmentIndex, speciesIndex)};
+    auto d{simDune.getConc(1, compartmentIndex, speciesIndex)};
+    REQUIRE(p.size() == d.size());
+    double maxAbsDiff{0};
+    double maxRelDiff{0};
+    for (std::size_t i = 0; i < p.size(); ++i) {
+      maxAbsDiff = std::max(maxAbsDiff, std::abs(p[i] - d[i]));
+      maxRelDiff = std::max(maxRelDiff, std::abs(p[i] - d[i]) /
+                                            (std::abs(p[i] + d[i] + eps)));
+    }
+    CAPTURE(maxAbsDiff);
+    CAPTURE(maxRelDiff);
+    REQUIRE(maxAbsDiff < maxAllowedAbsDiff);
+    REQUIRE(maxRelDiff < maxAllowedRelDiff);
+  }
   SECTION("reaction with t,x,y-dependence") {
     // looser tolerance: mesh distorts results
     constexpr double maxAllowedAbsDiff{0.002};
@@ -2462,6 +2514,157 @@ TEST_CASE("pixel simulation with invalid reaction rate expression",
   m.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
   REQUIRE_THAT(simulate::Simulation(m).errorMessage(),
                ContainsSubstring("Unknown symbol 'idontexist'"));
+}
+
+TEST_CASE("Cross-diffusion: zero diffusion with equivalent cross-diffusion",
+          "[core/simulate/simulate][core/simulate][core][simulate][pixel]") {
+  auto m{getExampleModel(Mod::SingleCompartmentDiffusion)};
+  // slow species has diffusion constant of 1, so should diffuse as normal
+  // fast species has diffusion constant of 0
+  m.getSpecies().setDiffusionConstant("fast", 0);
+  // but cross-diffusion constant of 1 with slow species, so should diffuse at
+  // same rate as slow species
+  m.getSpecies().setCrossDiffusionConstant("fast", "slow", "1");
+  m.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+  simulate::Simulation sim(m);
+  REQUIRE(sim.errorMessage().empty());
+  sim.doTimesteps(5);
+  REQUIRE(sim.errorMessage().empty());
+  constexpr double eps{1e-15};
+  constexpr double allowedAvgAbsDiff{1e-11};
+  constexpr double allowedAvgRelDiff{1e-7};
+  for (std::size_t timeIndex : {std::size_t{0}, std::size_t{1}}) {
+    const auto slow{sim.getConc(timeIndex, 0, 0)};
+    const auto fast{sim.getConc(timeIndex, 0, 1)};
+    REQUIRE(slow.size() == fast.size());
+    double avgAbsDiff{0.0};
+    double avgRelDiff{0.0};
+    for (std::size_t i = 0; i < slow.size(); ++i) {
+      const auto absDiff{std::abs(slow[i] - fast[i])};
+      avgAbsDiff += absDiff;
+      avgRelDiff += 2.0 * absDiff / (std::abs(slow[i] + fast[i]) + eps);
+    }
+    avgAbsDiff /= static_cast<double>(slow.size());
+    avgRelDiff /= static_cast<double>(slow.size());
+    CAPTURE(timeIndex);
+    CAPTURE(avgAbsDiff);
+    CAPTURE(avgRelDiff);
+    REQUIRE(avgAbsDiff < allowedAvgAbsDiff);
+    REQUIRE(avgRelDiff < allowedAvgRelDiff);
+  }
+}
+
+TEST_CASE(
+    "Cross-diffusion: DUNE and Pixel give similar concentrations",
+    "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel]") {
+  auto mDune{getExampleModel(Mod::SingleCompartmentDiffusion)};
+  auto mPixel{getExampleModel(Mod::SingleCompartmentDiffusion)};
+  mDune.getGeometry().getMesh2d()->setCompartmentMaxTriangleArea(0, 1);
+  // set zero diffusion constant for "fast" species
+  mDune.getSpecies().setDiffusionConstant("fast", 0);
+  mPixel.getSpecies().setDiffusionConstant("fast", 0);
+  // add cross-diffusion term so "fast" species can diffuse via "slow" species
+  mDune.getSpecies().setCrossDiffusionConstant("fast", "slow", "2");
+  mPixel.getSpecies().setCrossDiffusionConstant("fast", "slow", "2");
+  mDune.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
+  mPixel.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+  mDune.getSimulationSettings().options.dune.dt = 1e-1;
+  mDune.getSimulationSettings().options.dune.maxDt = 1e-1;
+  simulate::Simulation simDune(mDune);
+  simulate::Simulation simPixel(mPixel);
+  REQUIRE(simDune.errorMessage().empty());
+  REQUIRE(simPixel.errorMessage().empty());
+  simDune.doTimesteps(5);
+  simPixel.doTimesteps(5);
+  REQUIRE(simDune.errorMessage().empty());
+  REQUIRE(simPixel.errorMessage().empty());
+  const auto iLastDune{simDune.getTimePoints().size() - 1};
+  const auto iLastPixel{simPixel.getTimePoints().size() - 1};
+  constexpr double eps{1e-8};
+  constexpr double allowedAvgAbsDiff{5e-3};
+  constexpr double allowedAvgRelDiff{0.3};
+  for (std::size_t speciesIndex : {std::size_t{0}, std::size_t{1}}) {
+    const auto p{simPixel.getConc(iLastPixel, 0, speciesIndex)};
+    const auto d{simDune.getConc(iLastDune, 0, speciesIndex)};
+    REQUIRE(p.size() == d.size());
+    double avgAbsDiff{0.0};
+    double avgRelDiff{0.0};
+    for (std::size_t i = 0; i < p.size(); ++i) {
+      const auto absDiff{std::abs(p[i] - d[i])};
+      avgAbsDiff += absDiff;
+      avgRelDiff += 2.0 * absDiff / (std::abs(p[i] + d[i]) + eps);
+    }
+    avgAbsDiff /= static_cast<double>(p.size());
+    avgRelDiff /= static_cast<double>(p.size());
+    CAPTURE(speciesIndex);
+    CAPTURE(avgAbsDiff);
+    CAPTURE(avgRelDiff);
+    REQUIRE(avgAbsDiff < allowedAvgAbsDiff);
+    REQUIRE(avgRelDiff < allowedAvgRelDiff);
+  }
+}
+
+TEST_CASE(
+    "Cross-diffusion 3d: DUNE and Pixel remain close for "
+    "SingleCompartmentDiffusion3D",
+    "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel][3d]"
+    "[expensive]") {
+  auto configureModel = [](model::Model &m) {
+    m.getSpecies().setAnalyticConcentration(
+        "slow", "exp((-1/36) * ((x+4)^2 + y^2 + z^2))");
+    m.getSpecies().setAnalyticConcentration(
+        "fast", "exp((-1/49) * ((x-3)^2 + (y+2)^2 + z^2))");
+    m.getSpecies().setCrossDiffusionConstant("slow", "fast", "5 + 3*fast");
+    m.getSpecies().setCrossDiffusionConstant("fast", "slow", "7 + 2*slow");
+    m.getGeometry().getMesh3d()->setCompartmentMaxCellVolume(0, 4);
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.maxErr = {std::numeric_limits<double>::max(), 0.002};
+    options.pixel.integrator = simulate::PixelIntegratorType::RK435;
+    options.pixel.maxTimestep = 2e-3;
+    options.pixel.maxThreads = 2;
+    options.dune.dt = 2e-3;
+    options.dune.minDt = 1e-6;
+    options.dune.maxDt = 1e-2;
+  };
+
+  auto mDune{getExampleModel(Mod::SingleCompartmentDiffusion3D)};
+  auto mPixel{getExampleModel(Mod::SingleCompartmentDiffusion3D)};
+  configureModel(mDune);
+  configureModel(mPixel);
+  mDune.getSimulationSettings().simulatorType = simulate::SimulatorType::DUNE;
+  mPixel.getSimulationSettings().simulatorType = simulate::SimulatorType::Pixel;
+
+  simulate::Simulation simDune(mDune);
+  simulate::Simulation simPixel(mPixel);
+  REQUIRE(simDune.errorMessage().empty());
+  REQUIRE(simPixel.errorMessage().empty());
+  REQUIRE(simDune.doTimesteps(0.02, 2) >= 1);
+  REQUIRE(simPixel.doTimesteps(0.02, 2) >= 1);
+
+  const auto iLastDune{simDune.getTimePoints().size() - 1};
+  const auto iLastPixel{simPixel.getTimePoints().size() - 1};
+  constexpr double eps{1e-7};
+  constexpr double allowedAvgAbsDiff{1e-3};
+  constexpr double allowedAvgRelDiff{0.5};
+  for (std::size_t speciesIndex : {std::size_t{0}, std::size_t{1}}) {
+    const auto p{simPixel.getConc(iLastPixel, 0, speciesIndex)};
+    const auto d{simDune.getConc(iLastDune, 0, speciesIndex)};
+    REQUIRE(p.size() == d.size());
+    double avgAbsDiff{0.0};
+    double avgRelDiff{0.0};
+    for (std::size_t i = 0; i < p.size(); ++i) {
+      const auto absDiff{std::abs(p[i] - d[i])};
+      avgAbsDiff += absDiff;
+      avgRelDiff += 2.0 * absDiff / (std::abs(p[i] + d[i]) + eps);
+    }
+    avgAbsDiff /= static_cast<double>(p.size());
+    avgRelDiff /= static_cast<double>(p.size());
+    CAPTURE(speciesIndex);
+    CAPTURE(avgAbsDiff);
+    CAPTURE(avgRelDiff);
+    REQUIRE(avgAbsDiff < allowedAvgAbsDiff);
+    REQUIRE(avgRelDiff < allowedAvgRelDiff);
+  }
 }
 
 TEST_CASE("Fish model: simulation with piecewise function in reactions",

--- a/docs/reference/maths.rst
+++ b/docs/reference/maths.rst
@@ -8,25 +8,40 @@ The system of PDEs that we simulate in each compartment is the three-dimensional
 
 .. math::
 
-   S_s \frac{\partial c_s}{\partial t} = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
+   S_s \frac{\partial c_s}{\partial t}
+   =
+   \nabla \cdot \left(
+     D_{s,s} \nabla c_s
+     + \sum_{r \ne s} D_{s,r} \nabla c_r
+   \right)
+   + R_s
 
 where
 
 * :math:`c_s` is the concentration of species :math:`s` at position :math:`(x, y, z)` and time :math:`t`
-* :math:`D_s` is the (possibly spatially varying) scalar diffusion constant for species :math:`s`
+* :math:`D_{s,s}` is the (possibly spatially varying) scalar self-diffusion constant for species :math:`s`
+* :math:`D_{s,r}` (:math:`r \ne s`) are optional cross-diffusion coefficients for species :math:`s`, multiplying gradients of other species :math:`r` in the same compartment
 * :math:`R_s` is the reaction term for species :math:`s`
 * :math:`S_s` is the species storage coefficient (dimensionless, non-negative, default :math:`1`)
 
+If no cross-diffusion terms are defined, all :math:`D_{s,r}` with :math:`r \ne s` are zero and this reduces to the standard reaction-diffusion equation.
+
 and we assume that
 
-* the diffusion constant :math:`D_s` is isotropic (a scalar, not a tensor)
+* each diffusion coefficient :math:`D_{s,r}` is isotropic (a scalar, not a tensor)
 * the reaction term :math:`R_s` is a function that can depend on the concentrations of other species in the model, but only locally, i.e. the concentrations at the same spatial coordinate.
 
 When :math:`S_s = 0`, the equation becomes an algebraic constraint rather than a time-evolution equation:
 
 .. math::
 
-   0 = \nabla \cdot \left( D_s \nabla c_s \right) + R_s
+   0
+   =
+   \nabla \cdot \left(
+     D_{s,s} \nabla c_s
+     + \sum_{r \ne s} D_{s,r} \nabla c_r
+   \right)
+   + R_s
 
 The concentration of such a species is not integrated in time, but is instead determined at each timestep
 by satisfying this constraint. See the :doc:`pixel` documentation for details on how the Pixel solver handles this case.
@@ -35,10 +50,18 @@ For :math:`S_s > 0`, the equation can equivalently be written as
 
 .. math::
 
-   \frac{\partial c_s}{\partial t} = \frac{1}{S_s}\left(\nabla \cdot \left( D_s \nabla c_s \right) + R_s\right)
+   \frac{\partial c_s}{\partial t}
+   =
+   \frac{1}{S_s}\left(
+     \nabla \cdot \left(
+       D_{s,s} \nabla c_s
+       + \sum_{r \ne s} D_{s,r} \nabla c_r
+     \right)
+     + R_s
+   \right)
 
-If :math:`D_s` is constant in space, this reduces to
-:math:`\frac{1}{S_s}\left(D_s \nabla^2 c_s + R_s\right)`.
+If all diffusion coefficients are constant in space, this reduces to
+:math:`\frac{1}{S_s}\left(D_{s,s}\nabla^2 c_s + \sum_{r \ne s} D_{s,r}\nabla^2 c_r + R_s\right)`.
 
 Compartment Reactions
 ---------------------

--- a/docs/reference/pixel.rst
+++ b/docs/reference/pixel.rst
@@ -59,8 +59,8 @@ The concentration is defined as a 3d array of values :math:`c_{i,j,k}`,
 where the value with index :math:`(i,j,k)` corresponds to the concentration
 at the spatial point :math:`(x = i \delta x, y = j \delta y, z = k \delta z)`.
 
-For diffusion constants that vary in space, the diffusion term is written in conservative form.
-With species storage coefficient :math:`S \geq 0`, the PDE is
+For spatially varying self-diffusion constants, the diffusion term is written in conservative form.
+With species storage coefficient :math:`S \geq 0`, the PDE for one species is
 
 .. math::
 
@@ -71,14 +71,14 @@ For one species in voxel :math:`(i,j,k)`:
 
 .. math::
 
-   \begin{eqnarray}
-   \frac{dc_{i,j,k}}{dt}
-   & = & \frac{1}{S}\left(
-   \frac{D^x_{i+1/2,j,k}(c_{i+1,j,k}-c_{i,j,k}) - D^x_{i-1/2,j,k}(c_{i,j,k}-c_{i-1,j,k})}{\delta x^2} \right.\\
-   & & + \frac{D^y_{i,j+1/2,k}(c_{i,j+1,k}-c_{i,j,k}) - D^y_{i,j-1/2,k}(c_{i,j,k}-c_{i,j-1,k})}{\delta y^2} \\
-   & & + \left.\frac{D^z_{i,j,k+1/2}(c_{i,j,k+1}-c_{i,j,k}) - D^z_{i,j,k-1/2}(c_{i,j,k}-c_{i,j,k-1})}{\delta z^2}
-   + R_{i,j,k}\right)
-   \end{eqnarray}
+   \begin{aligned}
+   \frac{dc_{i,j,k}}{dt} = \frac{1}{S}\Bigg(
+   &\frac{D^x_{i+1/2,j,k}(c_{i+1,j,k}-c_{i,j,k}) - D^x_{i-1/2,j,k}(c_{i,j,k}-c_{i-1,j,k})}{\delta x^2} \\
+   &+ \frac{D^y_{i,j+1/2,k}(c_{i,j+1,k}-c_{i,j,k}) - D^y_{i,j-1/2,k}(c_{i,j,k}-c_{i,j-1,k})}{\delta y^2} \\
+   &+ \frac{D^z_{i,j,k+1/2}(c_{i,j,k+1}-c_{i,j,k}) - D^z_{i,j,k-1/2}(c_{i,j,k}-c_{i,j,k-1})}{\delta z^2} \\
+   &+ R_{i,j,k}
+   \Bigg)
+   \end{aligned}
 
 with face diffusion constants
 
@@ -93,10 +93,38 @@ Inserting this approximation into the reaction-diffusion equation converts the P
 
 If :math:`D` is spatially constant, this reduces to the usual central-difference Laplacian form.
 
+Cross-diffusion
+^^^^^^^^^^^^^^^
+
+If cross-diffusion is enabled, Pixel solves for each target species :math:`s`
+
+.. math::
+
+   S_s\frac{\partial c_s}{\partial t}
+   =
+   \nabla \cdot \left(
+     D_{s,s}\nabla c_s
+     + \sum_{r \ne s} D_{s,r}\nabla c_r
+   \right)
+   + R_s
+
+where :math:`D_{s,r}` is the cross-diffusion coefficient that maps gradients of species :math:`r`
+to flux of species :math:`s`.
+The same conservative face-flux stencil is applied term-by-term: for each pair :math:`(s,r)`,
+Pixel adds a face-averaged discretization of :math:`\nabla \cdot (D_{s,r}\nabla c_r)` to species :math:`s`.
+
+Space-dependent expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For spatially dependent reactions and cross-diffusion expressions, Pixel provides all three
+spatial coordinates as local variables per voxel: :math:`x`, :math:`y`, :math:`z`.
+The internal state vector therefore includes three spatial padding values (plus optional time),
+and these values are held constant during time integration.
+
 Step-by-step derivation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-For one species, start from
+For one species (without cross-diffusion), start from
 
 .. math::
 
@@ -291,8 +319,20 @@ above which the system becomes unstable:
 
    \delta t \leq  \frac{S}{2 D_{\max} \left(\frac{1}{\delta x^2}+\frac{1}{\delta y^2}+\frac{1}{\delta z^2}\right)}
 
-where :math:`D_{\max}` is the largest diffusion constant value over all voxels for the species,
-and :math:`S` is that species' storage coefficient.
+where :math:`D_{\max}` is an effective diffusion scale for the species, and :math:`S` is that
+species' storage coefficient.
+
+Without cross-diffusion, :math:`D_{\max}` is the largest self-diffusion value over all voxels.
+With cross-diffusion, Pixel uses a conservative bound based on
+
+.. math::
+
+   D_{\mathrm{eff},s}
+   =
+   D_{s,s,\max}
+   + \sum_{r \ne s} \max_{\mathbf{x}} \left|D_{s,r}(\mathbf{x})\right|
+
+and applies the same CFL expression with :math:`D_{\max} = D_{\mathrm{eff},s}`.
 
 So if the user selects a timestep larger than this,
 the simulator automatically reduces it to the above value to avoid the system becoming unstable.
@@ -326,6 +366,9 @@ When a species has storage coefficient :math:`S = 0`, its PDE becomes an algebra
 .. math::
 
    0 = \nabla \cdot \left( D \nabla c \right) + R
+
+If cross-diffusion terms are present, the same generalized diffusion operator from the
+``Cross-diffusion`` section is used in this constraint.
 
 Rather than being integrated forward in time, the concentration of such a species must satisfy this constraint at every timestep. The Pixel solver handles this via operator splitting with adaptive pseudo-time relaxation.
 
@@ -377,3 +420,9 @@ Non-spatial species
 ^^^^^^^^^^^^^^^^^^^
 
 A species can be 'non-spatial', which means that at each timestep, its time derivative is calculated as normal at each point in the compartment, but is then spatially averaged over the whole compartment. This can be used to approximate a species with a very high diffusion constant without requiring a correspondingly tiny timestep to maintain the stability of the solver.
+
+Non-negativity clamp
+^^^^^^^^^^^^^^^^^^^^
+
+After each accepted timestep, Pixel clamps negative primary-species concentrations to zero.
+This keeps concentrations physically meaningful and matches the behaviour of dune-copasi.

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -3,14 +3,19 @@
 #include "dialogimagedata.hpp"
 #include "guiutils.hpp"
 #include "qlabelmousetracker.hpp"
+#include "qplaintextmathedit.hpp"
 #include "qvoxelrenderer.hpp"
 #include "sme/logger.hpp"
 #include "sme/model.hpp"
 #include "ui_tabspecies.h"
 #include <QButtonGroup>
+#include <QCheckBox>
 #include <QColorDialog>
+#include <QHeaderView>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QSignalBlocker>
+#include <QTableWidgetItem>
 
 TabSpecies::TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
                        QVoxelRenderer *voxelRenderer, QWidget *parent)
@@ -74,6 +79,15 @@ TabSpecies::TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
           &TabSpecies::txtStorage_editingFinished);
   connect(ui->btnChangeSpeciesColor, &QPushButton::clicked, this,
           &TabSpecies::btnChangeSpeciesColor_clicked);
+  auto *crossDiffusionTable = ui->tblCrossDiffusion;
+  crossDiffusionTable->horizontalHeader()->setSectionResizeMode(
+      0, QHeaderView::ResizeToContents);
+  crossDiffusionTable->horizontalHeader()->setSectionResizeMode(
+      1, QHeaderView::ResizeToContents);
+  crossDiffusionTable->horizontalHeader()->setSectionResizeMode(
+      2, QHeaderView::Stretch);
+  crossDiffusionTable->verticalHeader()->setVisible(false);
+  crossDiffusionTable->setFocusPolicy(Qt::NoFocus);
 }
 
 TabSpecies::~TabSpecies() = default;
@@ -120,6 +134,7 @@ void TabSpecies::enableWidgets(bool enable) {
   ui->btnEditImageDiffusionConstant->setEnabled(enable);
   ui->btnSpeciesAdvanced->setEnabled(enable);
   ui->txtStorage->setEnabled(enable);
+  ui->tblCrossDiffusion->setEnabled(enable);
   ui->btnChangeSpeciesColor->setEnabled(enable);
 }
 
@@ -212,6 +227,7 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
   // storage
   ui->txtStorage->setText(
       QString::number(model.getSpecies().getStorage(currentSpeciesId)));
+  updateCrossDiffusionWidgets();
   // color
   lblSpeciesColorPixmap.fill(model.getSpecies().getColor(currentSpeciesId));
   ui->lblSpeciesColor->setPixmap(lblSpeciesColorPixmap);
@@ -450,5 +466,125 @@ void TabSpecies::btnChangeSpeciesColor_clicked() {
     SPDLOG_DEBUG("  - set new color to {:x}", newCol.rgb());
     model.getSpecies().setColor(currentSpeciesId, newCol.rgb());
     listSpecies_currentItemChanged(ui->listSpecies->currentItem(), nullptr);
+  }
+}
+
+void TabSpecies::updateCrossDiffusionWidgets() {
+  auto *table = ui->tblCrossDiffusion;
+  table->setRowCount(0);
+  if (currentSpeciesId.isEmpty()) {
+    return;
+  }
+  const auto compartmentId{model.getSpecies().getCompartment(currentSpeciesId)};
+  const auto speciesIds{model.getSpecies().getIds(compartmentId)};
+  const auto symbols{model.getParameters().getSymbols({compartmentId})};
+  const auto functions{model.getFunctions().getSymbolicFunctions()};
+  const bool allowCrossDiffusion{
+      model.getSpecies().getIsSpatial(currentSpeciesId) &&
+      !model.getSpecies().getIsConstant(currentSpeciesId)};
+  for (const auto &otherSpeciesId : speciesIds) {
+    if (otherSpeciesId == currentSpeciesId) {
+      continue;
+    }
+    const int row{table->rowCount()};
+    table->insertRow(row);
+    auto *speciesNameItem{
+        new QTableWidgetItem(model.getSpecies().getName(otherSpeciesId))};
+    speciesNameItem->setFlags(Qt::ItemIsEnabled);
+    table->setItem(row, 0, speciesNameItem);
+    const auto expression{model.getSpecies().getCrossDiffusionConstant(
+        currentSpeciesId, otherSpeciesId)};
+    auto *chkEnabled{new QCheckBox(table)};
+    chkEnabled->setChecked(!expression.isEmpty());
+    chkEnabled->setEnabled(allowCrossDiffusion);
+    table->setCellWidget(row, 1, chkEnabled);
+    auto *txtExpression{new QPlainTextMathEdit(table)};
+    txtExpression->setTabChangesFocus(true);
+    txtExpression->setMaximumHeight(35);
+    txtExpression->setMinimumHeight(30);
+    for (const auto &symbol : symbols) {
+      txtExpression->addVariable(symbol.id, symbol.name);
+    }
+    for (const auto &function : functions) {
+      txtExpression->addFunction(function);
+    }
+    {
+      QSignalBlocker blocker(txtExpression);
+      txtExpression->importVariableMath(
+          expression.isEmpty() ? "0" : expression.toStdString());
+    }
+    txtExpression->setEnabled(allowCrossDiffusion && chkEnabled->isChecked());
+    table->setCellWidget(row, 2, txtExpression);
+    connect(chkEnabled, &QCheckBox::toggled, this,
+            [this, otherSpeciesId, txtExpression](bool enabled) {
+              setCrossDiffusionEnabled(otherSpeciesId, txtExpression, enabled);
+            });
+    connect(txtExpression, &QPlainTextMathEdit::mathChanged, this,
+            [this, otherSpeciesId, txtExpression](
+                const QString &math, bool valid, const QString &errorMessage) {
+              Q_UNUSED(math);
+              Q_UNUSED(errorMessage);
+              setCrossDiffusionExpression(otherSpeciesId, txtExpression, valid);
+            });
+  }
+}
+
+void TabSpecies::setCrossDiffusionEnabled(const QString &otherSpeciesId,
+                                          QPlainTextMathEdit *txtExpression,
+                                          bool enabled) {
+  const bool allowCrossDiffusion{
+      model.getSpecies().getIsSpatial(currentSpeciesId) &&
+      !model.getSpecies().getIsConstant(currentSpeciesId)};
+  txtExpression->setEnabled(allowCrossDiffusion && enabled);
+  if (!allowCrossDiffusion) {
+    return;
+  }
+  if (!enabled) {
+    model.getSpecies().removeCrossDiffusionConstant(currentSpeciesId,
+                                                    otherSpeciesId);
+    return;
+  }
+  auto expr{txtExpression->getVariableMath()};
+  const bool exprIsZero{expr == "0" || expr == "0.0"};
+  const bool exprIsValid{txtExpression->mathIsValid() &&
+                         model.getSpecies().isValidCrossDiffusionExpression(
+                             currentSpeciesId, QString::fromStdString(expr))};
+  if (exprIsZero || !exprIsValid) {
+    expr = "1";
+    QSignalBlocker blocker(txtExpression);
+    txtExpression->importVariableMath(expr);
+  }
+  model.getSpecies().setCrossDiffusionConstant(currentSpeciesId, otherSpeciesId,
+                                               expr.c_str());
+}
+
+void TabSpecies::setCrossDiffusionExpression(const QString &otherSpeciesId,
+                                             QPlainTextMathEdit *txtExpression,
+                                             bool valid) {
+  if (!valid) {
+    return;
+  }
+  auto *table = ui->tblCrossDiffusion;
+  for (int row = 0; row < table->rowCount(); ++row) {
+    auto *chkEnabled = qobject_cast<QCheckBox *>(table->cellWidget(row, 1));
+    auto *txtExpr =
+        qobject_cast<QPlainTextMathEdit *>(table->cellWidget(row, 2));
+    if (txtExpr == txtExpression && chkEnabled != nullptr &&
+        chkEnabled->isChecked()) {
+      const auto expr{txtExpression->getVariableMath()};
+      if (expr == "0" || expr == "0.0") {
+        {
+          QSignalBlocker blocker(chkEnabled);
+          chkEnabled->setChecked(false);
+        }
+        txtExpression->setEnabled(false);
+        model.getSpecies().removeCrossDiffusionConstant(currentSpeciesId,
+                                                        otherSpeciesId);
+        return;
+      }
+      model.getSpecies().setCrossDiffusionConstant(
+          currentSpeciesId, otherSpeciesId, expr.c_str());
+      return;
+    }
   }
 }

--- a/gui/tabs/tabspecies.hpp
+++ b/gui/tabs/tabspecies.hpp
@@ -16,6 +16,7 @@ class Model;
 } // namespace sme::model
 
 class QLabelMouseTracker;
+class QPlainTextMathEdit;
 class QVoxelRenderer;
 
 class TabSpecies : public QWidget {
@@ -53,4 +54,11 @@ private:
   void btnEditImageDiffusionConstant_clicked();
   void txtStorage_editingFinished();
   void btnChangeSpeciesColor_clicked();
+  void updateCrossDiffusionWidgets();
+  void setCrossDiffusionEnabled(const QString &otherSpeciesId,
+                                QPlainTextMathEdit *txtExpression,
+                                bool enabled);
+  void setCrossDiffusionExpression(const QString &otherSpeciesId,
+                                   QPlainTextMathEdit *txtExpression,
+                                   bool valid);
 };

--- a/gui/tabs/tabspecies.ui
+++ b/gui/tabs/tabspecies.ui
@@ -557,6 +557,47 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblCrossDiffusion">
+              <property name="text">
+               <string>Cross diffusion:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="QTableWidget" name="tblCrossDiffusion">
+              <property name="alternatingRowColors">
+               <bool>true</bool>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::NoSelection</enum>
+              </property>
+              <property name="columnCount">
+               <number>3</number>
+              </property>
+              <property name="rowCount">
+               <number>0</number>
+              </property>
+              <column>
+               <property name="text">
+                <string>Species</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Enabled</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Expression</string>
+               </property>
+              </column>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -1,6 +1,7 @@
 #include "catch_wrapper.hpp"
 #include "model_test_utils.hpp"
 #include "qlabelmousetracker.hpp"
+#include "qplaintextmathedit.hpp"
 #include "qt_test_utils.hpp"
 #include "qvoxelrenderer.hpp"
 #include "sme/model.hpp"
@@ -10,6 +11,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QTableWidget>
 #include <QToolButton>
 #include <QTreeWidget>
 
@@ -81,6 +83,8 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
   REQUIRE(btnSpeciesAdvanced != nullptr);
   auto *txtStorage{tab.findChild<QLineEdit *>("txtStorage")};
   REQUIRE(txtStorage != nullptr);
+  auto *tblCrossDiffusion{tab.findChild<QTableWidget *>("tblCrossDiffusion")};
+  REQUIRE(tblCrossDiffusion != nullptr);
 
   auto *btnChangeSpeciesColor{
       tab.findChild<QPushButton *>("btnChangeSpeciesColor")};
@@ -180,12 +184,59 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     sendKeyEvents(listSpecies, {"Down"});
     REQUIRE(txtDiffusionConstant->text() == "9");
     // expand advanced settings and edit storage value
-    sendMouseClick(btnSpeciesAdvanced);
+    sendMouseClick(btnSpeciesAdvanced, btnSpeciesAdvanced->rect().center());
     txtStorage->setFocus();
     sendKeyEvents(txtStorage, {"End", "Backspace", "2", "Enter"});
+    REQUIRE(tblCrossDiffusion->rowCount() == 1);
+    auto *chkCrossDiffusionEnabled{
+        qobject_cast<QCheckBox *>(tblCrossDiffusion->cellWidget(0, 1))};
+    REQUIRE(chkCrossDiffusionEnabled != nullptr);
+    auto *txtCrossDiffusionExpression{qobject_cast<QPlainTextMathEdit *>(
+        tblCrossDiffusion->cellWidget(0, 2))};
+    REQUIRE(txtCrossDiffusionExpression != nullptr);
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == false);
+    REQUIRE(chkCrossDiffusionEnabled->isEnabled() == true);
+    REQUIRE(chkCrossDiffusionEnabled->isVisible() == true);
+    chkCrossDiffusionEnabled->setFocus();
+    sendKeyEvents(chkCrossDiffusionEnabled, {" "});
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == true);
+    txtCrossDiffusionExpression->setFocus();
+    sendKeyEvents(txtCrossDiffusionExpression,
+                  {"Backspace", "A", "_", "o", "u", "t"});
     sendKeyEvents(listSpecies, {"Up"});
     sendKeyEvents(listSpecies, {"Down"});
     REQUIRE(txtStorage->text() == "2");
+    REQUIRE(tblCrossDiffusion->rowCount() == 1);
+    chkCrossDiffusionEnabled =
+        qobject_cast<QCheckBox *>(tblCrossDiffusion->cellWidget(0, 1));
+    REQUIRE(chkCrossDiffusionEnabled != nullptr);
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == true);
+    txtCrossDiffusionExpression =
+        qobject_cast<QPlainTextMathEdit *>(tblCrossDiffusion->cellWidget(0, 2));
+    REQUIRE(txtCrossDiffusionExpression != nullptr);
+    // expression=0 should disable + remove the term
+    txtCrossDiffusionExpression->importVariableMath("0");
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == false);
+    REQUIRE(txtCrossDiffusionExpression->isEnabled() == false);
+    REQUIRE(
+        model.getSpecies().getCrossDiffusionConstant("B_c1", "A_c1").isEmpty());
+    // re-enable and set a non-zero expression again
+    chkCrossDiffusionEnabled->setFocus();
+    sendKeyEvents(chkCrossDiffusionEnabled, {" "});
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == true);
+    txtCrossDiffusionExpression->importVariableMath("A_c1 + 2");
+    sendKeyEvents(listSpecies, {"Up"});
+    sendKeyEvents(listSpecies, {"Down"});
+    chkCrossDiffusionEnabled =
+        qobject_cast<QCheckBox *>(tblCrossDiffusion->cellWidget(0, 1));
+    REQUIRE(chkCrossDiffusionEnabled != nullptr);
+    REQUIRE(chkCrossDiffusionEnabled->isChecked() == true);
+    auto storedCrossDiffusionExpr{
+        model.getSpecies().getCrossDiffusionConstant("B_c1", "A_c1")};
+    REQUIRE(!storedCrossDiffusionExpr.isEmpty());
+    REQUIRE(storedCrossDiffusionExpr != "1");
+    REQUIRE(storedCrossDiffusionExpr != "1.0");
+    REQUIRE(storedCrossDiffusionExpr.contains("2"));
     // click change species color, then cancel
     mwt.addUserAction({"Esc"});
     mwt.start();


### PR DESCRIPTION
- tabSpecies
  - add to advanced drop-down section
  - user can select any other species in the compartment and enter a cross-diffusion term
  - this is parsed in the same way as reaction terms
- dune-copasi
  - cross-diffusion expressions and their jacobians are provided in the same way as is done for reaction terms
- sbml
  - cross-diffusion terms are stored as annotations
- pixel
  - cross-diffusion contributions are calculated in an extra step if present
  - doesn't affect performance of the usual case where there are no cross-diffusion terms
- resolves #1115

Also

- add missing z values for pixel solver with spatially-dependent reaction terms
- clamp negative concentrations from pixel solver to zero to match dune-copasi