### PR TITLE
Make Python and CLI simulation options consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - dialog for importing analytic geometry where users can set voxel resolution and preview the converted sampled image before import
+- aligned simulation option exposure and naming across GUI, CLI and Python interfaces by adding DUNE/Pixel solver option overrides to CLI and exposing Python `model.simulation_settings` (including simulation times) plus optional `simulate(...)` time arguments
 
 ## [1.11.0] - 2026-02-04
 ### Added

--- a/cli/src/cli_command.cpp
+++ b/cli/src/cli_command.cpp
@@ -9,6 +9,88 @@
 
 namespace sme::cli {
 
+static bool simulationStoppedOrTimedOut(const std::string &msg) {
+  return msg == "Simulation timeout" || msg == "Simulation stopped early";
+}
+
+static void applySimulationOptionOverrides(model::Model &model,
+                                           const Params &params) {
+  auto &settings{model.getSimulationSettings()};
+  if (params.simType.has_value()) {
+    settings.simulatorType = params.simType.value();
+  }
+  auto &opt{settings.options};
+  if (params.maxThreads.has_value()) {
+    opt.dune.maxThreads = params.maxThreads.value();
+    opt.pixel.maxThreads = params.maxThreads.value();
+    if (!params.sim.pixelEnableMultithreading.has_value()) {
+      opt.pixel.enableMultiThreading = (params.maxThreads.value() != 1);
+    }
+  }
+  if (params.sim.duneIntegrator.has_value()) {
+    opt.dune.integrator = params.sim.duneIntegrator.value();
+  }
+  if (params.sim.duneInitialTimestep.has_value()) {
+    opt.dune.dt = params.sim.duneInitialTimestep.value();
+  }
+  if (params.sim.duneMinTimestep.has_value()) {
+    opt.dune.minDt = params.sim.duneMinTimestep.value();
+  }
+  if (params.sim.duneMaxTimestep.has_value()) {
+    opt.dune.maxDt = params.sim.duneMaxTimestep.value();
+  }
+  if (params.sim.duneIncreaseFactor.has_value()) {
+    opt.dune.increase = params.sim.duneIncreaseFactor.value();
+  }
+  if (params.sim.duneDecreaseFactor.has_value()) {
+    opt.dune.decrease = params.sim.duneDecreaseFactor.value();
+  }
+  if (params.sim.duneOutputVtkFiles.has_value()) {
+    opt.dune.writeVTKfiles = params.sim.duneOutputVtkFiles.value();
+  }
+  if (params.sim.duneNewtonRelativeError.has_value()) {
+    opt.dune.newtonRelErr = params.sim.duneNewtonRelativeError.value();
+  }
+  if (params.sim.duneNewtonAbsoluteError.has_value()) {
+    opt.dune.newtonAbsErr = params.sim.duneNewtonAbsoluteError.value();
+  }
+  if (params.sim.duneLinearSolver.has_value()) {
+    opt.dune.linearSolver = params.sim.duneLinearSolver.value();
+  }
+  if (params.sim.duneMaxThreads.has_value()) {
+    opt.dune.maxThreads = params.sim.duneMaxThreads.value();
+  }
+  if (params.sim.pixelIntegrator.has_value()) {
+    opt.pixel.integrator = params.sim.pixelIntegrator.value();
+  }
+  if (params.sim.pixelMaxRelativeError.has_value()) {
+    opt.pixel.maxErr.rel = params.sim.pixelMaxRelativeError.value();
+  }
+  if (params.sim.pixelMaxAbsoluteError.has_value()) {
+    opt.pixel.maxErr.abs = params.sim.pixelMaxAbsoluteError.value();
+  }
+  if (params.sim.pixelMaxTimestep.has_value()) {
+    opt.pixel.maxTimestep = params.sim.pixelMaxTimestep.value();
+  }
+  if (params.sim.pixelEnableMultithreading.has_value()) {
+    opt.pixel.enableMultiThreading =
+        params.sim.pixelEnableMultithreading.value();
+  }
+  if (params.sim.pixelMaxThreads.has_value()) {
+    opt.pixel.maxThreads = params.sim.pixelMaxThreads.value();
+    if (!params.sim.pixelEnableMultithreading.has_value()) {
+      opt.pixel.enableMultiThreading =
+          (params.sim.pixelMaxThreads.value() != 1);
+    }
+  }
+  if (params.sim.pixelDoCSE.has_value()) {
+    opt.pixel.doCSE = params.sim.pixelDoCSE.value();
+  }
+  if (params.sim.pixelOptLevel.has_value()) {
+    opt.pixel.optLevel = params.sim.pixelOptLevel.value();
+  }
+}
+
 void printSimulationInfo(const sme::model::Model &model) {
   const auto &data{model.getSimulationData()};
   if (auto n{data.timePoints.size()}; n > 1) {
@@ -38,24 +120,41 @@ bool runCommand(const Params &params) {
     return false;
   }
 
-  // setup simulator options
-  s.getSimulationSettings().simulatorType = params.simType;
-  auto &options{s.getSimulationSettings().options};
-  options.pixel.enableMultiThreading = true;
-  options.dune.maxThreads = params.maxThreads;
-  options.pixel.maxThreads = params.maxThreads;
-  if (params.maxThreads == 1) {
-    options.pixel.enableMultiThreading = false;
-  }
+  applySimulationOptionOverrides(s, params);
 
   if (params.command == "simulate") {
-    auto times{simulate::parseSimulationTimes(
-        params.sim.simulationTimes.c_str(), params.sim.imageIntervals.c_str())};
-    if (!times.has_value()) {
-      fmt::print("\n\nError: failed to parse simulation times\n\n");
+    const auto currentTimes{s.getSimulationSettings().times};
+    if (!params.sim.continueExistingSimulation) {
+      s.getSimulationData().clear();
+      s.getSimulationSettings().times.clear();
+    }
+    const bool hasSimulationTimes = !params.sim.simulationTimes.empty();
+    const bool hasImageIntervals = !params.sim.imageIntervals.empty();
+    if (hasSimulationTimes != hasImageIntervals) {
+      fmt::print("\n\nError: simulation times and image intervals must both "
+                 "be set or both be omitted\n\n");
       return false;
     }
-    printSimulationTimes(times.value());
+    std::vector<std::pair<std::size_t, double>> times;
+    if (hasSimulationTimes) {
+      auto parsedTimes{
+          simulate::parseSimulationTimes(params.sim.simulationTimes.c_str(),
+                                         params.sim.imageIntervals.c_str())};
+      if (!parsedTimes.has_value()) {
+        fmt::print("\n\nError: failed to parse simulation times\n\n");
+        return false;
+      }
+      times = parsedTimes.value();
+    } else {
+      times = currentTimes;
+      if (times.empty()) {
+        fmt::print("\n\nError: no simulation times specified. Provide times "
+                   "and image intervals, or use a model with existing "
+                   "simulation settings.\n\n");
+        return false;
+      }
+    }
+    printSimulationTimes(times);
     simulate::Simulation sim(s);
     if (const auto &e = sim.errorMessage(); !e.empty()) {
       fmt::print("\n\nError in simulation setup: {}\n\n", e);
@@ -64,10 +163,18 @@ bool runCommand(const Params &params) {
 
     printSimulationInfo(s);
 
-    sim.doMultipleTimesteps(times.value());
-    if (const auto &e = sim.errorMessage(); !e.empty()) {
+    const auto timeoutMilliseconds = params.sim.timeoutSeconds < 0.0
+                                         ? -1.0
+                                         : 1000.0 * params.sim.timeoutSeconds;
+    sim.doMultipleTimesteps(times, timeoutMilliseconds);
+    if (const auto &e = sim.errorMessage();
+        !e.empty() &&
+        (params.sim.throwOnTimeout || !simulationStoppedOrTimedOut(e))) {
       fmt::print("\n\nError during simulation: {}\n\n", e);
       return false;
+    } else if (const auto &e = sim.errorMessage();
+               !e.empty() && !params.sim.throwOnTimeout) {
+      fmt::print("\n# Simulation exited early: {}\n", e);
     }
   } else if (params.command == "fit") {
     s.getOptimizeOptions().optAlgorithm.optAlgorithmType = params.fit.algorithm;

--- a/cli/src/cli_command_t.cpp
+++ b/cli/src/cli_command_t.cpp
@@ -2,6 +2,7 @@
 #include "cli_command.hpp"
 #include "sme/model.hpp"
 #include <QFile>
+#include <optional>
 
 using namespace sme;
 
@@ -61,6 +62,63 @@ TEST_CASE("CLI Simulate", "[cli][simulate]") {
     m2.importFile(tmpOutputFile);
     REQUIRE(m2.getSimulationData().timePoints.size() == 13);
     REQUIRE(m2.getSimulationData().timePoints[12] == dbl_approx(1.20));
+
+    // run again, but clear existing simulation results before starting
+    params.sim.continueExistingSimulation = false;
+    cli::runCommand(params);
+    model::Model m3;
+    m3.importFile(tmpOutputFile);
+    REQUIRE(m3.getSimulationData().timePoints.size() == 7);
+    REQUIRE(m3.getSimulationSettings().options.pixel.integrator ==
+            simulate::PixelIntegratorType::RK212);
+
+    // and override some Pixel options
+    params.sim.pixelIntegrator = simulate::PixelIntegratorType::RK323;
+    params.sim.pixelEnableMultithreading = true;
+    params.sim.pixelMaxThreads = 1;
+    params.sim.pixelOptLevel = 2;
+    cli::runCommand(params);
+    model::Model m4;
+    m4.importFile(tmpOutputFile);
+    REQUIRE(m4.getSimulationSettings().options.pixel.integrator ==
+            simulate::PixelIntegratorType::RK323);
+    REQUIRE(m4.getSimulationSettings().options.pixel.enableMultiThreading ==
+            true);
+    REQUIRE(m4.getSimulationSettings().options.pixel.maxThreads == 1);
+    REQUIRE(m4.getSimulationSettings().options.pixel.optLevel == 2);
+
+    // overriding Pixel max threads should enable multithreading if not explicit
+    params.sim.pixelEnableMultithreading = std::nullopt;
+    params.sim.pixelMaxThreads = 4;
+    cli::runCommand(params);
+    model::Model m5;
+    m5.importFile(tmpOutputFile);
+    REQUIRE(m5.getSimulationSettings().options.pixel.enableMultiThreading ==
+            true);
+    REQUIRE(m5.getSimulationSettings().options.pixel.maxThreads == 4);
+
+    // omit times and intervals: use model simulation settings from input file
+    params.sim.simulationTimes.clear();
+    params.sim.imageIntervals.clear();
+    params.sim.continueExistingSimulation = false;
+    cli::runCommand(params);
+    model::Model m6;
+    m6.importFile(tmpOutputFile);
+    REQUIRE(m6.getSimulationData().timePoints.size() == 7);
+    REQUIRE(m6.getSimulationData().timePoints[6] == dbl_approx(0.60));
+  }
+  SECTION("Invalid partial simulation times") {
+    const char *tmpInputFile{"tmpcli4.xml"};
+    const char *tmpOutputFile{"tmpcli4.sme"};
+    QFile::remove(tmpInputFile);
+    QFile::remove(tmpOutputFile);
+    QFile::copy(":/models/ABtoC.xml", tmpInputFile);
+    cli::Params params;
+    params.command = "simulate";
+    params.inputFile = tmpInputFile;
+    params.sim.simulationTimes = "0.2";
+    params.outputFile = tmpOutputFile;
+    REQUIRE(cli::runCommand(params) == false);
   }
   SECTION("Parameter fitting") {
     const char *tmpInputFile{"tmpcli3.xml"};

--- a/cli/src/cli_params.cpp
+++ b/cli/src/cli_params.cpp
@@ -5,6 +5,41 @@
 
 namespace sme::cli {
 
+static auto makeSimulatorTypeMap() {
+  return std::map<std::string, simulate::SimulatorType, std::less<>>{
+      {"dune", simulate::SimulatorType::DUNE},
+      {"pixel", simulate::SimulatorType::Pixel}};
+}
+
+static auto makeDuneIntegratorMap() {
+  return std::map<std::string, std::string, std::less<>>{
+      {"expliciteuler", "ExplicitEuler"},
+      {"impliciteuler", "ImplicitEuler"},
+      {"heun", "Heun"},
+      {"fractionalsteptheta", "FractionalStepTheta"},
+      {"alexander2", "Alexander2"},
+      {"shu3", "Shu3"},
+      {"alexander3", "Alexander3"},
+      {"rungekutta4", "RungeKutta4"}};
+}
+
+static auto makeDuneLinearSolverMap() {
+  return std::map<std::string, std::string, std::less<>>{
+      {"bicgstab", "BiCGSTAB"},
+      {"cg", "CG"},
+      {"restartedgmres", "RestartedGMRes"},
+      {"umfpack", "UMFPack"},
+      {"superlu", "SuperLU"}};
+}
+
+static auto makePixelIntegratorMap() {
+  return std::map<std::string, simulate::PixelIntegratorType, std::less<>>{
+      {"rk101", simulate::PixelIntegratorType::RK101},
+      {"rk212", simulate::PixelIntegratorType::RK212},
+      {"rk323", simulate::PixelIntegratorType::RK323},
+      {"rk435", simulate::PixelIntegratorType::RK435}};
+}
+
 static void addParams(CLI::App &app, Params &params) {
   app.require_subcommand(1, 1);
   auto *sim_app = app.add_subcommand("simulate", "Run a spatial simulation");
@@ -19,34 +54,104 @@ static void addParams(CLI::App &app, Params &params) {
     sub_app
         ->add_option("-s,--simulator", params.simType,
                      "The simulator to use: dune or pixel")
-        ->transform(CLI::CheckedTransformer(
-            std::map<std::string, simulate::SimulatorType, std::less<>>{
-                {"dune", simulate::SimulatorType::DUNE},
-                {"pixel", simulate::SimulatorType::Pixel}},
-            CLI::ignore_case))
-        ->capture_default_str();
+        ->transform(
+            CLI::CheckedTransformer(makeSimulatorTypeMap(), CLI::ignore_case));
     sub_app
-        ->add_option("-t,--nthreads", params.maxThreads,
+        ->add_option("-t,--max-threads,--nthreads", params.maxThreads,
                      "The maximum number of CPU threads to use when simulating "
-                     "(0 means unlimited)")
-        ->check(CLI::NonNegativeNumber)
-        ->capture_default_str();
+                     "(0 means unlimited). This sets both DUNE and Pixel "
+                     "thread limits.")
+        ->check(CLI::NonNegativeNumber);
+    sub_app
+        ->add_option("--dune-integrator", params.sim.duneIntegrator,
+                     "DUNE integrator: expliciteuler, impliciteuler, heun, "
+                     "fractionalsteptheta, alexander2, shu3, alexander3, or "
+                     "rungekutta4")
+        ->transform(
+            CLI::CheckedTransformer(makeDuneIntegratorMap(), CLI::ignore_case));
+    sub_app->add_option("--dune-initial-timestep",
+                        params.sim.duneInitialTimestep,
+                        "DUNE initial timestep");
+    sub_app->add_option("--dune-min-timestep", params.sim.duneMinTimestep,
+                        "DUNE minimum timestep");
+    sub_app->add_option("--dune-max-timestep", params.sim.duneMaxTimestep,
+                        "DUNE maximum timestep");
+    sub_app->add_option("--dune-increase-factor", params.sim.duneIncreaseFactor,
+                        "DUNE timestep increase factor");
+    sub_app->add_option("--dune-decrease-factor", params.sim.duneDecreaseFactor,
+                        "DUNE timestep decrease factor");
+    sub_app->add_option("--dune-output-vtk-files",
+                        params.sim.duneOutputVtkFiles,
+                        "DUNE output VTK files (true/false)");
+    sub_app->add_option("--dune-newton-relative-error",
+                        params.sim.duneNewtonRelativeError,
+                        "DUNE Newton relative error");
+    sub_app->add_option("--dune-newton-absolute-error",
+                        params.sim.duneNewtonAbsoluteError,
+                        "DUNE Newton absolute error");
+    sub_app
+        ->add_option("--dune-linear-solver", params.sim.duneLinearSolver,
+                     "DUNE linear solver: bicgstab, cg, restartedgmres, "
+                     "umfpack, or superlu")
+        ->transform(CLI::CheckedTransformer(makeDuneLinearSolverMap(),
+                                            CLI::ignore_case));
+    sub_app->add_option("--dune-max-threads", params.sim.duneMaxThreads,
+                        "DUNE max CPU threads (0 means unlimited)");
+    sub_app
+        ->add_option("--pixel-integrator", params.sim.pixelIntegrator,
+                     "Pixel integrator: rk101, rk212, rk323, or rk435")
+        ->transform(CLI::CheckedTransformer(makePixelIntegratorMap(),
+                                            CLI::ignore_case));
+    sub_app->add_option("--pixel-max-relative-error",
+                        params.sim.pixelMaxRelativeError,
+                        "Pixel max relative local error");
+    sub_app->add_option("--pixel-max-absolute-error",
+                        params.sim.pixelMaxAbsoluteError,
+                        "Pixel max absolute local error");
+    sub_app->add_option("--pixel-max-timestep", params.sim.pixelMaxTimestep,
+                        "Pixel max timestep");
+    sub_app->add_option("--pixel-enable-multithreading",
+                        params.sim.pixelEnableMultithreading,
+                        "Enable Pixel multithreading (true/false)");
+    sub_app->add_option("--pixel-max-threads", params.sim.pixelMaxThreads,
+                        "Pixel max CPU threads (0 means unlimited)");
+    sub_app->add_option("--pixel-do-cse", params.sim.pixelDoCSE,
+                        "Enable Pixel common subexpression elimination "
+                        "(true/false)");
+    sub_app
+        ->add_option("--pixel-opt-level", params.sim.pixelOptLevel,
+                     "Pixel compiler optimization level (0-3)")
+        ->check(CLI::Range(0, 3));
     sub_app->add_option(
         "-o,--output-file", params.outputFile,
         "The output file to write the results to. If not set, then "
         "the input file is used.");
   }
   // simulation options
+  sim_app->add_option(
+      "times", params.sim.simulationTimes,
+      "The simulation time(s) (in model units of time, separated by ';'). "
+      "Optional if image-intervals is also omitted, in which case model "
+      "simulation settings are used.");
+  sim_app->add_option(
+      "image-intervals", params.sim.imageIntervals,
+      "The interval(s) between saving images (in model units of time). "
+      "Optional if times is also omitted, in which case model simulation "
+      "settings are used.");
   sim_app
-      ->add_option(
-          "times", params.sim.simulationTimes,
-          "The simulation time(s) (in model units of time, separated by ';') ")
-      ->required();
+      ->add_option("--timeout-seconds", params.sim.timeoutSeconds,
+                   "Simulation timeout in seconds (-1 means no timeout)")
+      ->capture_default_str();
   sim_app
-      ->add_option(
-          "image-intervals", params.sim.imageIntervals,
-          "The interval(s) between saving images (in model units of time)")
-      ->required();
+      ->add_option("--throw-on-timeout", params.sim.throwOnTimeout,
+                   "Whether to treat timeout as an error (true/false)")
+      ->capture_default_str();
+  sim_app
+      ->add_option("--continue-existing-simulation",
+                   params.sim.continueExistingSimulation,
+                   "Whether to continue existing simulation results from the "
+                   "input model (true/false)")
+      ->capture_default_str();
   // fitting options
   using enum sme::simulate::OptAlgorithmType;
   fit_app
@@ -125,6 +230,7 @@ std::string toString(const simulate::SimulatorType &s) {
 }
 
 void printParams(const Params &params) {
+  auto boolToString = [](bool b) { return b ? "true" : "false"; };
   if (params.command == "fit") {
     fmt::print("\n# Fitting parameters:\n");
   } else if (params.command == "simulate") {
@@ -132,8 +238,13 @@ void printParams(const Params &params) {
   }
   fmt::print("#   - Input file: {}\n", params.inputFile);
   fmt::print("#   - Output file: {}\n", params.outputFile);
-  fmt::print("#   - Simulation Type: {}\n", toString(params.simType));
-  fmt::print("#   - Max CPU threads (simulation): {}\n", params.maxThreads);
+  fmt::print("#   - Simulation Type: {}\n",
+             params.simType.has_value() ? toString(params.simType.value())
+                                        : "(from model)");
+  fmt::print("#   - Max CPU threads (simulation): {}\n",
+             params.maxThreads.has_value()
+                 ? fmt::format("{}", params.maxThreads.value())
+                 : "(from model)");
   if (params.command == "fit") {
     fmt::print("#   - Optimization algorithm: {}\n",
                simulate::toString(params.fit.algorithm));
@@ -144,8 +255,17 @@ void printParams(const Params &params) {
     fmt::print("#   - Number of iterations: {}\n", params.fit.nIterations);
   }
   if (params.command == "simulate") {
-    fmt::print("#   - Simulation Length(s): {}\n", params.sim.simulationTimes);
-    fmt::print("#   - Image Interval(s): {}\n", params.sim.imageIntervals);
+    fmt::print("#   - Simulation Length(s): {}\n",
+               params.sim.simulationTimes.empty() ? "(from model)"
+                                                  : params.sim.simulationTimes);
+    fmt::print("#   - Image Interval(s): {}\n",
+               params.sim.imageIntervals.empty() ? "(from model)"
+                                                 : params.sim.imageIntervals);
+    fmt::print("#   - Timeout (seconds): {}\n", params.sim.timeoutSeconds);
+    fmt::print("#   - Throw on timeout: {}\n",
+               boolToString(params.sim.throwOnTimeout));
+    fmt::print("#   - Continue existing simulation: {}\n",
+               boolToString(params.sim.continueExistingSimulation));
   }
 }
 

--- a/cli/src/cli_params.hpp
+++ b/cli/src/cli_params.hpp
@@ -3,12 +3,36 @@
 #include "sme/optimize_options.hpp"
 #include "sme/simulate.hpp"
 #include <CLI/CLI.hpp>
+#include <optional>
+#include <string>
 
 namespace sme::cli {
 
 struct SimParams {
   std::string simulationTimes;
   std::string imageIntervals;
+  double timeoutSeconds{-1.0};
+  bool throwOnTimeout{true};
+  bool continueExistingSimulation{true};
+  std::optional<std::string> duneIntegrator{};
+  std::optional<double> duneInitialTimestep{};
+  std::optional<double> duneMinTimestep{};
+  std::optional<double> duneMaxTimestep{};
+  std::optional<double> duneIncreaseFactor{};
+  std::optional<double> duneDecreaseFactor{};
+  std::optional<bool> duneOutputVtkFiles{};
+  std::optional<double> duneNewtonRelativeError{};
+  std::optional<double> duneNewtonAbsoluteError{};
+  std::optional<std::string> duneLinearSolver{};
+  std::optional<std::size_t> duneMaxThreads{};
+  std::optional<simulate::PixelIntegratorType> pixelIntegrator{};
+  std::optional<double> pixelMaxRelativeError{};
+  std::optional<double> pixelMaxAbsoluteError{};
+  std::optional<double> pixelMaxTimestep{};
+  std::optional<bool> pixelEnableMultithreading{};
+  std::optional<std::size_t> pixelMaxThreads{};
+  std::optional<bool> pixelDoCSE{};
+  std::optional<unsigned> pixelOptLevel{};
 };
 
 struct FitParams {
@@ -23,9 +47,9 @@ struct Params {
   SimParams sim{};
   FitParams fit{};
   std::string inputFile;
-  simulate::SimulatorType simType{simulate::SimulatorType::DUNE};
+  std::optional<simulate::SimulatorType> simType{};
   std::string outputFile{};
-  std::size_t maxThreads{0};
+  std::optional<std::size_t> maxThreads{};
 };
 
 Params setupCLI(CLI::App &app);

--- a/cli/src/cli_params_t.cpp
+++ b/cli/src/cli_params_t.cpp
@@ -22,4 +22,37 @@ TEST_CASE("CLI Params", "[cli][params]") {
     REQUIRE_NOTHROW(a.parse(fmt::format("fit x.sme -a{}", i)));
     REQUIRE(params.fit.algorithm == simulate::optAlgorithmTypes[i]);
   }
+
+  CLI::App b;
+  auto simParams = cli::setupCLI(b);
+  REQUIRE_NOTHROW(b.parse(
+      "simulate x.sme 1 0.1 --simulator pixel --max-threads 3 "
+      "--dune-integrator heun --dune-linear-solver superlu "
+      "--pixel-integrator rk323 --pixel-enable-multithreading true "
+      "--pixel-opt-level 2 --timeout-seconds 10 --throw-on-timeout false "
+      "--continue-existing-simulation false"));
+  REQUIRE(simParams.simType.has_value());
+  REQUIRE(simParams.simType.value() == simulate::SimulatorType::Pixel);
+  REQUIRE(simParams.maxThreads.has_value());
+  REQUIRE(simParams.maxThreads.value() == 3);
+  REQUIRE(simParams.sim.duneIntegrator.has_value());
+  REQUIRE(simParams.sim.duneIntegrator.value() == "Heun");
+  REQUIRE(simParams.sim.duneLinearSolver.has_value());
+  REQUIRE(simParams.sim.duneLinearSolver.value() == "SuperLU");
+  REQUIRE(simParams.sim.pixelIntegrator.has_value());
+  REQUIRE(simParams.sim.pixelIntegrator.value() ==
+          simulate::PixelIntegratorType::RK323);
+  REQUIRE(simParams.sim.pixelEnableMultithreading.has_value());
+  REQUIRE(simParams.sim.pixelEnableMultithreading.value() == true);
+  REQUIRE(simParams.sim.pixelOptLevel.has_value());
+  REQUIRE(simParams.sim.pixelOptLevel.value() == 2);
+  REQUIRE(simParams.sim.timeoutSeconds == dbl_approx(10));
+  REQUIRE(simParams.sim.throwOnTimeout == false);
+  REQUIRE(simParams.sim.continueExistingSimulation == false);
+
+  CLI::App c;
+  auto simParamsNoTimes = cli::setupCLI(c);
+  REQUIRE_NOTHROW(c.parse("simulate x.sme"));
+  REQUIRE(simParamsNoTimes.sim.simulationTimes.empty());
+  REQUIRE(simParamsNoTimes.sim.imageIntervals.empty());
 }

--- a/docs/quickstart/run-simulation.rst
+++ b/docs/quickstart/run-simulation.rst
@@ -2,7 +2,8 @@ Running a Simulation
 ====================
 
 To simulate the spatial model, click on the "Simulate" tab,
-specify the simulation time and desired interval between images, then click "Simulate".
+specify the simulation times and desired image intervals, then click "Simulate".
+Both fields accept semicolon-delimited lists for multi-stage simulations.
 
 The default simulation type is `DUNE`, a high-quality FEM solver,
 which solves the PDE on the triangular meshed approximation of the geometry.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -47,6 +47,13 @@ For example:
 
     ./spatial-cli simulate results.sme "5;25;10" "1;2.5;0.1"
 
+If the model already has simulation settings, the positional ``times`` and ``image-intervals``
+arguments can be omitted and the stored settings will be used:
+
+.. code-block:: bash
+
+    ./spatial-cli simulate results.sme --continue-existing-simulation false
+
 Parameter fitting
 -----------------
 
@@ -67,7 +74,7 @@ Command line parameters
 
 .. code-block:: bash
 
-    Spatial Model Editor CLI v1.9.0
+    Spatial Model Editor CLI v1.11.0
 
 
     ./cli/spatial-cli [OPTIONS] SUBCOMMAND
@@ -90,24 +97,73 @@ Command line parameters
     Run a spatial simulation
 
 
-    ./spatial-cli simulate [OPTIONS] file times image-intervals
+    ./spatial-cli simulate [OPTIONS] file [times] [image-intervals]
 
 
     POSITIONALS:
       file TEXT:FILE REQUIRED     The spatial SBML model to simulate
-      times TEXT REQUIRED         The simulation time(s) (in model units of time, separated by ';')
-      image-intervals TEXT REQUIRED
-                                  The interval(s) between saving images (in model units of time)
+      times TEXT                  The simulation time(s) (in model units of time, separated by ';').
+                                  Optional if image-intervals is also omitted, in which case model
+                                  simulation settings are used.
+      image-intervals TEXT        The interval(s) between saving images (in model units of time).
+                                  Optional if times is also omitted, in which case model simulation
+                                  settings are used.
 
     OPTIONS:
       -h,     --help              Print this help message and exit
-      -s,     --simulator ENUM:value in {dune->0,pixel->1} OR {0,1} [0]
+      -s,     --simulator ENUM:value in {dune->0,pixel->1} OR {0,1}
                                   The simulator to use: dune or pixel
-      -t,     --nthreads UINT:NONNEGATIVE [0]
+      -t,     --max-threads, --nthreads UINT:NONNEGATIVE
                                   The maximum number of CPU threads to use when simulating (0 means
-                                  unlimited)
+                                  unlimited). This sets both DUNE and Pixel thread limits.
+              --dune-integrator TEXT
+                                  DUNE integrator: expliciteuler, impliciteuler, heun,
+                                  fractionalsteptheta, alexander2, shu3, alexander3, or rungekutta4
+              --dune-initial-timestep FLOAT
+                                  DUNE initial timestep
+              --dune-min-timestep FLOAT
+                                  DUNE minimum timestep
+              --dune-max-timestep FLOAT
+                                  DUNE maximum timestep
+              --dune-increase-factor FLOAT
+                                  DUNE timestep increase factor
+              --dune-decrease-factor FLOAT
+                                  DUNE timestep decrease factor
+              --dune-output-vtk-files BOOLEAN
+                                  DUNE output VTK files (true/false)
+              --dune-newton-relative-error FLOAT
+                                  DUNE Newton relative error
+              --dune-newton-absolute-error FLOAT
+                                  DUNE Newton absolute error
+              --dune-linear-solver TEXT
+                                  DUNE linear solver: bicgstab, cg, restartedgmres, umfpack, or superlu
+              --dune-max-threads UINT
+                                  DUNE max CPU threads (0 means unlimited)
+              --pixel-integrator ENUM
+                                  Pixel integrator: rk101, rk212, rk323, or rk435
+              --pixel-max-relative-error FLOAT
+                                  Pixel max relative local error
+              --pixel-max-absolute-error FLOAT
+                                  Pixel max absolute local error
+              --pixel-max-timestep FLOAT
+                                  Pixel max timestep
+              --pixel-enable-multithreading BOOLEAN
+                                  Enable Pixel multithreading (true/false)
+              --pixel-max-threads UINT
+                                  Pixel max CPU threads (0 means unlimited)
+              --pixel-do-cse BOOLEAN
+                                  Enable Pixel common subexpression elimination (true/false)
+              --pixel-opt-level UINT
+                                  Pixel compiler optimization level (0-3)
       -o,     --output-file TEXT  The output file to write the results to. If not set, then the
                                   input file is used.
+              --timeout-seconds FLOAT [-1]
+                                  Simulation timeout in seconds (-1 means no timeout)
+              --throw-on-timeout BOOLEAN [1]
+                                  Whether to treat timeout as an error (true/false)
+              --continue-existing-simulation BOOLEAN [1]
+                                  Whether to continue existing simulation results from the input model
+                                  (true/false)
 
 `spatial-cli fit --help` displays the available options for the parameter fitting subcommand:
 
@@ -124,11 +180,30 @@ Command line parameters
 
     OPTIONS:
       -h,     --help              Print this help message and exit
-      -s,     --simulator ENUM:value in {dune->0,pixel->1} OR {0,1} [0]
+      -s,     --simulator ENUM:value in {dune->0,pixel->1} OR {0,1}
                                   The simulator to use: dune or pixel
-      -t,     --nthreads UINT:NONNEGATIVE [0]
+      -t,     --max-threads, --nthreads UINT:NONNEGATIVE
                                   The maximum number of CPU threads to use when simulating (0 means
-                                  unlimited)
+                                  unlimited). This sets both DUNE and Pixel thread limits.
+              --dune-integrator TEXT
+              --dune-initial-timestep FLOAT
+              --dune-min-timestep FLOAT
+              --dune-max-timestep FLOAT
+              --dune-increase-factor FLOAT
+              --dune-decrease-factor FLOAT
+              --dune-output-vtk-files BOOLEAN
+              --dune-newton-relative-error FLOAT
+              --dune-newton-absolute-error FLOAT
+              --dune-linear-solver TEXT
+              --dune-max-threads UINT
+              --pixel-integrator ENUM
+              --pixel-max-relative-error FLOAT
+              --pixel-max-absolute-error FLOAT
+              --pixel-max-timestep FLOAT
+              --pixel-enable-multithreading BOOLEAN
+              --pixel-max-threads UINT
+              --pixel-do-cse BOOLEAN
+              --pixel-opt-level UINT
       -o,     --output-file TEXT  The output file to write the results to. If not set, then the
                                   input file is used.
       -a,     --algorithm ENUM:value in {ABC->6,AL->12,BOBYQA->9,COBYLA->8,DE->2,GPSO->1,NMS->10,PRAXIS->13,PSO->0,gaco->7,iDE->3,jDE->4,pDE->5,sbplx->11} OR {6,12,9,8,2,1,10,13,0,7,3,4,5,11} [0]

--- a/gui/tabs/tabsimulate.cpp
+++ b/gui/tabs/tabsimulate.cpp
@@ -268,8 +268,8 @@ void TabSimulate::btnSimulate_clicked() {
   auto simulationTimes{sme::simulate::parseSimulationTimes(
       ui->txtSimLength->text(), ui->txtSimInterval->text())};
   if (!simulationTimes.has_value()) {
-    QMessageBox::warning(this, "Invalid simulation length or image interval",
-                         "Invalid simulation length or image interval");
+    QMessageBox::warning(this, "Invalid simulation times or image intervals",
+                         "Invalid simulation times or image intervals");
     return;
   }
   QString imageIntervalsText;

--- a/gui/tabs/tabsimulate.ui
+++ b/gui/tabs/tabsimulate.ui
@@ -53,7 +53,7 @@
      <item row="0" column="2">
       <widget class="QLabel" name="lblSimInterval">
        <property name="text">
-        <string>Image interval:</string>
+        <string>Image intervals:</string>
        </property>
       </widget>
      </item>
@@ -96,7 +96,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="lblSimLength">
        <property name="text">
-        <string>Simulation length:</string>
+        <string>Simulation times:</string>
        </property>
       </widget>
      </item>

--- a/gui/tabs/tabsimulate_t.cpp
+++ b/gui/tabs/tabsimulate_t.cpp
@@ -123,7 +123,7 @@ TEST_CASE("TabSimulate", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
 
     // set an invalid simulation lengths / image intervals
     sendMouseClick(btnResetSimulation);
-    QString invalidMessage{"Invalid simulation length or image interval"};
+    QString invalidMessage{"Invalid simulation times or image intervals"};
     // invalid double
     sendKeyEvents(txtSimLength, {";", "c"});
     mwt.start();

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -9,11 +9,17 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <QImage>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 namespace pysme {
 
 void bindModel(nanobind::module_ &m) {
+  nanobind::enum_<::sme::simulate::DuneDiscretizationType>(
+      m, "DuneDiscretizationType")
+      .value("FEM1", ::sme::simulate::DuneDiscretizationType::FEM1);
   nanobind::class_<Model> model(m, "Model",
                                 R"(
                                      the spatial model
@@ -21,11 +27,84 @@ void bindModel(nanobind::module_ &m) {
   nanobind::enum_<::sme::simulate::SimulatorType>(m, "SimulatorType")
       .value("DUNE", ::sme::simulate::SimulatorType::DUNE)
       .value("Pixel", ::sme::simulate::SimulatorType::Pixel);
+  nanobind::enum_<::sme::simulate::PixelIntegratorType>(m,
+                                                        "PixelIntegratorType")
+      .value("RK101", ::sme::simulate::PixelIntegratorType::RK101)
+      .value("RK212", ::sme::simulate::PixelIntegratorType::RK212)
+      .value("RK323", ::sme::simulate::PixelIntegratorType::RK323)
+      .value("RK435", ::sme::simulate::PixelIntegratorType::RK435);
+  nanobind::class_<::sme::simulate::PixelIntegratorError>(
+      m, "PixelIntegratorError")
+      .def(nanobind::init<>())
+      .def_rw("abs", &::sme::simulate::PixelIntegratorError::abs)
+      .def_rw("rel", &::sme::simulate::PixelIntegratorError::rel);
+  nanobind::class_<::sme::simulate::DuneOptions>(m, "DuneOptions")
+      .def(nanobind::init<>())
+      .def_rw("discretization", &::sme::simulate::DuneOptions::discretization)
+      .def_rw("integrator", &::sme::simulate::DuneOptions::integrator)
+      .def_rw("dt", &::sme::simulate::DuneOptions::dt)
+      .def_rw("min_dt", &::sme::simulate::DuneOptions::minDt)
+      .def_rw("max_dt", &::sme::simulate::DuneOptions::maxDt)
+      .def_rw("increase", &::sme::simulate::DuneOptions::increase)
+      .def_rw("decrease", &::sme::simulate::DuneOptions::decrease)
+      .def_rw("write_vtk_files", &::sme::simulate::DuneOptions::writeVTKfiles)
+      .def_rw("newton_rel_err", &::sme::simulate::DuneOptions::newtonRelErr)
+      .def_rw("newton_abs_err", &::sme::simulate::DuneOptions::newtonAbsErr)
+      .def_rw("linear_solver", &::sme::simulate::DuneOptions::linearSolver)
+      .def_rw("max_threads", &::sme::simulate::DuneOptions::maxThreads);
+  nanobind::class_<::sme::simulate::PixelOptions>(m, "PixelOptions")
+      .def(nanobind::init<>())
+      .def_rw("integrator", &::sme::simulate::PixelOptions::integrator)
+      .def_rw("max_err", &::sme::simulate::PixelOptions::maxErr)
+      .def_rw("max_timestep", &::sme::simulate::PixelOptions::maxTimestep)
+      .def_rw("enable_multithreading",
+              &::sme::simulate::PixelOptions::enableMultiThreading)
+      .def_rw("max_threads", &::sme::simulate::PixelOptions::maxThreads)
+      .def_rw("do_cse", &::sme::simulate::PixelOptions::doCSE)
+      .def_rw("opt_level", &::sme::simulate::PixelOptions::optLevel);
+  nanobind::class_<::sme::simulate::Options>(m, "SimulationOptions")
+      .def(nanobind::init<>())
+      .def_rw("dune", &::sme::simulate::Options::dune)
+      .def_rw("pixel", &::sme::simulate::Options::pixel);
+  nanobind::class_<SimulationSettings>(m, "SimulationSettings",
+                                       R"(
+      simulation settings used by :func:`Model.simulate`
+      )")
+      .def(nanobind::init<>())
+      .def_rw("times", &SimulationSettings::times,
+              R"(
+              list[tuple[int, float]]: list of `(n_steps, step_size)` simulation stages
+              )")
+      .def_rw("options", &SimulationSettings::options,
+              R"(
+              SimulationOptions: simulator-specific options
+              )")
+      .def_rw("simulator_type", &SimulationSettings::simulatorType,
+              R"(
+              SimulatorType: simulator to use
+              )");
   model.def(nanobind::init<const std::string &>(), nanobind::arg("filename"))
       .def_prop_rw("name", &Model::getName, &Model::setName,
                    R"(
                     str: the name of this model
                     )")
+      .def_prop_rw("simulation_settings",
+                   static_cast<SimulationSettings &(Model::*)()>(
+                       &Model::getSimulationSettings),
+                   &Model::setSimulationSettings,
+                   nanobind::rv_policy::reference_internal,
+                   R"(
+          SimulationSettings: settings used when running simulations
+
+          Modify this object and assign it back to update the model defaults:
+
+          >>> settings = model.simulation_settings
+          >>> settings.times = [(2, 0.1)]
+          >>> settings.simulator_type = sme.SimulatorType.Pixel
+          >>> settings.options.pixel.enable_multithreading = True
+          >>> settings.options.pixel.max_threads = 4
+          >>> model.simulation_settings = settings
+          )")
       .def("export_sbml_file", &Model::exportSbmlFile,
            nanobind::arg("filename"),
            R"(
@@ -174,62 +253,92 @@ void bindModel(nanobind::module_ &m) {
            Args:
                filename (str): the name of the geometry image to import
            )")
-      .def("simulate", &Model::simulateFloat, nanobind::arg("simulation_time"),
-           nanobind::arg("image_interval"),
-           nanobind::arg("timeout_seconds") = 86400,
-           nanobind::arg("throw_on_timeout") = true,
-           nanobind::arg("simulator_type") =
-               ::sme::simulate::SimulatorType::Pixel,
-           nanobind::arg("continue_existing_simulation") = false,
-           nanobind::arg("return_results") = true,
-           nanobind::arg("n_threads") = 1,
-           R"(
-           returns the results of the simulation.
+      .def(
+          "simulate",
+          [](Model &self, std::optional<double> simulationTime,
+             std::optional<double> imageInterval, int timeoutSeconds,
+             bool throwOnTimeout,
+             std::optional<::sme::simulate::SimulatorType> simulatorType,
+             bool continueExistingSimulation, bool returnResults,
+             std::optional<int> nThreads,
+             std::optional<SimulationSettings> settings) {
+            return self.simulateFloat(simulationTime, imageInterval,
+                                      timeoutSeconds, throwOnTimeout,
+                                      simulatorType, continueExistingSimulation,
+                                      returnResults, nThreads, settings);
+          },
+          nanobind::arg("simulation_time") = nanobind::none(),
+          nanobind::arg("image_interval") = nanobind::none(),
+          nanobind::arg("timeout_seconds") = 86400,
+          nanobind::arg("throw_on_timeout") = true,
+          nanobind::arg("simulator_type") = nanobind::none(),
+          nanobind::arg("continue_existing_simulation") = false,
+          nanobind::arg("return_results") = true,
+          nanobind::arg("n_threads") = nanobind::none(), nanobind::kw_only(),
+          nanobind::arg("settings") = nanobind::none(),
+          R"(
+          returns the results of the simulation.
 
-           Args:
-               simulation_time (float): The length of the simulation in model units of time, e.g. `5.5`
-               image_interval (float): The interval between images in model units of time, e.g. `1.1`
-               timeout_seconds (int): The maximum time in seconds that the simulation can run for. Default value: 86400 = 1 day.
-               throw_on_timeout (bool): Whether to throw an exception on simulation timeout. Default value: `True`.
-               simulator_type (sme.SimulatorType): The simulator to use: `sme.SimulatorType.DUNE` or `sme.SimulatorType.Pixel`. Default value: Pixel.
-               continue_existing_simulation (bool): Whether to continue the existing simulation, or start a new simulation. Default value: `False`, i.e. any existing simulation results are discarded before doing the simulation.
-               return_results (bool): Whether to return the simulation results. Default value: `True`. If `False`, an empty SimulationResultList is returned.
-               n_threads(int): Number of cpu threads to use (for Pixel simulations). Default value is 1, 0 means use all available threads.
+          Args:
+              simulation_time (float, optional): The length of the simulation in model units of time, e.g. `5.5`.
+              image_interval (float, optional): The interval between images in model units of time, e.g. `1.1`.
+                  If both are omitted, simulation stages are taken from `model.simulation_settings.times` (or from `settings.times` when `settings` is provided).
+              timeout_seconds (int): The maximum time in seconds that the simulation can run for. Default value: 86400 = 1 day.
+              throw_on_timeout (bool): Whether to throw an exception on simulation timeout. Default value: `True`.
+              simulator_type (sme.SimulatorType, optional): Per-call simulator override. If not supplied, the model's simulation settings are used.
+              continue_existing_simulation (bool): Whether to continue the existing simulation, or start a new simulation. Default value: `False`, i.e. any existing simulation results are discarded before doing the simulation.
+              return_results (bool): Whether to return the simulation results. Default value: `True`. If `False`, an empty SimulationResultList is returned.
+              n_threads(int, optional): Per-call Pixel thread override, where `0` means use all available threads.
+              settings (sme.SimulationSettings, optional): Per-call simulation settings override. If not supplied, `model.simulation_settings` is used.
 
-           Returns:
-               SimulationResultList: the results of the simulation
+          Returns:
+              SimulationResultList: the results of the simulation
 
-           Raises:
-               RuntimeError: if the simulation times out or fails
-           )")
-      .def("simulate", &Model::simulateString,
-           nanobind::arg("simulation_times"), nanobind::arg("image_intervals"),
-           nanobind::arg("timeout_seconds") = 86400,
-           nanobind::arg("throw_on_timeout") = true,
-           nanobind::arg("simulator_type") =
-               ::sme::simulate::SimulatorType::Pixel,
-           nanobind::arg("continue_existing_simulation") = false,
-           nanobind::arg("return_results") = true,
-           nanobind::arg("n_threads") = 1,
-           R"(
-           returns the results of the simulation.
+          Raises:
+              RuntimeError: if the simulation times out or fails
+          )")
+      .def(
+          "simulate",
+          [](Model &self, const std::string &simulationTimes,
+             const std::string &imageIntervals, int timeoutSeconds,
+             bool throwOnTimeout,
+             std::optional<::sme::simulate::SimulatorType> simulatorType,
+             bool continueExistingSimulation, bool returnResults,
+             std::optional<int> nThreads,
+             std::optional<SimulationSettings> settings) {
+            return self.simulateString(
+                simulationTimes, imageIntervals, timeoutSeconds, throwOnTimeout,
+                simulatorType, continueExistingSimulation, returnResults,
+                nThreads, settings);
+          },
+          nanobind::arg("simulation_times"), nanobind::arg("image_intervals"),
+          nanobind::arg("timeout_seconds") = 86400,
+          nanobind::arg("throw_on_timeout") = true,
+          nanobind::arg("simulator_type") = nanobind::none(),
+          nanobind::arg("continue_existing_simulation") = false,
+          nanobind::arg("return_results") = true,
+          nanobind::arg("n_threads") = nanobind::none(), nanobind::kw_only(),
+          nanobind::arg("settings") = nanobind::none(),
+          R"(
+          returns the results of the simulation.
 
-           Args:
-               simulation_times (str): The length(s) of the simulation in model units of time as a semicolon-delimited list, e.g. `"5"`, or `"10;100;20"`
-               image_intervals (str): The interval(s) between images in model units of time as a semicolon-delimited list, e.g. `"1"`, or `"2;10;0.5"`
-               timeout_seconds (int): The maximum time in seconds that the simulation can run for. Default value: 86400 = 1 day.
-               throw_on_timeout (bool): Whether to throw an exception on simulation timeout. Default value: `true`.
-               simulator_type (sme.SimulatorType): The simulator to use: `sme.SimulatorType.DUNE` or `sme.SimulatorType.Pixel`. Default value: Pixel.
-               continue_existing_simulation (bool): Whether to continue the existing simulation, or start a new simulation. Default value: `false`, i.e. any existing simulation results are discarded before doing the simulation.
-               return_results (bool): Whether to return the simulation results. Default value: `True`. If `False`, an empty SimulationResultList is returned.
-               n_threads(int): Number of cpu threads to use (for Pixel simulations). Default value is 1, 0 means use all available threads.
+          Args:
+              simulation_times (str): The length(s) of the simulation in model units of time as a semicolon-delimited list, e.g. `"5"`, or `"10;100;20"`
+              image_intervals (str): The interval(s) between images in model units of time as a semicolon-delimited list, e.g. `"1"`, or `"2;10;0.5"`
+              timeout_seconds (int): The maximum time in seconds that the simulation can run for. Default value: 86400 = 1 day.
+              throw_on_timeout (bool): Whether to throw an exception on simulation timeout. Default value: `true`.
+              simulator_type (sme.SimulatorType, optional): Per-call simulator override. If not supplied, the model's simulation settings are used.
+              continue_existing_simulation (bool): Whether to continue the existing simulation, or start a new simulation. Default value: `false`, i.e. any existing simulation results are discarded before doing the simulation.
+              return_results (bool): Whether to return the simulation results. Default value: `True`. If `False`, an empty SimulationResultList is returned.
+              n_threads(int, optional): Per-call Pixel thread override, where `0` means use all available threads.
+              settings (sme.SimulationSettings, optional): Per-call simulation settings override. If not supplied, `model.simulation_settings` is used.
 
-           Returns:
-               SimulationResultList: the results of the simulation
+          Returns:
+              SimulationResultList: the results of the simulation
 
-           Raises:
-               RuntimeError: if the simulation times out or fails
-           )")
+          Raises:
+              RuntimeError: if the simulation times out or fails
+          )")
       .def("simulation_results", &Model::getSimulationResults,
            R"(
           returns the simulation results.
@@ -329,6 +438,18 @@ std::string Model::getName() const { return s->getName().toStdString(); }
 
 void Model::setName(const std::string &name) { s->setName(name.c_str()); }
 
+const SimulationSettings &Model::getSimulationSettings() const {
+  return s->getSimulationSettings();
+}
+
+SimulationSettings &Model::getSimulationSettings() {
+  return s->getSimulationSettings();
+}
+
+void Model::setSimulationSettings(const SimulationSettings &settings) {
+  s->getSimulationSettings() = settings;
+}
+
 nanobind::ndarray<nanobind::numpy, std::uint8_t>
 Model::compartment_image() const {
   return toPyImageRgb(s->getGeometry().getImages());
@@ -352,32 +473,62 @@ void Model::exportSmeFile(const std::string &filename) {
   s->exportSMEFile(filename);
 }
 
-std::vector<SimulationResult>
-Model::simulateString(const std::string &lengths, const std::string &intervals,
-                      int timeoutSeconds, bool throwOnTimeout,
-                      ::sme::simulate::SimulatorType simulatorType,
-                      bool continueExistingSimulation, bool returnResults,
-                      int nThreads) {
+std::vector<SimulationResult> Model::simulateString(
+    std::optional<std::string> lengths, std::optional<std::string> intervals,
+    int timeoutSeconds, bool throwOnTimeout,
+    std::optional<::sme::simulate::SimulatorType> simulatorType,
+    bool continueExistingSimulation, bool returnResults,
+    std::optional<int> nThreads,
+    const std::optional<SimulationSettings> &simulationSettingsOverride) {
   QElapsedTimer simulationRuntimeTimer;
   simulationRuntimeTimer.start();
   double timeoutMillisecs{static_cast<double>(timeoutSeconds) * 1000.0};
+  auto currentTimes{s->getSimulationSettings().times};
   if (!continueExistingSimulation) {
     s->getSimulationData().clear();
+    s->getSimulationSettings().times.clear();
   }
-  s->getSimulationSettings().simulatorType = simulatorType;
-  if (simulatorType == ::sme::simulate::SimulatorType::Pixel) {
-    auto &pixelOpts{s->getSimulationSettings().options.pixel};
-    if (nThreads != 1) {
+  if ((lengths.has_value() && !intervals.has_value()) ||
+      (!lengths.has_value() && intervals.has_value())) {
+    throw std::invalid_argument(
+        "simulation lengths and intervals must both be set or both be omitted");
+  }
+  auto &effectiveSettings{s->getSimulationSettings()};
+  if (simulationSettingsOverride.has_value()) {
+    effectiveSettings = simulationSettingsOverride.value();
+  }
+  if (simulatorType.has_value()) {
+    effectiveSettings.simulatorType = simulatorType.value();
+  }
+  if (nThreads.has_value() && effectiveSettings.simulatorType ==
+                                  ::sme::simulate::SimulatorType::Pixel) {
+    auto &pixelOpts{effectiveSettings.options.pixel};
+    if (nThreads.value() != 1) {
       pixelOpts.enableMultiThreading = true;
-      pixelOpts.maxThreads = static_cast<std::size_t>(nThreads);
+      pixelOpts.maxThreads = static_cast<std::size_t>(nThreads.value());
     } else {
       pixelOpts.enableMultiThreading = false;
+      pixelOpts.maxThreads = 1;
     }
   }
-  auto times{::sme::simulate::parseSimulationTimes(lengths.c_str(),
-                                                   intervals.c_str())};
-  if (!times.has_value()) {
-    throw std::invalid_argument("Invalid simulation lengths or intervals");
+  std::vector<std::pair<std::size_t, double>> times;
+  if (lengths.has_value() && intervals.has_value()) {
+    auto parsedTimes{::sme::simulate::parseSimulationTimes(lengths->c_str(),
+                                                           intervals->c_str())};
+    if (!parsedTimes.has_value()) {
+      throw std::invalid_argument("Invalid simulation lengths or intervals");
+    }
+    times = parsedTimes.value();
+  } else if (simulationSettingsOverride.has_value() &&
+             !simulationSettingsOverride->times.empty()) {
+    times = simulationSettingsOverride->times;
+  } else {
+    times = currentTimes;
+  }
+  if (times.empty()) {
+    throw std::invalid_argument(
+        "No simulation times specified: set simulation_time/image_interval, "
+        "or set simulation_settings.times");
   }
   // ensure any existing DUNE objects are destroyed to avoid later segfaults
   sim.reset();
@@ -385,7 +536,7 @@ Model::simulateString(const std::string &lengths, const std::string &intervals,
   if (const auto &e = sim->errorMessage(); !e.empty()) {
     throw std::runtime_error(fmt::format("Error in simulation setup: {}", e));
   }
-  sim->doMultipleTimesteps(times.value(), timeoutMillisecs, []() {
+  sim->doMultipleTimesteps(times, timeoutMillisecs, []() {
     if (PyErr_CheckSignals() != 0) {
       throw nanobind::python_error();
     }
@@ -401,13 +552,28 @@ Model::simulateString(const std::string &lengths, const std::string &intervals,
 }
 
 std::vector<SimulationResult> Model::simulateFloat(
-    double simulationTime, double imageInterval, int timeoutSeconds,
-    bool throwOnTimeout, ::sme::simulate::SimulatorType simulatorType,
-    bool continueExistingSimulation, bool returnResults, int nThreads) {
-  return simulateString(QString::number(simulationTime, 'g', 17).toStdString(),
-                        QString::number(imageInterval, 'g', 17).toStdString(),
-                        timeoutSeconds, throwOnTimeout, simulatorType,
-                        continueExistingSimulation, returnResults, nThreads);
+    std::optional<double> simulationTime, std::optional<double> imageInterval,
+    int timeoutSeconds, bool throwOnTimeout,
+    std::optional<::sme::simulate::SimulatorType> simulatorType,
+    bool continueExistingSimulation, bool returnResults,
+    std::optional<int> nThreads,
+    const std::optional<SimulationSettings> &simulationSettingsOverride) {
+  if (simulationTime.has_value() != imageInterval.has_value()) {
+    throw std::invalid_argument("simulation_time and image_interval must both "
+                                "be set or both be omitted");
+  }
+  if (simulationTime.has_value()) {
+    return simulateString(
+        QString::number(simulationTime.value(), 'g', 17).toStdString(),
+        QString::number(imageInterval.value(), 'g', 17).toStdString(),
+        timeoutSeconds, throwOnTimeout, simulatorType,
+        continueExistingSimulation, returnResults, nThreads,
+        simulationSettingsOverride);
+  }
+  return simulateString(std::nullopt, std::nullopt, timeoutSeconds,
+                        throwOnTimeout, simulatorType,
+                        continueExistingSimulation, returnResults, nThreads,
+                        simulationSettingsOverride);
 }
 
 std::vector<SimulationResult> Model::getSimulationResults() {

--- a/sme/src/sme_model.hpp
+++ b/sme/src/sme_model.hpp
@@ -9,12 +9,15 @@
 #include "sme_simulationresult.hpp"
 #include <memory>
 #include <nanobind/nanobind.h>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace pysme {
 
 void bindModel(nanobind::module_ &m);
+
+using SimulationSettings = ::sme::model::SimulationSettings;
 
 class Model {
 private:
@@ -28,6 +31,9 @@ public:
   void importSbmlString(const std::string &xml);
   [[nodiscard]] std::string getName() const;
   void setName(const std::string &name);
+  [[nodiscard]] const SimulationSettings &getSimulationSettings() const;
+  SimulationSettings &getSimulationSettings();
+  void setSimulationSettings(const SimulationSettings &settings);
   nanobind::ndarray<nanobind::numpy, std::uint8_t> compartment_image() const;
   void importGeometryFromImage(const std::string &filename);
   void exportSbmlFile(const std::string &filename);
@@ -35,16 +41,20 @@ public:
   std::vector<Compartment> compartments;
   std::vector<Membrane> membranes;
   std::vector<Parameter> parameters;
-  std::vector<SimulationResult>
-  simulateString(const std::string &lengths, const std::string &intervals,
-                 int timeoutSeconds, bool throwOnTimeout,
-                 ::sme::simulate::SimulatorType simulatorType,
-                 bool continueExistingSimulation, bool returnResults,
-                 int nThreads);
+  std::vector<SimulationResult> simulateString(
+      std::optional<std::string> lengths, std::optional<std::string> intervals,
+      int timeoutSeconds, bool throwOnTimeout,
+      std::optional<::sme::simulate::SimulatorType> simulatorType,
+      bool continueExistingSimulation, bool returnResults,
+      std::optional<int> nThreads,
+      const std::optional<SimulationSettings> &simulationSettingsOverride);
   std::vector<SimulationResult> simulateFloat(
-      double simulationTime, double imageInterval, int timeoutSeconds,
-      bool throwOnTimeout, ::sme::simulate::SimulatorType simulatorType,
-      bool continueExistingSimulation, bool returnResults, int nThreads);
+      std::optional<double> simulationTime, std::optional<double> imageInterval,
+      int timeoutSeconds, bool throwOnTimeout,
+      std::optional<::sme::simulate::SimulatorType> simulatorType,
+      bool continueExistingSimulation, bool returnResults,
+      std::optional<int> nThreads,
+      const std::optional<SimulationSettings> &simulationSettingsOverride);
   std::vector<SimulationResult> getSimulationResults();
   [[nodiscard]] std::string getStr() const;
 };

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -98,6 +98,30 @@ def test_simulate_invalid_timesteps():
             m.simulate("10;seven", "1;1", simulator_type=sim_type)
 
 
+def test_model_simulation_settings():
+    m = sme.open_example_model()
+    m.simulation_settings.simulator_type = sme.SimulatorType.Pixel
+    assert m.simulation_settings.simulator_type == sme.SimulatorType.Pixel
+
+    settings = m.simulation_settings
+    settings.options.pixel.enable_multithreading = True
+    settings.options.pixel.max_threads = 2
+    m.simulation_settings = settings
+
+    sim_results = m.simulate(0.002, 0.001)
+    assert len(sim_results) == 3
+
+    settings2 = m.simulation_settings
+    assert settings2.simulator_type == sme.SimulatorType.Pixel
+    assert settings2.options.pixel.enable_multithreading
+    assert settings2.options.pixel.max_threads == 2
+
+    # if simulation times are in model settings, simulate() can omit time args
+    m.simulation_settings.times = [(2, 0.001)]
+    sim_results2 = m.simulate()
+    assert len(sim_results2) == 3
+
+
 def test_simulate():
     for sim_type in [sme.SimulatorType.DUNE, sme.SimulatorType.Pixel]:
         m = sme.open_example_model()
@@ -169,7 +193,10 @@ def test_simulate():
 
     # approximate dcdt (only returned from simulate & pixel & last timepoint)
     m = sme.open_example_model()
-    sim_results = m.simulate(0.002, 0.001, simulator_type=sme.SimulatorType.Pixel)
+    settings = m.simulation_settings
+    settings.simulator_type = sme.SimulatorType.Pixel
+    m.simulation_settings = settings
+    sim_results = m.simulate(0.002, 0.001)
     assert len(sim_results) == 3
     assert len(sim_results[0].species_dcdt) == 0
     assert len(sim_results[1].species_dcdt) == 0
@@ -209,6 +236,35 @@ def test_simulate():
         # but results are still available from the model
         sim_results2 = m.simulation_results()
         assert len(sim_results2) == 3
+
+    # explicit Pixel solver options
+    m = sme.open_example_model()
+    settings = m.simulation_settings
+    settings.simulator_type = sme.SimulatorType.Pixel
+    settings.options.pixel.integrator = sme.PixelIntegratorType.RK323
+    settings.options.pixel.max_err.rel = 0.1
+    settings.options.pixel.max_err.abs = 0.1
+    settings.options.pixel.max_timestep = 0.01
+    settings.options.pixel.enable_multithreading = True
+    settings.options.pixel.max_threads = 1
+    settings.options.pixel.do_cse = False
+    settings.options.pixel.opt_level = 2
+    m.simulation_settings = settings
+    sim_results = m.simulate(0.002, 0.001, return_results=False)
+    assert len(sim_results) == 0
+    assert len(m.simulation_results()) == 3
+
+    # explicit DUNE solver options
+    m = sme.open_example_model()
+    settings = m.simulation_settings
+    settings.simulator_type = sme.SimulatorType.DUNE
+    settings.options.dune.integrator = "Alexander2"
+    settings.options.dune.write_vtk_files = False
+    settings.options.dune.max_threads = 1
+    m.simulation_settings = settings
+    sim_results = m.simulate(0.002, 0.001, return_results=False)
+    assert len(sim_results) == 0
+    assert len(m.simulation_results()) == 3
 
 
 def test_simulate_3d():


### PR DESCRIPTION
- python
  - expose core sme::model::SimulationSettings in as model.simulation_settings
  - make Model.simulate(simulation_time, image_interval) arguments optional in Python; fallback to simulation_settings.times
  - update CLI/Python docs and changelog
- CLI
  - make CLI simulate positional times and image-intervals optional
  - when omitted in CLI, run using model simulationSettings.times; error on partial or missing timings
  - add command line overrides for simulation settings members
  - add tests for direct settings mutation, no-arg simulate in Python
  - add tests for CLI no-times/partial-times behavior
- resolves #312
