### PR TITLE
Display RAM usage

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -137,7 +137,8 @@ target_link_libraries(
           Combine-static
           CGAL::CGAL
           cereal::cereal
-          TBB::tbb)
+          TBB::tbb
+          $<$<PLATFORM_ID:Windows>:psapi>)
 target_link_libraries(
   core
   PUBLIC opencv_core

--- a/core/common/include/sme/system_memory.hpp
+++ b/core/common/include/sme/system_memory.hpp
@@ -1,0 +1,18 @@
+// System memory information
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+namespace sme::common {
+
+struct SystemMemoryInfo {
+  std::size_t totalPhysicalBytes{};
+  std::size_t availablePhysicalBytes{};
+};
+
+[[nodiscard]] std::optional<SystemMemoryInfo> getSystemMemoryInfo();
+[[nodiscard]] std::optional<std::size_t> getCurrentProcessMemoryUsageBytes();
+
+} // namespace sme::common

--- a/core/common/include/sme/utils.hpp
+++ b/core/common/include/sme/utils.hpp
@@ -165,6 +165,16 @@ std::vector<bool> toBool(const std::vector<int> &v);
 std::vector<int> toInt(const std::vector<bool> &v);
 
 /**
+ * @brief Add byte counts with saturation at max size_t
+ */
+[[nodiscard]] std::size_t saturatingAdd(std::size_t a, std::size_t b);
+
+/**
+ * @brief Format bytes using binary units (B, KiB, MiB, GiB, TiB)
+ */
+[[nodiscard]] QString formatMemoryBytes(std::size_t nBytes);
+
+/**
  * @brief Convert a string to a vector of values
  *
  * The values in the string are separated by spaces.

--- a/core/common/src/CMakeLists.txt
+++ b/core/common/src/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
           serialization.cpp
           simple_symbolic.cpp
           symbolic.cpp
+          system_memory.cpp
           tiff.cpp
           utils.cpp
           ${PROJECT_BINARY_DIR}/src/core/common/src/version.cpp)
@@ -20,6 +21,7 @@ if(BUILD_TESTING)
            serialization_t.cpp
            simple_symbolic_t.cpp
            symbolic_t.cpp
+           system_memory_t.cpp
            tiff_t.cpp
            utils_t.cpp
            voxel_t.cpp)

--- a/core/common/src/system_memory.cpp
+++ b/core/common/src/system_memory.cpp
@@ -1,0 +1,230 @@
+#include "sme/system_memory.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#endif
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+// windows include has to come before psapi:
+#include <windows.h>
+
+// psapi assumes windows.h has been included:
+#include <psapi.h>
+
+#endif
+
+namespace sme::common {
+
+namespace {
+
+[[nodiscard]] std::size_t toSizeT(std::uint64_t value) {
+  return value > static_cast<std::uint64_t>(
+                     std::numeric_limits<std::size_t>::max())
+             ? std::numeric_limits<std::size_t>::max()
+             : static_cast<std::size_t>(value);
+}
+
+#if defined(__linux__)
+
+[[nodiscard]] std::optional<std::uint64_t>
+readMeminfoBytes(const std::string &key) {
+  std::ifstream file("/proc/meminfo");
+  if (!file) {
+    return {};
+  }
+  std::string label{};
+  std::uint64_t valueInKb{0};
+  std::string unit{};
+  while (file >> label >> valueInKb >> unit) {
+    if (!label.empty() && label.back() == ':') {
+      label.pop_back();
+    }
+    if (label == key) {
+      return valueInKb * 1024;
+    }
+    file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+  return {};
+}
+
+[[nodiscard]] std::optional<std::uint64_t>
+readUintFromFile(const std::string &filename) {
+  std::ifstream file(filename);
+  if (!file) {
+    return {};
+  }
+  std::string value{};
+  file >> value;
+  if (!file || value.empty() || value == "max") {
+    return {};
+  }
+  try {
+    return std::stoull(value);
+  } catch (...) {
+    return {};
+  }
+}
+
+[[nodiscard]] std::optional<std::uint64_t>
+readProcStatusBytes(const std::string &key) {
+  std::ifstream file("/proc/self/status");
+  if (!file) {
+    return {};
+  }
+  std::string line{};
+  while (std::getline(file, line)) {
+    const auto prefix = key + ":";
+    if (line.rfind(prefix, 0) != 0) {
+      continue;
+    }
+    std::istringstream iss(line.substr(prefix.size()));
+    std::uint64_t valueInKb{0};
+    std::string unit{};
+    if (iss >> valueInKb >> unit && unit == "kB") {
+      return valueInKb * 1024;
+    }
+    return {};
+  }
+  return {};
+}
+
+[[nodiscard]] bool isUnconstrainedCgroupLimit(std::uint64_t limit) {
+  constexpr std::uint64_t unconstrainedThreshold{1ULL << 60};
+  return limit >= unconstrainedThreshold;
+}
+
+[[nodiscard]] std::optional<std::uint64_t> getCgroupLimitBytes() {
+  if (auto limit = readUintFromFile("/sys/fs/cgroup/memory.max");
+      limit.has_value() && !isUnconstrainedCgroupLimit(limit.value())) {
+    return limit;
+  }
+  if (auto limit =
+          readUintFromFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+      limit.has_value() && !isUnconstrainedCgroupLimit(limit.value())) {
+    return limit;
+  }
+  return {};
+}
+
+[[nodiscard]] std::optional<std::uint64_t> getCgroupAvailableBytes() {
+  if (const auto limit = readUintFromFile("/sys/fs/cgroup/memory.max"),
+      usage = readUintFromFile("/sys/fs/cgroup/memory.current");
+      limit.has_value() && usage.has_value() &&
+      !isUnconstrainedCgroupLimit(limit.value())) {
+    return usage.value() >= limit.value() ? 0 : limit.value() - usage.value();
+  }
+  if (const auto limit =
+          readUintFromFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
+      usage = readUintFromFile("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+      limit.has_value() && usage.has_value() &&
+      !isUnconstrainedCgroupLimit(limit.value())) {
+    return usage.value() >= limit.value() ? 0 : limit.value() - usage.value();
+  }
+  return {};
+}
+
+#endif
+
+} // namespace
+
+std::optional<SystemMemoryInfo> getSystemMemoryInfo() {
+#if defined(__linux__)
+  auto total = readMeminfoBytes("MemTotal");
+  auto available = readMeminfoBytes("MemAvailable");
+  if (!available.has_value()) {
+    available = readMeminfoBytes("MemFree");
+  }
+  if (!total.has_value() || !available.has_value()) {
+    return {};
+  }
+  if (auto cgroupLimit = getCgroupLimitBytes(); cgroupLimit.has_value()) {
+    total = std::min(total.value(), cgroupLimit.value());
+  }
+  if (auto cgroupAvailable = getCgroupAvailableBytes();
+      cgroupAvailable.has_value()) {
+    available = std::min(available.value(), cgroupAvailable.value());
+  }
+  if (available.value() > total.value()) {
+    available = total;
+  }
+  return SystemMemoryInfo{toSizeT(total.value()), toSizeT(available.value())};
+#elif defined(__APPLE__)
+  std::uint64_t totalBytes{0};
+  std::size_t totalBytesLen{sizeof(totalBytes)};
+  if (sysctlbyname("hw.memsize", &totalBytes, &totalBytesLen, nullptr, 0) !=
+      0) {
+    return {};
+  }
+  vm_size_t pageSize{0};
+  if (host_page_size(mach_host_self(), &pageSize) != KERN_SUCCESS) {
+    return {};
+  }
+  vm_statistics64_data_t vmStats{};
+  mach_msg_type_number_t count{HOST_VM_INFO64_COUNT};
+  if (host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                        reinterpret_cast<host_info64_t>(&vmStats),
+                        &count) != KERN_SUCCESS) {
+    return {};
+  }
+  const std::uint64_t availablePages{
+      static_cast<std::uint64_t>(vmStats.free_count) +
+      static_cast<std::uint64_t>(vmStats.inactive_count) +
+      static_cast<std::uint64_t>(vmStats.speculative_count)};
+  const std::uint64_t availableBytes{availablePages *
+                                     static_cast<std::uint64_t>(pageSize)};
+  return SystemMemoryInfo{toSizeT(totalBytes), toSizeT(availableBytes)};
+#elif defined(_WIN32)
+  MEMORYSTATUSEX memoryStatus{};
+  memoryStatus.dwLength = sizeof(memoryStatus);
+  if (!GlobalMemoryStatusEx(&memoryStatus)) {
+    return {};
+  }
+  return SystemMemoryInfo{toSizeT(memoryStatus.ullTotalPhys),
+                          toSizeT(memoryStatus.ullAvailPhys)};
+#else
+  return {};
+#endif
+}
+
+std::optional<std::size_t> getCurrentProcessMemoryUsageBytes() {
+#if defined(__linux__)
+  if (const auto residentBytes = readProcStatusBytes("VmRSS");
+      residentBytes.has_value()) {
+    return toSizeT(residentBytes.value());
+  }
+  return {};
+#elif defined(__APPLE__)
+  mach_task_basic_info taskInfo{};
+  mach_msg_type_number_t count{MACH_TASK_BASIC_INFO_COUNT};
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                reinterpret_cast<task_info_t>(&taskInfo),
+                &count) != KERN_SUCCESS) {
+    return {};
+  }
+  return toSizeT(taskInfo.resident_size);
+#elif defined(_WIN32)
+  PROCESS_MEMORY_COUNTERS counters{};
+  if (!GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters))) {
+    return {};
+  }
+  return toSizeT(counters.WorkingSetSize);
+#else
+  return {};
+#endif
+}
+
+} // namespace sme::common

--- a/core/common/src/system_memory_t.cpp
+++ b/core/common/src/system_memory_t.cpp
@@ -1,0 +1,16 @@
+#include "catch_wrapper.hpp"
+#include "sme/system_memory.hpp"
+
+using namespace sme;
+
+TEST_CASE("System memory info", "[core/common/system_memory][core][common]") {
+  const auto info = common::getSystemMemoryInfo();
+  REQUIRE(info.has_value());
+  REQUIRE(info->totalPhysicalBytes > 0);
+  REQUIRE(info->availablePhysicalBytes > 0);
+  REQUIRE(info->availablePhysicalBytes <= info->totalPhysicalBytes);
+
+  const auto residentBytes = common::getCurrentProcessMemoryUsageBytes();
+  REQUIRE(residentBytes.has_value());
+  REQUIRE(residentBytes.value() > 0);
+}

--- a/core/common/src/utils.cpp
+++ b/core/common/src/utils.cpp
@@ -57,6 +57,25 @@ std::vector<int> toInt(const std::vector<bool> &v) {
   return r;
 }
 
+std::size_t saturatingAdd(std::size_t a, std::size_t b) {
+  if (a > std::numeric_limits<std::size_t>::max() - b) {
+    return std::numeric_limits<std::size_t>::max();
+  }
+  return a + b;
+}
+
+QString formatMemoryBytes(std::size_t nBytes) {
+  static const std::array units{"B", "KiB", "MiB", "GiB", "TiB"};
+  double value{static_cast<double>(nBytes)};
+  std::size_t unitIndex{0};
+  while (value >= 1024.0 && unitIndex + 1 < units.size()) {
+    value /= 1024.0;
+    ++unitIndex;
+  }
+  const int precision{(unitIndex == 0 || value >= 100.0) ? 0 : 1};
+  return QString("%1 %2").arg(value, 0, 'f', precision).arg(units[unitIndex]);
+}
+
 const std::vector<QColor> indexedColors::colors = std::vector<QColor>{
     {230, 25, 75},  {60, 180, 75},   {255, 225, 25}, {0, 130, 200},
     {245, 130, 48}, {145, 30, 180},  {70, 240, 240}, {240, 50, 230},

--- a/core/common/src/utils_t.cpp
+++ b/core/common/src/utils_t.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QImage>
 #include <QRgb>
+#include <limits>
 #include <list>
 #include <set>
 #include <vector>
@@ -122,5 +123,21 @@ TEST_CASE("Utils", "[core/common/utils][core/common][core][utils]") {
       REQUIRE(sme::common::get_unique_values(in) == out);
       REQUIRE(sme::common::get_unique_values(in1) == out1);
     }
+  }
+  SECTION("saturatingAdd") {
+    REQUIRE(common::saturatingAdd(2, 3) == 5);
+    REQUIRE(common::saturatingAdd(std::numeric_limits<std::size_t>::max(), 1) ==
+            std::numeric_limits<std::size_t>::max());
+    REQUIRE(
+        common::saturatingAdd(std::numeric_limits<std::size_t>::max() - 5, 5) ==
+        std::numeric_limits<std::size_t>::max());
+  }
+  SECTION("formatMemoryBytes") {
+    REQUIRE(common::formatMemoryBytes(0) == "0 B");
+    REQUIRE(common::formatMemoryBytes(1023) == "1023 B");
+    REQUIRE(common::formatMemoryBytes(1024) == "1.0 KiB");
+    REQUIRE(common::formatMemoryBytes(1536) == "1.5 KiB");
+    REQUIRE(common::formatMemoryBytes(1024 * 100) == "100 KiB");
+    REQUIRE(common::formatMemoryBytes(1024 * 1024) == "1.0 MiB");
   }
 }

--- a/core/simulate/include/sme/simulate_data.hpp
+++ b/core/simulate/include/sme/simulate_data.hpp
@@ -24,6 +24,9 @@ public:
   std::string xmlModel;
   void clear();
   [[nodiscard]] std::size_t size() const;
+  [[nodiscard]] std::size_t getEstimatedMemoryBytes() const;
+  [[nodiscard]] std::size_t
+  getEstimatedAdditionalMemoryBytes(std::size_t nAdditionalTimepoints) const;
   void reserve(std::size_t n);
   void pop_back();
 

--- a/core/simulate/src/simulate_data.cpp
+++ b/core/simulate/src/simulate_data.cpp
@@ -1,6 +1,43 @@
 #include "sme/simulate_data.hpp"
+#include "sme/utils.hpp"
+#include <limits>
 
 namespace sme::simulate {
+
+namespace {
+
+[[nodiscard]] std::size_t saturatingMul(std::size_t a, std::size_t b) {
+  if (a == 0 || b == 0) {
+    return 0;
+  }
+  if (a > std::numeric_limits<std::size_t>::max() / b) {
+    return std::numeric_limits<std::size_t>::max();
+  }
+  return a * b;
+}
+
+template <typename T>
+[[nodiscard]] std::size_t
+get2dElementsBytes(const std::vector<std::vector<T>> &vec) {
+  std::size_t bytes{0};
+  for (const auto &inner : vec) {
+    bytes =
+        common::saturatingAdd(bytes, saturatingMul(inner.size(), sizeof(T)));
+  }
+  return bytes;
+}
+
+template <typename T>
+[[nodiscard]] std::size_t
+get3dElementsBytes(const std::vector<std::vector<std::vector<T>>> &vec) {
+  std::size_t bytes{0};
+  for (const auto &middle : vec) {
+    bytes = common::saturatingAdd(bytes, get2dElementsBytes(middle));
+  }
+  return bytes;
+}
+
+} // namespace
 
 void SimulationData::clear() {
   timePoints.clear();
@@ -12,6 +49,39 @@ void SimulationData::clear() {
 }
 
 std::size_t SimulationData::size() const { return timePoints.size(); }
+
+std::size_t SimulationData::getEstimatedMemoryBytes() const {
+  std::size_t bytes{0};
+  bytes = common::saturatingAdd(
+      bytes, saturatingMul(timePoints.size(), sizeof(double)));
+  bytes = common::saturatingAdd(
+      bytes, saturatingMul(concPadding.size(), sizeof(std::size_t)));
+  bytes = common::saturatingAdd(bytes, get3dElementsBytes(concentration));
+  bytes = common::saturatingAdd(bytes, get3dElementsBytes(avgMinMax));
+  bytes = common::saturatingAdd(bytes, get3dElementsBytes(concentrationMax));
+  bytes = common::saturatingAdd(bytes,
+                                saturatingMul(xmlModel.size(), sizeof(char)));
+  return bytes;
+}
+
+std::size_t SimulationData::getEstimatedAdditionalMemoryBytes(
+    std::size_t nAdditionalTimepoints) const {
+  if (nAdditionalTimepoints == 0 || concentration.empty()) {
+    return 0;
+  }
+  std::size_t bytesPerTimepoint{sizeof(double) + sizeof(std::size_t)};
+  bytesPerTimepoint = common::saturatingAdd(
+      bytesPerTimepoint, get2dElementsBytes(concentration.back()));
+  if (!avgMinMax.empty()) {
+    bytesPerTimepoint = common::saturatingAdd(
+        bytesPerTimepoint, get2dElementsBytes(avgMinMax.back()));
+  }
+  if (!concentrationMax.empty()) {
+    bytesPerTimepoint = common::saturatingAdd(
+        bytesPerTimepoint, get2dElementsBytes(concentrationMax.back()));
+  }
+  return saturatingMul(bytesPerTimepoint, nAdditionalTimepoints);
+}
 
 void SimulationData::reserve(std::size_t n) {
   timePoints.reserve(n);

--- a/core/simulate/src/simulate_data_t.cpp
+++ b/core/simulate/src/simulate_data_t.cpp
@@ -22,6 +22,44 @@ TEST_CASE("SimulateData",
   REQUIRE(data.avgMinMax.size() == 2);
   REQUIRE(data.concentrationMax.size() == 2);
   REQUIRE(data.concPadding.size() == 2);
+  SECTION("memory size estimates") {
+    std::size_t expectedBytes{0};
+    expectedBytes += data.timePoints.size() * sizeof(double);
+    expectedBytes += data.concPadding.size() * sizeof(std::size_t);
+    for (const auto &tp : data.concentration) {
+      for (const auto &comp : tp) {
+        expectedBytes += comp.size() * sizeof(double);
+      }
+    }
+    for (const auto &tp : data.avgMinMax) {
+      for (const auto &comp : tp) {
+        expectedBytes += comp.size() * sizeof(simulate::AvgMinMax);
+      }
+    }
+    for (const auto &tp : data.concentrationMax) {
+      for (const auto &comp : tp) {
+        expectedBytes += comp.size() * sizeof(double);
+      }
+    }
+    expectedBytes += data.xmlModel.size() * sizeof(char);
+    REQUIRE(data.getEstimatedMemoryBytes() == expectedBytes);
+
+    std::size_t expectedAdditionalPerTimepoint{sizeof(double) +
+                                               sizeof(std::size_t)};
+    for (const auto &comp : data.concentration.back()) {
+      expectedAdditionalPerTimepoint += comp.size() * sizeof(double);
+    }
+    for (const auto &comp : data.avgMinMax.back()) {
+      expectedAdditionalPerTimepoint +=
+          comp.size() * sizeof(simulate::AvgMinMax);
+    }
+    for (const auto &comp : data.concentrationMax.back()) {
+      expectedAdditionalPerTimepoint += comp.size() * sizeof(double);
+    }
+    REQUIRE(data.getEstimatedAdditionalMemoryBytes(0) == 0);
+    REQUIRE(data.getEstimatedAdditionalMemoryBytes(3) ==
+            3 * expectedAdditionalPerTimepoint);
+  }
   SECTION("clear()") {
     data.clear();
     REQUIRE(data.timePoints.empty());

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "dialogsteadystate.hpp"
 #include "dialogunits.hpp"
 #include "guiutils.hpp"
+#include "memoryusagebarwidget.hpp"
 #include "ode_import_wizard.hpp"
 #include "sme/duneconverter.hpp"
 #include "sme/logger.hpp"
@@ -92,6 +93,7 @@ QString MainWindow::getConvertedFilename(const QString &filename) {
 
 static QLabel *makeStatusBarPermanentMessage(QWidget *parent) {
   QLabel *lbl{new QLabel(QString(), parent)};
+  lbl->setObjectName("statusBarPermanentMessage");
   lbl->setTextFormat(Qt::TextFormat::RichText);
   lbl->setOpenExternalLinks(false);
   lbl->setTextInteractionFlags(
@@ -111,6 +113,8 @@ MainWindow::MainWindow(const QString &filename, QWidget *parent)
   statusBarPermanentMessage = makeStatusBarPermanentMessage(this);
   ui->statusBar->addPermanentWidget(statusBarPermanentMessage);
   statusBarPermanentMessage->hide();
+  statusBarMemoryUsageBar = new MemoryUsageBarWidget(this);
+  ui->statusBar->addPermanentWidget(statusBarMemoryUsageBar);
 
   setupTabs();
   setupConnections();

--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -13,6 +13,7 @@ class TabParameters;
 class TabReactions;
 class TabSimulate;
 class TabSpecies;
+class MemoryUsageBarWidget;
 
 namespace Ui {
 class MainWindow;
@@ -27,7 +28,8 @@ public:
 
 private:
   std::unique_ptr<Ui::MainWindow> ui;
-  QLabel *statusBarPermanentMessage;
+  QLabel *statusBarPermanentMessage{};
+  MemoryUsageBarWidget *statusBarMemoryUsageBar{};
   sme::model::Model model;
   bool haveCopasiSE{false};
 

--- a/gui/mainwindow_t.cpp
+++ b/gui/mainwindow_t.cpp
@@ -3,11 +3,13 @@
 #include "model_test_utils.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qt_test_utils.hpp"
+#include "sme/system_memory.hpp"
 #include <QComboBox>
 #include <QFile>
 #include <QMenu>
 #include <QSpinBox>
 #include <QStatusBar>
+#include <QWidget>
 
 using namespace sme::test;
 using Catch::Matchers::ContainsSubstring;
@@ -480,7 +482,8 @@ TEST_CASE("MainWindow: non-spatial model import", tags) {
   MainWindow w("tmpmainw-nonspatial.xml");
   w.show();
   waitFor(&w);
-  auto *statusBarPermanentMessage{w.statusBar()->findChild<QLabel *>()};
+  auto *statusBarPermanentMessage{
+      w.statusBar()->findChild<QLabel *>("statusBarPermanentMessage")};
   REQUIRE(statusBarPermanentMessage != nullptr);
   REQUIRE(statusBarPermanentMessage->text().contains(
       "Importing non-spatial model. Step 1/3"));
@@ -497,6 +500,24 @@ TEST_CASE("MainWindow: non-spatial model import", tags) {
   REQUIRE(mwt.getResult() == "Edit Geometry Image");
   REQUIRE(statusBarPermanentMessage->text().contains(
       "Importing non-spatial model. Step 2/3"));
+}
+
+TEST_CASE("MainWindow: status bar memory info", tags) {
+  MainWindow w;
+  w.show();
+  waitFor(&w);
+  auto *statusBarMemoryUsageBar{
+      w.statusBar()->findChild<QWidget *>("statusBarMemoryUsageBar")};
+  REQUIRE(statusBarMemoryUsageBar != nullptr);
+
+  const auto memoryInfo{sme::common::getSystemMemoryInfo()};
+  const auto processMemoryInfo{
+      sme::common::getCurrentProcessMemoryUsageBytes()};
+  REQUIRE(memoryInfo.has_value());
+  REQUIRE(processMemoryInfo.has_value());
+  REQUIRE(statusBarMemoryUsageBar->toolTip().contains("RAM used by SME:"));
+  REQUIRE(statusBarMemoryUsageBar->toolTip().contains("RAM used by system:"));
+  REQUIRE(statusBarMemoryUsageBar->toolTip().contains("RAM total available:"));
 }
 
 TEST_CASE("MainWindow: drag & drop events", tags) {

--- a/gui/tabs/tabsimulate.cpp
+++ b/gui/tabs/tabsimulate.cpp
@@ -11,12 +11,15 @@
 #include "sme/model.hpp"
 #include "sme/serialization.hpp"
 #include "sme/simulate.hpp"
+#include "sme/system_memory.hpp"
 #include "sme/utils.hpp"
 #include "ui_tabsimulate.h"
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QtConcurrent/QtConcurrent>
 #include <algorithm>
+#include <cmath>
+#include <limits>
 
 TabSimulate::TabSimulate(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
                          QVoxelRenderer *voxelRenderer, QWidget *parent)
@@ -84,6 +87,74 @@ static void importModelTimesAndIntervals(
   if (!simInterval.isEmpty()) {
     ui->txtSimInterval->setText(simInterval);
   }
+}
+
+[[nodiscard]] static std::size_t getTotalTimesteps(
+    const std::vector<std::pair<std::size_t, double>> &timesteps) {
+  std::size_t total{0};
+  for (const auto &[n, dt] : timesteps) {
+    Q_UNUSED(dt);
+    total += n;
+  }
+  return total;
+}
+
+[[nodiscard]] static bool continueWithEstimatedMemoryUse(
+    QWidget *parent, const sme::simulate::SimulationData &data,
+    const std::vector<std::pair<std::size_t, double>> &timesteps) {
+  constexpr std::size_t absoluteWarningThresholdBytesNoMemInfo{
+      10ULL * 1024ULL * 1024ULL * 1024ULL};
+  constexpr double additionalDataSafetyFactor{1.25};
+  constexpr double availableMemoryWarningFraction{0.8};
+  const std::size_t nAdditionalTimesteps{getTotalTimesteps(timesteps)};
+  const std::size_t currentBytes{data.getEstimatedMemoryBytes()};
+  const auto additionalBytesUnscaled{
+      data.getEstimatedAdditionalMemoryBytes(nAdditionalTimesteps)};
+  std::size_t additionalBytes{additionalBytesUnscaled};
+  const auto maxBytes{std::numeric_limits<std::size_t>::max()};
+  const auto additionalLimit{static_cast<double>(maxBytes) /
+                             additionalDataSafetyFactor};
+  if (static_cast<double>(additionalBytesUnscaled) >= additionalLimit) {
+    additionalBytes = maxBytes;
+  } else {
+    additionalBytes = static_cast<std::size_t>(
+        std::ceil(additionalDataSafetyFactor *
+                  static_cast<double>(additionalBytesUnscaled)));
+  }
+  const std::size_t estimatedTotalBytes{
+      sme::common::saturatingAdd(currentBytes, additionalBytes)};
+  const auto memInfo{sme::common::getSystemMemoryInfo()};
+  bool showWarning{false};
+  if (memInfo.has_value()) {
+    const std::size_t availableWarningThreshold{static_cast<std::size_t>(
+        availableMemoryWarningFraction *
+        static_cast<double>(memInfo->availablePhysicalBytes))};
+    showWarning = estimatedTotalBytes >= availableWarningThreshold;
+  } else {
+    showWarning = estimatedTotalBytes >= absoluteWarningThresholdBytesNoMemInfo;
+  }
+  if (!showWarning) {
+    return true;
+  }
+  QString warning{
+      QString("The requested simulation is estimated to require around %1 "
+              "of simulation data RAM.\n\n"
+              "Current simulation data: %2\n"
+              "Additional data for this run: %3")
+          .arg(sme::common::formatMemoryBytes(estimatedTotalBytes),
+               sme::common::formatMemoryBytes(currentBytes),
+               sme::common::formatMemoryBytes(additionalBytes))};
+  if (memInfo.has_value()) {
+    warning.append(
+        QString("\n\nSystem memory available: %1\nSystem memory total: %2")
+            .arg(
+                sme::common::formatMemoryBytes(memInfo->availablePhysicalBytes),
+                sme::common::formatMemoryBytes(memInfo->totalPhysicalBytes)));
+  }
+  warning.append("\n\nContinue?");
+  return QMessageBox::question(parent, "High memory usage expected", warning,
+                               QMessageBox::Yes | QMessageBox::No,
+                               QMessageBox::No) == QMessageBox::Yes;
 }
 
 void TabSimulate::loadModelData() {
@@ -272,8 +343,13 @@ void TabSimulate::btnSimulate_clicked() {
                          "Invalid simulation times or image intervals");
     return;
   }
+  const auto timesteps{simulationTimes.value()};
+  if (!continueWithEstimatedMemoryUse(this, model.getSimulationData(),
+                                      timesteps)) {
+    return;
+  }
   QString imageIntervalsText;
-  for (const auto &[n, dt] : simulationTimes.value()) {
+  for (const auto &[n, dt] : timesteps) {
     SPDLOG_DEBUG("{} x {}", n, dt);
     imageIntervalsText.append(QString::number(dt));
     imageIntervalsText.append(";");
@@ -288,7 +364,7 @@ void TabSimulate::btnSimulate_clicked() {
   ui->btnSimulate->setEnabled(false);
   ui->btnResetSimulation->setEnabled(false);
   auto progressMax{static_cast<int>(time.size())};
-  for (const auto &simulationTime : simulationTimes.value()) {
+  for (const auto &simulationTime : timesteps) {
     progressMax += static_cast<int>(simulationTime.first);
   }
   progressDialog->setMaximum(progressMax);
@@ -296,9 +372,9 @@ void TabSimulate::btnSimulate_clicked() {
   this->setCursor(Qt::WaitCursor);
   simFinishedHandled.store(false);
   // start simulation in a new thread
-  simSteps = QtConcurrent::run(&sme::simulate::Simulation::doMultipleTimesteps,
-                               sim.get(), simulationTimes.value(), -1.0,
-                               std::function<bool()>{});
+  simSteps =
+      QtConcurrent::run(&sme::simulate::Simulation::doMultipleTimesteps,
+                        sim.get(), timesteps, -1.0, std::function<bool()>{});
   simWatcher.setFuture(simSteps);
   // start timer to periodically update simulation results
   plotRefreshTimer.start();

--- a/gui/widgets/CMakeLists.txt
+++ b/gui/widgets/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   gui
   PRIVATE plotwrapper.cpp
+          memoryusagebarwidget.cpp
           qlabelslice.cpp
           qlabelmousetracker.cpp
           qplaintextmathedit.cpp
@@ -13,6 +14,7 @@ if(BUILD_TESTING)
   target_sources(
     gui_tests
     PUBLIC plotwrapper_t.cpp
+           memoryusagebarwidget_t.cpp
            qlabelslice_t.cpp
            qlabelmousetracker_t.cpp
            qplaintextmathedit_t.cpp

--- a/gui/widgets/memoryusagebarwidget.cpp
+++ b/gui/widgets/memoryusagebarwidget.cpp
@@ -1,0 +1,110 @@
+#include "memoryusagebarwidget.hpp"
+#include "sme/utils.hpp"
+#include <QPainter>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+MemoryUsageBarWidget::MemoryUsageBarWidget(QWidget *parent)
+    : MemoryUsageBarWidget(sme::common::getSystemMemoryInfo,
+                           sme::common::getCurrentProcessMemoryUsageBytes,
+                           parent) {}
+
+MemoryUsageBarWidget::MemoryUsageBarWidget(
+    SystemMemoryInfoProvider systemMemoryInfoProvider,
+    ProcessMemoryUsageProvider processMemoryUsageProvider, QWidget *parent,
+    int updateIntervalMs)
+    : QWidget(parent),
+      systemMemoryInfoProvider{std::move(systemMemoryInfoProvider)},
+      processMemoryUsageProvider{std::move(processMemoryUsageProvider)} {
+  setObjectName("statusBarMemoryUsageBar");
+  setMinimumWidth(140);
+  setFixedHeight(14);
+  updateTimer.setTimerType(Qt::TimerType::VeryCoarseTimer);
+  setUpdateIntervalMs(updateIntervalMs);
+  connect(&updateTimer, &QTimer::timeout, this, &MemoryUsageBarWidget::refresh);
+  updateTimer.start();
+  refresh();
+}
+
+void MemoryUsageBarWidget::setUpdateIntervalMs(int updateIntervalMs) {
+  updateTimer.setInterval(updateIntervalMs);
+}
+
+void MemoryUsageBarWidget::refresh() {
+  const auto totalMemoryInfo{systemMemoryInfoProvider()};
+  const auto processMemoryUsage{processMemoryUsageProvider()};
+  if (!totalMemoryInfo.has_value() || !processMemoryUsage.has_value() ||
+      totalMemoryInfo->totalPhysicalBytes == 0) {
+    hide();
+    return;
+  }
+
+  const std::size_t totalBytes{totalMemoryInfo->totalPhysicalBytes};
+  const std::size_t totalAvailableBytes{
+      std::min(totalMemoryInfo->availablePhysicalBytes, totalBytes)};
+  const std::size_t totalUsedBytes{totalBytes - totalAvailableBytes};
+  const std::size_t smeUsedBytes{
+      std::min(processMemoryUsage.value(), totalUsedBytes)};
+  const std::size_t systemUsedBytes{totalUsedBytes - smeUsedBytes};
+  setMemoryUsage(smeUsedBytes, systemUsedBytes, totalAvailableBytes,
+                 totalBytes);
+  show();
+}
+
+void MemoryUsageBarWidget::setMemoryUsage(std::size_t smeUsed,
+                                          std::size_t systemUsed,
+                                          std::size_t totalAvailable,
+                                          std::size_t total) {
+  smeUsedBytes = smeUsed;
+  systemUsedBytes = systemUsed;
+  totalAvailableBytes = totalAvailable;
+  totalBytes = total;
+  setToolTip(QString("RAM used by SME: %1\n"
+                     "RAM used by system: %2\n"
+                     "RAM total available: %3")
+                 .arg(sme::common::formatMemoryBytes(smeUsedBytes),
+                      sme::common::formatMemoryBytes(systemUsedBytes),
+                      sme::common::formatMemoryBytes(totalAvailableBytes)));
+  update();
+}
+
+void MemoryUsageBarWidget::paintEvent(QPaintEvent *event) {
+  Q_UNUSED(event);
+  QPainter painter(this);
+  const QRect outerRect = rect().adjusted(0, 0, -1, -1);
+  painter.setPen(palette().color(QPalette::ColorRole::Mid));
+  painter.setBrush(Qt::NoBrush);
+  painter.drawRect(outerRect);
+  const QRect innerRect = outerRect.adjusted(1, 1, -1, -1);
+  if (innerRect.width() <= 0 || innerRect.height() <= 0 || totalBytes == 0) {
+    return;
+  }
+
+  const auto totalAsDouble = static_cast<double>(totalBytes);
+  const int innerWidth = innerRect.width();
+  const int smeWidth = static_cast<int>(
+      std::floor(static_cast<double>(smeUsedBytes) *
+                 static_cast<double>(innerWidth) / totalAsDouble));
+  const int systemWidth = static_cast<int>(
+      std::floor(static_cast<double>(systemUsedBytes) *
+                 static_cast<double>(innerWidth) / totalAsDouble));
+  const int availableWidth = std::max(0, innerWidth - smeWidth - systemWidth);
+
+  int x = innerRect.left();
+  if (smeWidth > 0) {
+    painter.fillRect(QRect(x, innerRect.top(), smeWidth, innerRect.height()),
+                     QColor("#4A4A4A"));
+    x += smeWidth;
+  }
+  if (systemWidth > 0) {
+    painter.fillRect(QRect(x, innerRect.top(), systemWidth, innerRect.height()),
+                     QColor("#BDBDBD"));
+    x += systemWidth;
+  }
+  if (availableWidth > 0) {
+    painter.fillRect(
+        QRect(x, innerRect.top(), availableWidth, innerRect.height()),
+        QColor("#FFFFFF"));
+  }
+}

--- a/gui/widgets/memoryusagebarwidget.hpp
+++ b/gui/widgets/memoryusagebarwidget.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "sme/system_memory.hpp"
+#include <QTimer>
+#include <QWidget>
+#include <cstddef>
+#include <functional>
+#include <optional>
+
+class MemoryUsageBarWidget : public QWidget {
+public:
+  using SystemMemoryInfoProvider =
+      std::function<std::optional<sme::common::SystemMemoryInfo>()>;
+  using ProcessMemoryUsageProvider =
+      std::function<std::optional<std::size_t>()>;
+
+  explicit MemoryUsageBarWidget(QWidget *parent = nullptr);
+
+  MemoryUsageBarWidget(SystemMemoryInfoProvider systemMemoryInfoProvider,
+                       ProcessMemoryUsageProvider processMemoryUsageProvider,
+                       QWidget *parent = nullptr, int updateIntervalMs = 2000);
+
+  void refresh();
+  void setUpdateIntervalMs(int updateIntervalMs);
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+
+private:
+  SystemMemoryInfoProvider systemMemoryInfoProvider;
+  ProcessMemoryUsageProvider processMemoryUsageProvider;
+  QTimer updateTimer;
+  std::size_t smeUsedBytes{};
+  std::size_t systemUsedBytes{};
+  std::size_t totalAvailableBytes{};
+  std::size_t totalBytes{};
+
+  void setMemoryUsage(std::size_t smeUsed, std::size_t systemUsed,
+                      std::size_t totalAvailable, std::size_t total);
+};

--- a/gui/widgets/memoryusagebarwidget_t.cpp
+++ b/gui/widgets/memoryusagebarwidget_t.cpp
@@ -1,0 +1,64 @@
+#include "catch_wrapper.hpp"
+#include "memoryusagebarwidget.hpp"
+#include "qt_test_utils.hpp"
+
+using namespace sme::test;
+
+TEST_CASE("MemoryUsageBarWidget", "[gui/widgets/memoryusagebarwidget][gui/"
+                                  "widgets][gui][memoryusagebarwidget]") {
+  SECTION("valid memory info shows tooltip and widget") {
+    MemoryUsageBarWidget widget(
+        []() -> std::optional<sme::common::SystemMemoryInfo> {
+          return sme::common::SystemMemoryInfo{100, 30};
+        },
+        []() -> std::optional<std::size_t> { return 40; }, nullptr, 60000);
+    widget.show();
+    waitFor(&widget);
+    widget.refresh();
+
+    REQUIRE(widget.isHidden() == false);
+    REQUIRE(widget.toolTip().contains("RAM used by SME: 40 B"));
+    REQUIRE(widget.toolTip().contains("RAM used by system: 30 B"));
+    REQUIRE(widget.toolTip().contains("RAM total available: 30 B"));
+  }
+
+  SECTION("SME usage is capped at total used memory") {
+    MemoryUsageBarWidget widget(
+        []() -> std::optional<sme::common::SystemMemoryInfo> {
+          return sme::common::SystemMemoryInfo{100, 30};
+        },
+        []() -> std::optional<std::size_t> { return 99; }, nullptr, 60000);
+    widget.show();
+    waitFor(&widget);
+    widget.refresh();
+
+    REQUIRE(widget.toolTip().contains("RAM used by SME: 70 B"));
+    REQUIRE(widget.toolTip().contains("RAM used by system: 0 B"));
+  }
+
+  SECTION("missing memory info hides widget") {
+    MemoryUsageBarWidget widget(
+        []() -> std::optional<sme::common::SystemMemoryInfo> {
+          return std::nullopt;
+        },
+        []() -> std::optional<std::size_t> { return 10; }, nullptr, 60000);
+    widget.show();
+    waitFor(&widget);
+    widget.refresh();
+
+    REQUIRE(widget.isHidden());
+  }
+
+  SECTION("zero total memory hides widget") {
+    MemoryUsageBarWidget widget(
+        []() -> std::optional<sme::common::SystemMemoryInfo> {
+          return sme::common::SystemMemoryInfo{0, 0};
+        },
+        []() -> std::optional<std::size_t> { return 10; }, nullptr, 60000);
+    widget.show();
+    waitFor(&widget);
+    widget.refresh();
+
+    REQUIRE(widget.isHidden());
+  }
+}


### PR DESCRIPTION
- add SimulationData memory estimation APIs for current and projected timestep data
- warn before simulation when projected RAM is high (absolute + available-memory based)
- add common::getSystemMemoryInfo() with Linux/macOS/Windows implementations
- include Linux cgroup-aware limits in memory availability checks
- add/enable tests for memory estimation and system memory info
- resolves #1018
