### PR TITLE
Fix 3D geometry clipping

### DIFF
--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -119,7 +119,8 @@ void TabGeometry::loadModelData(const QString &selection) {
   lblGeometry->setImage(model.getGeometry().getImages());
   lblGeometry->setPhysicalUnits(model.getUnits().getLength().name);
   lblGeometry->setPhysicalOrigin(model.getGeometry().getPhysicalOrigin());
-  voxGeometry->setImage(model.getGeometry().getImages());
+  voxGeometry->setImage(model.getGeometry().getImages(),
+                        model.getGeometry().getPhysicalOrigin());
   enableTabs();
   selectMatchingOrFirstItem(ui->listCompartments, selection);
 }
@@ -288,7 +289,8 @@ void TabGeometry::btnChangeCompartmentColor_clicked() {
       ui->mshCompMesh->setColors(mesh3d->getColors());
     }
     lblGeometry->setImage(model.getGeometry().getImages());
-    voxGeometry->setImage(model.getGeometry().getImages());
+    voxGeometry->setImage(model.getGeometry().getImages(),
+                          model.getGeometry().getPhysicalOrigin());
   }
 }
 

--- a/gui/widgets/qvoxelrenderer.cpp
+++ b/gui/widgets/qvoxelrenderer.cpp
@@ -73,7 +73,8 @@ imageStackToVtkArray(const sme::common::ImageStack &img,
   return array;
 }
 
-void QVoxelRenderer::setImage(const sme::common::ImageStack &img) {
+void QVoxelRenderer::setImage(const sme::common::ImageStack &img,
+                              const sme::common::VoxelF &origin) {
   std::array<int, 3> dims{};
   imageDataArray = imageStackToVtkArray(img, dims);
   imageData->SetDimensions(dims.data());
@@ -83,7 +84,7 @@ void QVoxelRenderer::setImage(const sme::common::ImageStack &img) {
   volume->GetProperty()->SetScalarOpacityUnitDistance(3, avgVoxelLength);
   imageData->SetSpacing(img.voxelSize().width(), img.voxelSize().height(),
                         img.voxelSize().depth());
-  imageData->SetOrigin(0.0, 0.0, 0.0);
+  imageData->SetOrigin(origin.p.x(), origin.p.y(), origin.z);
   imageData->GetPointData()->SetScalars(imageDataArray);
   renderer->ResetCameraClippingRange();
   renderer->ResetCamera();
@@ -160,7 +161,9 @@ void QVoxelRenderer::mousePressEvent(QMouseEvent *ev) {
 void QVoxelRenderer::slideClippingPlaneOrigin_valueChanged(int value) {
   double fractionalValue =
       static_cast<double>(value) / slideClippingPlaneOrigin->maximum();
-  double origin = fractionalValue * maxClippingPlaneOrigin;
+  double origin =
+      minClippingPlaneOrigin +
+      fractionalValue * (maxClippingPlaneOrigin - minClippingPlaneOrigin);
   clippingPlane->SetOrigin(origin, origin, origin);
   clippingPlane->Modified();
   vtkRender();
@@ -188,7 +191,19 @@ void QVoxelRenderer::cmbClippingPlaneNormal_currentTextChanged(
   double dy;
   double dz;
   imageData->GetSpacing(dx, dy, dz);
-  maxClippingPlaneOrigin = x * dim[0] * dx + y * dim[1] * dy + z * dim[2] * dz;
+  double ox;
+  double oy;
+  double oz;
+  imageData->GetOrigin(ox, oy, oz);
+  // Expand the clipping range slightly so "no clipping" doesn't slice geometry
+  // that lies numerically on, or very close to, the image boundary.
+  const double axisSpacing = x * dx + y * dy + z * dz;
+  const double clipPadding = axisSpacing;
+  minClippingPlaneOrigin = x * ox + y * oy + z * oz;
+  maxClippingPlaneOrigin =
+      x * (ox + dim[0] * dx) + y * (oy + dim[1] * dy) + z * (oz + dim[2] * dz);
+  minClippingPlaneOrigin -= clipPadding;
+  maxClippingPlaneOrigin += clipPadding;
   if (slideClippingPlaneOrigin != nullptr) {
     slideClippingPlaneOrigin_valueChanged(slideClippingPlaneOrigin->value());
   }

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -18,7 +18,8 @@ class QVoxelRenderer : public SmeVtkWidget {
   Q_OBJECT
 public:
   explicit QVoxelRenderer(QWidget *parent = nullptr);
-  void setImage(const sme::common::ImageStack &img);
+  void setImage(const sme::common::ImageStack &img,
+                const sme::common::VoxelF &origin = {0.0, 0.0, 0.0});
   void setClippingPlaneOriginSlider(QSlider *slider);
   void setClippingPlaneNormalCombobox(QComboBox *combobox);
   void renderOnClippingPaneChange(SmeVtkWidget *smeVtkWidget);
@@ -39,6 +40,7 @@ private:
   vtkNew<vtkPlane> clippingPlane;
   QString lengthUnits{};
   SmeVtkWidget *smeVtkWidgetToRenderOnClippingPlaneChange{nullptr};
+  double minClippingPlaneOrigin{0.0};
   double maxClippingPlaneOrigin{0.0};
   QSlider *slideClippingPlaneOrigin{nullptr};
   QComboBox *cmbClippingPlaneNormal{nullptr};

--- a/gui/widgets/qvoxelrenderer_t.cpp
+++ b/gui/widgets/qvoxelrenderer_t.cpp
@@ -3,6 +3,9 @@
 #include "qt_test_utils.hpp"
 #include "qvoxelrenderer.hpp"
 #include "sme/image_stack.hpp"
+#include <QComboBox>
+#include <QSlider>
+#include <array>
 
 using namespace sme::test;
 
@@ -84,5 +87,40 @@ TEST_CASE("QVoxelRenderer",
       voxelRenderer.setImage(imageStack);
       wait(delay_ms);
     }
+  }
+  SECTION("clipping plane uses physical origin") {
+    auto model = sme::test::getExampleModel(Mod::SingleCompartmentDiffusion3D);
+    auto imageStack = model.getGeometry().getImages();
+    const auto &origin = model.getGeometry().getPhysicalOrigin();
+    REQUIRE(origin.p.x() == dbl_approx(-50.0));
+    REQUIRE(origin.p.y() == dbl_approx(-50.0));
+    REQUIRE(origin.z == dbl_approx(-50.0));
+    QSlider slider;
+    QComboBox comboBox;
+    voxelRenderer.setClippingPlaneOriginSlider(&slider);
+    voxelRenderer.setClippingPlaneNormalCombobox(&comboBox);
+    voxelRenderer.setImage(imageStack, origin);
+    wait(delay_ms);
+    const double xPad = imageStack.voxelSize().width();
+    const double zPad = imageStack.voxelSize().depth();
+    std::array<double, 3> planeOrigin{};
+    voxelRenderer.getClippingPlane()->GetOrigin(planeOrigin.data());
+    REQUIRE(planeOrigin[2] == dbl_approx(origin.z - zPad));
+
+    slider.setValue(slider.maximum() / 2);
+    wait(delay_ms);
+    voxelRenderer.getClippingPlane()->GetOrigin(planeOrigin.data());
+    REQUIRE(planeOrigin[2] == dbl_approx(0.0));
+
+    comboBox.setCurrentText("x");
+    slider.setValue(0);
+    wait(delay_ms);
+    voxelRenderer.getClippingPlane()->GetOrigin(planeOrigin.data());
+    REQUIRE(planeOrigin[0] == dbl_approx(origin.p.x() - xPad));
+
+    slider.setValue(slider.maximum());
+    wait(delay_ms);
+    voxelRenderer.getClippingPlane()->GetOrigin(planeOrigin.data());
+    REQUIRE(planeOrigin[0] == dbl_approx(50.0 + xPad));
   }
 }


### PR DESCRIPTION
- set VTK image origin from model geometry origin in QVoxelRenderer
  - this was previously always set to zero
- compute clipping plane min/max from image origin + spacing + dimensions
  - previously also assumed zero origin
- add a voxel of padding to ensure no clipping when clipping slider is set to minimum
- resolves #1129
