### PR TITLE
Allow constant species to be spatial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- dialog for importing analytic geometry where users can set voxel resolution and preview the converted sampled image before import
-- aligned simulation option exposure and naming across GUI, CLI and Python interfaces by adding DUNE/Pixel solver option overrides to CLI and exposing Python `model.simulation_settings` (including simulation times) plus optional `simulate(...)` time arguments
+- allow constant species to have spatially varying concentrations [#1133](https://github.com/spatial-model-editor/spatial-model-editor/issues/1133)
 
 ## [1.11.0] - 2026-02-04
 ### Added

--- a/core/model/include/sme/model_species.hpp
+++ b/core/model/include/sme/model_species.hpp
@@ -356,6 +356,18 @@ public:
    */
   [[nodiscard]] bool getIsConstant(const QString &id) const;
   /**
+   * @brief Returns whether species is a scalar constant.
+   * @param id Species id.
+   * @returns ``true`` if species is constant and non-spatial.
+   */
+  [[nodiscard]] bool isScalarConstantSpecies(const QString &id) const;
+  /**
+   * @brief Returns whether species should be present in simulation fields.
+   * @param id Species id.
+   * @returns ``true`` if species should appear in simulation state/results.
+   */
+  [[nodiscard]] bool isSimulatedSpecies(const QString &id) const;
+  /**
    * @brief Returns whether species participates in any reaction.
    * @param id Species id.
    * @returns ``true`` if species is reactive.

--- a/core/model/src/model_parameters.cpp
+++ b/core/model/src/model_parameters.cpp
@@ -386,13 +386,22 @@ static bool isConstantParameter(const libsbml::Parameter *param) {
   return true;
 }
 
+static bool isSpatialSpecies(const libsbml::Species *spec) {
+  if (const auto *ssp = static_cast<const libsbml::SpatialSpeciesPlugin *>(
+          spec->getPlugin("spatial"));
+      ssp != nullptr) {
+    return ssp->getIsSpatial();
+  }
+  return false;
+}
+
 std::vector<IdNameValue> ModelParameters::getGlobalConstants() const {
   std::vector<IdNameValue> constants;
-  // add all *constant* species as constants
+  // add all scalar constant species as constants
   for (unsigned k = 0; k < sbmlModel->getNumSpecies(); ++k) {
     const auto *spec = sbmlModel->getSpecies(k);
-    if (getIsSpeciesConstant(spec)) {
-      SPDLOG_TRACE("found constant species {}", spec->getId());
+    if (getIsSpeciesConstant(spec) && !isSpatialSpecies(spec)) {
+      SPDLOG_TRACE("found scalar constant species {}", spec->getId());
       double init_conc = spec->getInitialConcentration();
       constants.push_back({spec->getId(), spec->getName(), init_conc});
       SPDLOG_TRACE("parameter {} = {}", spec->getId(), init_conc);

--- a/core/model/src/model_species.cpp
+++ b/core/model/src/model_species.cpp
@@ -534,11 +534,10 @@ void ModelSpecies::setIsSpatial(const QString &id, bool isSpatial) {
   }
   hasUnsavedChanges = true;
   ssp->setIsSpatial(isSpatial);
-  if (isSpatial) {
-    // for now spatial species cannot be constant
-    setIsConstant(id, false);
-  } else {
+  if (!isSpatial) {
     removeInitialAssignment(id);
+    fields[static_cast<std::size_t>(i)].setUniformConcentration(
+        spec->getInitialConcentration());
     setDiffusionConstant(id, 0.0);
   }
 }
@@ -1033,9 +1032,8 @@ void ModelSpecies::setIsConstant(const QString &id, bool constant) {
   species->setConstant(constant);
   SPDLOG_INFO("Clearing simulation data");
   simulationData->clear();
-  if (constant) {
-    // for now: constant species must be non-spatial
-    setIsSpatial(id, false);
+  if (constant && sbmlAnnotation != nullptr) {
+    sbmlAnnotation->speciesCrossDiffusionConstants.erase(id.toStdString());
   }
   // todo: think about how to deal with boundaryCondition properly
   // for now, just set it to false here
@@ -1046,6 +1044,14 @@ void ModelSpecies::setIsConstant(const QString &id, bool constant) {
 bool ModelSpecies::getIsConstant(const QString &id) const {
   const auto *spec = sbmlModel->getSpecies(id.toStdString());
   return getIsSpeciesConstant(spec);
+}
+
+bool ModelSpecies::isScalarConstantSpecies(const QString &id) const {
+  return getIsConstant(id) && !getIsSpatial(id);
+}
+
+bool ModelSpecies::isSimulatedSpecies(const QString &id) const {
+  return !isScalarConstantSpecies(id);
 }
 
 bool ModelSpecies::isReactive(const QString &id) const {

--- a/core/model/src/model_species_t.cpp
+++ b/core/model/src/model_species_t.cpp
@@ -39,16 +39,104 @@ TEST_CASE("SBML species",
     // also make it constant
     s.setIsConstant("B_c3", true);
     REQUIRE(s.containsNonSpatialReactiveSpecies() == false);
-    // making a species constant also implies making it non-spatial
+    // constant spatial species are allowed
     REQUIRE(s.getIsSpatial("B_c2") == true);
     s.setIsConstant("B_c2", true);
     REQUIRE(s.getIsConstant("B_c2") == true);
-    REQUIRE(s.getIsSpatial("B_c2") == false);
+    REQUIRE(s.getIsSpatial("B_c2") == true);
     REQUIRE(s.containsNonSpatialReactiveSpecies() == false);
     s.setIsConstant("B_c2", false);
     REQUIRE(s.getIsConstant("B_c2") == false);
-    REQUIRE(s.getIsSpatial("B_c2") == false);
-    REQUIRE(s.containsNonSpatialReactiveSpecies() == true);
+    REQUIRE(s.getIsSpatial("B_c2") == true);
+    REQUIRE(s.containsNonSpatialReactiveSpecies() == false);
+  }
+  SECTION("Constant spatial species preserve spatial initial conditions") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &s{m.getSpecies()};
+    const auto nVoxels{static_cast<std::size_t>(
+        m.getGeometry().getImages().volume().nVoxels())};
+
+    s.setIsConstant("A_c1", true);
+    s.setIsSpatial("A_c1", true);
+    REQUIRE(s.getIsConstant("A_c1") == true);
+    REQUIRE(s.getIsSpatial("A_c1") == true);
+
+    std::vector<double> sampledField(nVoxels, 0.0);
+    const auto *comp = m.getCompartments().getCompartment("c1");
+    std::size_t i{0};
+    for (const auto &voxel : comp->getVoxels()) {
+      const auto arrayIndex = common::voxelArrayIndex(
+          m.getGeometry().getImages().volume(), voxel, true);
+      sampledField[arrayIndex] = static_cast<double>(i++ % 7);
+    }
+    s.setSampledFieldConcentration("A_c1", sampledField);
+    s.setIsConstant("A_c1", true);
+    const auto storedSampledField{s.getSampledFieldConcentration("A_c1")};
+    REQUIRE(s.getIsConstant("A_c1") == true);
+    REQUIRE(s.getIsSpatial("A_c1") == true);
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Image);
+    REQUIRE(storedSampledField != std::vector<double>(nVoxels, 0.0));
+
+    model::Model mImageRoundTrip;
+    mImageRoundTrip.importSBMLString(m.getXml().toStdString());
+    REQUIRE(mImageRoundTrip.getSpecies().getIsConstant("A_c1") == true);
+    REQUIRE(mImageRoundTrip.getSpecies().getIsSpatial("A_c1") == true);
+    REQUIRE(mImageRoundTrip.getSpecies().getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Image);
+    REQUIRE(mImageRoundTrip.getSpecies().getSampledFieldConcentration("A_c1") ==
+            storedSampledField);
+
+    s.setAnalyticConcentration("A_c1", "x");
+    s.setIsConstant("A_c1", true);
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Analytic);
+    REQUIRE(symEq(s.getAnalyticConcentration("A_c1"), "x"));
+
+    model::Model mAnalyticRoundTrip;
+    mAnalyticRoundTrip.importSBMLString(m.getXml().toStdString());
+    REQUIRE(mAnalyticRoundTrip.getSpecies().getIsConstant("A_c1") == true);
+    REQUIRE(mAnalyticRoundTrip.getSpecies().getIsSpatial("A_c1") == true);
+    REQUIRE(mAnalyticRoundTrip.getSpecies().getInitialConcentrationType(
+                "A_c1") == model::SpatialDataType::Analytic);
+    REQUIRE(symEq(
+        mAnalyticRoundTrip.getSpecies().getAnalyticConcentration("A_c1"), "x"));
+  }
+  SECTION(
+      "Switching a species to non-spatial resets initial concentration type") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &s{m.getSpecies()};
+
+    s.setAnalyticConcentration("A_c1", "x");
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Analytic);
+    s.setIsSpatial("A_c1", false);
+    REQUIRE(s.getIsSpatial("A_c1") == false);
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Uniform);
+    REQUIRE(s.getField("A_c1")->getIsUniformConcentration() == true);
+    REQUIRE(s.getInitialConcentration("A_c1") == dbl_approx(1.0));
+
+    s.setIsSpatial("A_c1", true);
+    const auto nVoxels{static_cast<std::size_t>(
+        m.getGeometry().getImages().volume().nVoxels())};
+    std::vector<double> sampledField(nVoxels, 0.0);
+    const auto *comp = m.getCompartments().getCompartment("c1");
+    std::size_t i{0};
+    for (const auto &voxel : comp->getVoxels()) {
+      const auto arrayIndex = common::voxelArrayIndex(
+          m.getGeometry().getImages().volume(), voxel, true);
+      sampledField[arrayIndex] = static_cast<double>(i++ % 5);
+    }
+    s.setSampledFieldConcentration("A_c1", sampledField);
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Image);
+    s.setIsSpatial("A_c1", false);
+    REQUIRE(s.getIsSpatial("A_c1") == false);
+    REQUIRE(s.getInitialConcentrationType("A_c1") ==
+            model::SpatialDataType::Uniform);
+    REQUIRE(s.getField("A_c1")->getIsUniformConcentration() == true);
+    REQUIRE(s.getInitialConcentration("A_c1") == dbl_approx(1.0));
   }
   SECTION("Remove species also removes dependents") {
     auto m{getExampleModel(Mod::VerySimpleModel)};
@@ -115,8 +203,7 @@ TEST_CASE("SBML species",
     REQUIRE(r.getParameterValue("B_transport", "k1") == dbl_approx(0.1));
 
     // make species B_c3 constant
-    // this resets any existing simulation data (as non-constant species number
-    // has changed, invalidating existing simulation data)
+    // this resets any existing simulation data
     REQUIRE(r.getHasUnsavedChanges() == false);
     REQUIRE(s.getHasUnsavedChanges() == false);
     s.setIsConstant("B_c3", true);

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -159,23 +159,24 @@ static void addCompartment(
 
   SPDLOG_TRACE("compartment {}", compartmentId.toStdString());
 
-  auto nonConstantSpecies = getNonConstantSpecies(model, compartmentId);
-  auto duneSpeciesNames = makeValidDuneSpeciesNames(nonConstantSpecies);
+  auto simulatedSpecies = getSimulatedSpecies(model, compartmentId);
+  auto duneSpeciesNames = makeValidDuneSpeciesNames(simulatedSpecies);
 
   speciesNames[compartmentId.toStdString()] = [&model, &compartmentId,
                                                &duneSpeciesNames]() {
     std::vector<std::string> duneSpeciesNamesSmeIndices;
     std::size_t duneNameIndex{0};
     for (const auto &s : model.getSpecies().getIds(compartmentId)) {
-      if (!model.getSpecies().getIsConstant(s)) {
+      if (model.getSpecies().isSimulatedSpecies(s)) {
         duneSpeciesNamesSmeIndices.push_back(duneSpeciesNames[duneNameIndex++]);
         SPDLOG_INFO("  - SME species {} -> DUNE species {}", s.toStdString(),
                     duneSpeciesNamesSmeIndices.back());
       } else {
-        // if SME species is not in dune sim dune species name is empty string
+        // if SME species is not simulated its DUNE species name is empty string
         duneSpeciesNamesSmeIndices.emplace_back();
         SPDLOG_INFO(
-            "  - SME species {} is constant -> not present in DUNE simulation",
+            "  - SME species {} is scalar constant -> not present in DUNE "
+            "simulation",
             s.toStdString());
       }
     }
@@ -192,11 +193,11 @@ static void addCompartment(
   SPDLOG_INFO("  - multiplying reactions by [length]^3/[vol] = {}",
               scaleFactors.reaction);
 
-  Pde pde(&model, nonConstantSpecies, reacs, duneSpeciesNames, scaleFactors,
+  Pde pde(&model, simulatedSpecies, reacs, duneSpeciesNames, scaleFactors,
           extraReactionVars, relabelledExtraReactionVars, substitutions);
 
   std::vector<QString> tiffs;
-  std::size_t nSpecies{nonConstantSpecies.size()};
+  std::size_t nSpecies{simulatedSpecies.size()};
   if (nSpecies == 0) {
     // dummy species with no reactions if compartment is empty
     auto dummySpeciesName{QString("%1_dummy_species").arg(compartmentId)};
@@ -211,7 +212,7 @@ static void addCompartment(
     return;
   }
   for (std::size_t i = 0; i < nSpecies; ++i) {
-    QString name{nonConstantSpecies[i].c_str()};
+    QString name{simulatedSpecies[i].c_str()};
     QString duneName{duneSpeciesNames[i].c_str()};
     ini.addSection("model", "scalar_field", duneName);
     ini.addValue("compartment", compartmentId);
@@ -255,7 +256,7 @@ static void addCompartment(
         auto simField{*f};
         const std::size_t nPixels{f->getCompartment()->nVoxels()};
         const std::size_t padding{model.getSimulationData().concPadding.back()};
-        const std::size_t stride{padding + nonConstantSpecies.size()};
+        const std::size_t stride{padding + simulatedSpecies.size()};
         std::vector<double> c(nPixels, 0.0);
         SPDLOG_INFO("using simulation concentration data for species {}",
                     name.toStdString());
@@ -291,9 +292,12 @@ static void addCompartment(
     }
 
     // diffusion constant
-    QString sId{nonConstantSpecies[i].c_str()};
-    if (model.getSpecies().getDiffusionConstantType(sId) !=
-        model::SpatialDataType::Uniform) {
+    QString sId{simulatedSpecies[i].c_str()};
+    if (model.getSpecies().getIsConstant(sId)) {
+      ini.addValue(QString("cross_diffusion.%1.expression").arg(duneName), 0.0,
+                   doublePrecision);
+    } else if (model.getSpecies().getDiffusionConstantType(sId) !=
+               model::SpatialDataType::Uniform) {
       std::string diffusionName =
           "__diffusion_constant_cell_data_" + duneSpeciesNames[i];
       diffusionConstantArrays[diffusionName] =
@@ -309,7 +313,10 @@ static void addCompartment(
       if (j == i) {
         continue;
       }
-      const QString sourceSpeciesId{nonConstantSpecies[j].c_str()};
+      if (model.getSpecies().getIsConstant(sId)) {
+        continue;
+      }
+      const QString sourceSpeciesId{simulatedSpecies[j].c_str()};
       const auto crossDiffusionExpression{
           model.getSpecies().getCrossDiffusionConstant(sId, sourceSpeciesId)};
       if (crossDiffusionExpression.isEmpty()) {
@@ -317,7 +324,7 @@ static void addCompartment(
       }
       auto [crossExpression, crossJacobian] =
           getCrossDiffusionExpressionAndJacobian(
-              model, crossDiffusionExpression.toStdString(), nonConstantSpecies,
+              model, crossDiffusionExpression.toStdString(), simulatedSpecies,
               duneSpeciesNames, extraReactionVars, relabelledExtraReactionVars,
               volOverL3, substitutions);
       ini.addValue(QString("cross_diffusion.%1.expression")
@@ -346,13 +353,12 @@ static void addCompartment(
         QString membraneID = membrane.getId().c_str();
         auto mReacs =
             common::toStdString(model.getReactions().getIds(membraneID));
-        auto nonConstantSpeciesOther =
-            getNonConstantSpecies(model, otherCompId);
+        auto simulatedSpeciesOther = getSimulatedSpecies(model, otherCompId);
         auto duneSpeciesNamesOther =
-            makeValidDuneSpeciesNames(nonConstantSpeciesOther);
+            makeValidDuneSpeciesNames(simulatedSpeciesOther);
 
-        auto mSpecies = nonConstantSpecies;
-        for (const auto &s : nonConstantSpeciesOther) {
+        auto mSpecies = simulatedSpecies;
+        for (const auto &s : simulatedSpeciesOther) {
           mSpecies.push_back(s);
         }
         auto mDuneSpecies = duneSpeciesNames;
@@ -381,7 +387,7 @@ static void addCompartment(
       }
     }
   }
-  if (!nonConstantSpecies.empty()) {
+  if (!simulatedSpecies.empty()) {
     ++simDataCompartmentIndex;
   }
   if (forExternalUse && !tiffs.empty()) {

--- a/core/simulate/src/duneconverter_impl.cpp
+++ b/core/simulate/src/duneconverter_impl.cpp
@@ -59,19 +59,19 @@ makeValidDuneSpeciesNames(const std::vector<std::string> &names) {
   return duneNames;
 }
 
-bool compartmentContainsNonConstantSpecies(const model::Model &model,
-                                           const QString &compId) {
+bool compartmentContainsSimulatedSpecies(const model::Model &model,
+                                         const QString &compId) {
   const auto &specs = model.getSpecies().getIds(compId);
   return std::ranges::any_of(specs, [m = &model](const auto &s) {
-    return !m->getSpecies().getIsConstant(s);
+    return m->getSpecies().isSimulatedSpecies(s);
   });
 }
 
-std::vector<std::string> getNonConstantSpecies(const model::Model &model,
-                                               const QString &compId) {
+std::vector<std::string> getSimulatedSpecies(const model::Model &model,
+                                             const QString &compId) {
   std::vector<std::string> v;
   for (const auto &s : model.getSpecies().getIds(compId)) {
-    if (!model.getSpecies().getIsConstant(s)) {
+    if (model.getSpecies().isSimulatedSpecies(s)) {
       v.push_back(s.toStdString());
     }
   }

--- a/core/simulate/src/duneconverter_impl.hpp
+++ b/core/simulate/src/duneconverter_impl.hpp
@@ -17,15 +17,15 @@ std::vector<std::string>
 makeValidDuneSpeciesNames(const std::vector<std::string> &names);
 
 /**
- * @brief Returns whether compartment has any non-constant species.
+ * @brief Returns whether compartment has any simulated species.
  */
-bool compartmentContainsNonConstantSpecies(const model::Model &model,
-                                           const QString &compId);
+bool compartmentContainsSimulatedSpecies(const model::Model &model,
+                                         const QString &compId);
 
 /**
- * @brief Non-constant species ids in compartment.
+ * @brief Simulated species ids in compartment.
  */
-std::vector<std::string> getNonConstantSpecies(const model::Model &model,
-                                               const QString &compId);
+std::vector<std::string> getSimulatedSpecies(const model::Model &model,
+                                             const QString &compId);
 
 } // namespace sme::simulate

--- a/core/simulate/src/duneconverter_impl_t.cpp
+++ b/core/simulate/src/duneconverter_impl_t.cpp
@@ -23,49 +23,57 @@ TEST_CASE("DUNE: DuneConverter impl",
   }
   SECTION("ABtoC model") {
     auto s{getExampleModel(Mod::ABtoC)};
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "comp") == true);
-    auto nonConstantSpecies = simulate::getNonConstantSpecies(s, "comp");
-    REQUIRE(nonConstantSpecies.size() == 3);
-    REQUIRE(nonConstantSpecies[0] == "A");
-    REQUIRE(nonConstantSpecies[1] == "B");
-    REQUIRE(nonConstantSpecies[2] == "C");
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "comp") == true);
+    auto simulatedSpecies = simulate::getSimulatedSpecies(s, "comp");
+    REQUIRE(simulatedSpecies.size() == 3);
+    REQUIRE(simulatedSpecies[0] == "A");
+    REQUIRE(simulatedSpecies[1] == "B");
+    REQUIRE(simulatedSpecies[2] == "C");
 
-    // make all species constant
+    // scalar constant species are excluded from the simulated field set
+    s.getSpecies().setIsSpatial("A", false);
+    s.getSpecies().setIsSpatial("B", false);
+    s.getSpecies().setIsSpatial("C", false);
     s.getSpecies().setIsConstant("A", true);
     s.getSpecies().setIsConstant("B", true);
     s.getSpecies().setIsConstant("C", true);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "comp") ==
-            false);
-    REQUIRE(simulate::getNonConstantSpecies(s, "comp").empty());
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "comp") == false);
+    REQUIRE(simulate::getSimulatedSpecies(s, "comp").empty());
+
+    // spatial constant species remain part of the simulated field set
+    s.getSpecies().setIsSpatial("A", true);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "comp") == true);
+    REQUIRE(simulate::getSimulatedSpecies(s, "comp") ==
+            std::vector<std::string>{"A"});
   }
   SECTION("very-simple-model model") {
     auto s{getExampleModel(Mod::VerySimpleModel)};
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c1") == true);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c2") == true);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c3") == true);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c1").size() == 1);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c1") == true);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c2") == true);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c3") == true);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c1").size() == 1);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c2").size() == 2);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c3").size() == 2);
 
-    // remove only non-constant species in compartment c1
+    // remove only simulated species in compartment c1
     s.getSpecies().remove("B_c1");
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c1") == false);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c2") == true);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c3") == true);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c1").empty());
-    REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c1") == false);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c2") == true);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c3") == true);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c1").empty());
+    REQUIRE(simulate::getSimulatedSpecies(s, "c2").size() == 2);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c3").size() == 2);
 
     // remove membrane reactions
     s.getReactions().remove("A_uptake");
     s.getReactions().remove("A_transport");
     s.getReactions().remove("B_excretion");
     s.getReactions().remove("B_transport");
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c1") == false);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c2") == true);
-    REQUIRE(simulate::compartmentContainsNonConstantSpecies(s, "c3") == true);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c1").empty());
-    REQUIRE(simulate::getNonConstantSpecies(s, "c2").size() == 2);
-    REQUIRE(simulate::getNonConstantSpecies(s, "c3").size() == 2);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c1") == false);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c2") == true);
+    REQUIRE(simulate::compartmentContainsSimulatedSpecies(s, "c3") == true);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c1").empty());
+    REQUIRE(simulate::getSimulatedSpecies(s, "c2").size() == 2);
+    REQUIRE(simulate::getSimulatedSpecies(s, "c3").size() == 2);
   }
 }

--- a/core/simulate/src/duneconverter_t.cpp
+++ b/core/simulate/src/duneconverter_t.cpp
@@ -41,6 +41,26 @@ TEST_CASE("DUNE: DuneConverter",
     REQUIRE(symEq(*line++, "reaction.jacobian.C.expression = 0"));
     REQUIRE(symEq(*line++, "cross_diffusion.C.expression = 25"));
   }
+  SECTION("ABtoC model with spatial constant species") {
+    auto s{getExampleModel(Mod::ABtoC)};
+    s.getSpecies().setIsConstant("A", true);
+    s.getSpecies().setIsSpatial("A", true);
+    simulate::DuneConverter dc(s, {}, true, {}, 14);
+    QStringList ini = dc.getIniFile().split("\n");
+    auto line = find_line("[model.scalar_field.A]", ini);
+    REQUIRE(line != ini.cend());
+    REQUIRE(*line++ == "[model.scalar_field.A]");
+    REQUIRE(*line++ == "compartment = comp");
+    REQUIRE(line->startsWith("initial.expression = "));
+    REQUIRE(line->contains("A_initialConcentration(position_x,position_y)"));
+    ++line;
+    REQUIRE(*line++ == "storage.expression = 1");
+    REQUIRE(symEq(*line++, "reaction.expression = 0"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.A.expression = 0"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.B.expression = 0"));
+    REQUIRE(symEq(*line++, "reaction.jacobian.C.expression = 0"));
+    REQUIRE(symEq(*line++, "cross_diffusion.A.expression = 0"));
+  }
   SECTION("ABtoC model with non-default storage") {
     auto s{getExampleModel(Mod::ABtoC)};
     s.getSpecies().setStorage("C", 2.5);

--- a/core/simulate/src/dunefunction.hpp
+++ b/core/simulate/src/dunefunction.hpp
@@ -75,7 +75,7 @@ private:
 };
 
 /**
- * @brief Build DUNE grid functions for each non-constant species.
+ * @brief Build DUNE grid functions for each simulated species.
  */
 template <typename Grid, typename GridFunction>
 std::unordered_map<std::string, GridFunction>

--- a/core/simulate/src/dunefunction_t.cpp
+++ b/core/simulate/src/dunefunction_t.cpp
@@ -51,7 +51,7 @@ static void setAnalyticInitialConc(sme::model::Model &m) {
   // set initial concentration from analytic expression
   for (const auto &compId : m.getCompartments().getIds()) {
     for (const auto &id : m.getSpecies().getIds(compId)) {
-      if (!m.getSpecies().getIsConstant(id)) {
+      if (m.getSpecies().isSimulatedSpecies(id)) {
         m.getSpecies().setAnalyticConcentration(id,
                                                 "sqrt(1.0 + x*x + y*y + z*z)");
       }

--- a/core/simulate/src/dunesim_impl.hpp
+++ b/core/simulate/src/dunesim_impl.hpp
@@ -295,27 +295,26 @@ private:
       auto nPixels{comp->getVoxels().size()};
       SPDLOG_INFO("  - {} pixels", nPixels);
       const auto &compartmentSpeciesNames{speciesNames[comp->getId()]};
-      std::size_t nNonConstantSpecies{0};
+      std::size_t nSimulatedSpecies{0};
       for (const auto &speciesName : compartmentSpeciesNames) {
         if (!speciesName.empty()) {
-          ++nNonConstantSpecies;
+          ++nSimulatedSpecies;
         }
       }
       auto nSpecies{compartmentSpeciesNames.size()};
       SPDLOG_INFO("  - {} species", nSpecies);
-      SPDLOG_INFO("    - of which {} non-constant species",
-                  nNonConstantSpecies);
-      if (nNonConstantSpecies > 0) {
+      SPDLOG_INFO("    - of which {} are simulated", nSimulatedSpecies);
+      if (nSimulatedSpecies > 0) {
         duneCompartments.push_back(
             {comp->getId(),
              compIndex,
-             nNonConstantSpecies,
+             nSimulatedSpecies,
              compartmentSpeciesNames,
              geometry::VoxelIndexer(imgVolume, comp->getVoxels()),
              comp.get(),
              {},
              {},
-             std::vector<double>(nPixels * nNonConstantSpecies, 0.0)});
+             std::vector<double>(nPixels * nSimulatedSpecies, 0.0)});
       }
       ++compIndex;
     }

--- a/core/simulate/src/pde_t.cpp
+++ b/core/simulate/src/pde_t.cpp
@@ -3,6 +3,7 @@
 #include "model_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/pde.hpp"
+#include <algorithm>
 
 using namespace sme;
 using namespace sme::test;
@@ -29,6 +30,22 @@ TEST_CASE("PDE", "[core/simulate/pde][core/simulate][core][pde]") {
     REQUIRE(reac.getMatrixElement(0, 2) == dbl_approx(+1.0));
     REQUIRE_THROWS(reac.getMatrixElement(0, 3));
     REQUIRE_THROWS(reac.getMatrixElement(1, 0));
+  }
+  SECTION("ABtoC model with spatial constant species") {
+    auto s{getExampleModel(Mod::ABtoC)};
+    s.getSpecies().setIsConstant("A", true);
+    s.getSpecies().setIsSpatial("A", true);
+
+    simulate::Reaction reac(&s, {"A", "B", "C"}, {"r1"});
+    REQUIRE(reac.size() == 1);
+    REQUIRE(std::none_of(reac.getConstants(0).cbegin(),
+                         reac.getConstants(0).cend(),
+                         [](const auto &c) { return c.first == "A"; }));
+
+    simulate::Pde pde(&s, {"A", "B", "C"}, {"r1"});
+    REQUIRE(symEq(pde.getRHS()[0], "0"));
+    REQUIRE(pde.getRHS()[1].find("A") != std::string::npos);
+    REQUIRE(pde.getRHS()[2].find("A") != std::string::npos);
   }
   SECTION("ABtoC model with invalid reaction rate expression") {
     auto s{getExampleModel(Mod::ABtoC)};

--- a/core/simulate/src/pixelsim.cpp
+++ b/core/simulate/src/pixelsim.cpp
@@ -354,6 +354,9 @@ PixelSim::PixelSim(
     const bool allUniformDiffusion = [this, &compartmentSpeciesIds]() {
       for (const auto &speciesIds : compartmentSpeciesIds) {
         for (const auto &speciesId : speciesIds) {
+          if (doc.getSpecies().getIsConstant(speciesId.c_str())) {
+            continue;
+          }
           const auto *field = doc.getSpecies().getField(speciesId.c_str());
           if (field == nullptr || !field->getIsUniformDiffusionConstant()) {
             return false;

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -144,6 +144,7 @@ SimCompartment::SimCompartment(
   dz2 = voxelSize.depth() * voxelSize.depth();
   for (const auto &s : speciesIds) {
     const auto *field = doc.getSpecies().getField(s.c_str());
+    const bool speciesIsConstant = doc.getSpecies().getIsConstant(s.c_str());
     double storageValue = doc.getSpecies().getStorage(s.c_str());
     if (storageValue < 0.0) {
       throw PixelSimImplError("Invalid negative storage value for species '" +
@@ -164,7 +165,8 @@ SimCompartment::SimCompartment(
     }
     if (useUniformDiffusionOperator) {
       const auto &diffArray = field->getDiffusionConstant();
-      double d = diffArray.empty() ? 0.0 : diffArray.front();
+      double d =
+          speciesIsConstant || diffArray.empty() ? 0.0 : diffArray.front();
       diffConstantsUniform.push_back(
           {d / dx2, d / dy2, d / dz2}); // dimensionless diffusion
       if (storageValue == 0.0) {
@@ -190,7 +192,11 @@ SimCompartment::SimCompartment(
       maxPrimaryDiagonalDiffusion.push_back(d);
     } else {
       // store diffusion constant per voxel
-      diffConstants.push_back(field->getDiffusionConstant());
+      if (speciesIsConstant) {
+        diffConstants.emplace_back(nPixels, 0.0);
+      } else {
+        diffConstants.push_back(field->getDiffusionConstant());
+      }
       if (diffConstants.back().empty()) {
         diffConstants.back().assign(nPixels, 0.0);
       }
@@ -279,6 +285,9 @@ SimCompartment::SimCompartment(
   std::vector<std::string> crossDiffusionExpressions;
   for (std::size_t iTarget = 0; iTarget < nPrimarySpecies; ++iTarget) {
     const QString targetSpeciesId{speciesIds[iTarget].c_str()};
+    if (doc.getSpecies().getIsConstant(targetSpeciesId)) {
+      continue;
+    }
     for (std::size_t iSource = 0; iSource < nPrimarySpecies; ++iSource) {
       if (iSource == iTarget) {
         continue;

--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -25,7 +25,7 @@ void Simulation::initModel() {
     std::vector<QRgb> cols;
     const geometry::Compartment *comp = nullptr;
     for (const auto &s : model.getSpecies().getIds(compartmentId)) {
-      if (!model.getSpecies().getIsConstant(s)) {
+      if (model.getSpecies().isSimulatedSpecies(s)) {
         sIds.push_back(s.toStdString());
         const auto &field = model.getSpecies().getField(s);
         cols.push_back(field->getColor());

--- a/core/simulate/src/simulate_steadystate.cpp
+++ b/core/simulate/src/simulate_steadystate.cpp
@@ -52,7 +52,7 @@ void SteadyStateSimulation::initModel() {
     std::vector<QRgb> cols;
     const geometry::Compartment *comp = nullptr;
     for (const auto &s : m_model.getSpecies().getIds(compartmentId)) {
-      if (!m_model.getSpecies().getIsConstant(s)) {
+      if (m_model.getSpecies().isSimulatedSpecies(s)) {
         sIds.push_back(s.toStdString());
         const auto &field = m_model.getSpecies().getField(s);
         cols.push_back(field->getColor());

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -1328,6 +1328,97 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "Simulate: spatial constant species remain fixed and drive reactions",
+    "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel]") {
+  auto makeModel = []() {
+    auto m{getExampleModel(Mod::ABtoC)};
+    const auto &vol = m.getGeometry().getImages().volume();
+    const auto mid = static_cast<std::size_t>(vol.width()) / 2;
+    auto *comp = m.getCompartments().getCompartment("comp");
+    std::vector<double> aConc(static_cast<std::size_t>(vol.nVoxels()), 0.0);
+    for (const auto &voxel : comp->getVoxels()) {
+      const auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
+      aConc[arrayIndex] =
+          static_cast<std::size_t>(voxel.p.x()) < mid ? 2.0 : 0.5;
+    }
+    m.getSpecies().setSampledFieldConcentration("A", aConc);
+    m.getSpecies().setIsSpatial("A", true);
+    m.getSpecies().setIsConstant("A", true);
+    m.getSpecies().setInitialConcentration("B", 1.0);
+    m.getSpecies().setInitialConcentration("C", 0.0);
+    m.getGeometry().getMesh2d()->setCompartmentMaxTriangleArea(0, 3);
+    auto &options{m.getSimulationSettings().options};
+    options.pixel.maxErr = {std::numeric_limits<double>::max(), 0.001};
+    options.pixel.maxThreads = 2;
+    options.dune.dt = 0.1;
+    options.dune.maxDt = 0.1;
+    return m;
+  };
+
+  for (auto simulator :
+       {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
+    auto m = makeModel();
+    m.getSimulationSettings().simulatorType = simulator;
+    simulate::Simulation sim(m);
+    REQUIRE(sim.errorMessage().empty());
+
+    const auto &speciesIds = sim.getSpeciesIds(0);
+    const auto aIt = std::find(speciesIds.cbegin(), speciesIds.cend(), "A");
+    const auto bIt = std::find(speciesIds.cbegin(), speciesIds.cend(), "B");
+    REQUIRE(aIt != speciesIds.cend());
+    REQUIRE(bIt != speciesIds.cend());
+    const auto aIndex =
+        static_cast<std::size_t>(std::distance(speciesIds.cbegin(), aIt));
+    const auto bIndex =
+        static_cast<std::size_t>(std::distance(speciesIds.cbegin(), bIt));
+
+    const auto a0 = sim.getConcArray(0, 0, aIndex);
+    sim.doTimesteps(1.0);
+    REQUIRE(sim.errorMessage().empty());
+    const auto timeIndex = sim.getTimePoints().size() - 1;
+    const auto a1 = sim.getConcArray(timeIndex, 0, aIndex);
+    const auto b1 = sim.getConcArray(timeIndex, 0, bIndex);
+
+    double maxADelta{0.0};
+    for (std::size_t i = 0; i < a0.size(); ++i) {
+      maxADelta = std::max(maxADelta, std::abs(a1[i] - a0[i]));
+    }
+    const auto &vol = m.getGeometry().getImages().volume();
+    const auto mid = static_cast<std::size_t>(vol.width()) / 2;
+    auto *comp = m.getCompartments().getCompartment("comp");
+    double leftMean{0.0};
+    double rightMean{0.0};
+    std::size_t leftCount{0};
+    std::size_t rightCount{0};
+    for (const auto &voxel : comp->getVoxels()) {
+      const auto arrayIndex = common::voxelArrayIndex(vol, voxel, true);
+      if (static_cast<std::size_t>(voxel.p.x()) < mid) {
+        leftMean += b1[arrayIndex];
+        ++leftCount;
+      } else {
+        rightMean += b1[arrayIndex];
+        ++rightCount;
+      }
+    }
+    REQUIRE(leftCount > 0);
+    REQUIRE(rightCount > 0);
+    leftMean /= static_cast<double>(leftCount);
+    rightMean /= static_cast<double>(rightCount);
+
+    CAPTURE(simulator);
+    CAPTURE(maxADelta);
+    CAPTURE(leftMean);
+    CAPTURE(rightMean);
+    const double maxATolerance =
+        (simulator == simulate::SimulatorType::Pixel) ? 1e-12 : 1e-2;
+    const double meanGap =
+        (simulator == simulate::SimulatorType::Pixel) ? 1e-3 : 5e-3;
+    REQUIRE(maxADelta < maxATolerance);
+    REQUIRE(leftMean + meanGap < rightMean);
+  }
+}
+
+TEST_CASE(
     "Simulate: smooth spatially varying diffusion, dune vs pixel",
     "[core/simulate/simulate][core/simulate][core][simulate][dune][pixel]") {
   auto configureModel = [](model::Model &m) {

--- a/docs/quickstart/species.rst
+++ b/docs/quickstart/species.rst
@@ -7,7 +7,7 @@ To create a new species, click the `Add` button, select a suitable name, and hit
 
 On the right hand side, you see the Species Settings menu. Here you can define all relevant properties of the species.
 
-At the top, you can rename the species or assign it to a different compartment. You can also select whether it should be constant for the whole simulation or be variable. Constancy may be a useful simplifying assumption in some models if, for example, the species is produces far more quickly than the characteristic simulation timescale.
+At the top, you can rename the species or assign it to a different compartment. You can also select whether it should be constant for the whole simulation or be variable. A constant species is fixed in time, but it can still be spatially varying if the `Spatial` option is enabled and the initial concentration is defined analytically or from an image. Constancy may be a useful simplifying assumption in some models if, for example, the species is produced far more quickly than the characteristic simulation timescale.
 
 .. figure:: img/species-definition.apng
    :alt: video showing species settings

--- a/gui/dialogs/dialogoptsetup.cpp
+++ b/gui/dialogs/dialogoptsetup.cpp
@@ -114,12 +114,12 @@ getDefaultOptCosts(const sme::model::Model &model) {
   }
   for (const auto &compartmentId : model.getCompartments().getIds()) {
     // note: compartment/species indices here are constructed to match those in
-    // the simulation data (i.e. constant species are ignored). todo: refactor
-    // this logic which is duplicated in the simulation setup
+    // the simulation data (i.e. scalar constant species are ignored). todo:
+    // refactor this logic which is duplicated in the simulation setup
     bool compartmentHasSpecies{false};
     std::size_t speciesIndex{0};
     for (const auto &speciesId : model.getSpecies().getIds(compartmentId)) {
-      if (!model.getSpecies().getIsConstant(speciesId)) {
+      if (model.getSpecies().isSimulatedSpecies(speciesId)) {
         optCosts.push_back(
             {sme::simulate::OptCostType::Concentration,
              sme::simulate::OptCostDiffType::Absolute,

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -181,6 +181,10 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
   ui->chkSpeciesIsConstant->setChecked(isConstant);
   if (isConstant) {
     ui->radDiffusionConstantUniform->setEnabled(false);
+    ui->radDiffusionConstantAnalytic->setEnabled(false);
+    ui->btnEditAnalyticDiffusionConstant->setEnabled(false);
+    ui->radDiffusionConstantImage->setEnabled(false);
+    ui->btnEditImageDiffusionConstant->setEnabled(false);
     ui->txtDiffusionConstant->setEnabled(false);
     ui->lblDiffusionConstantUnits->setText("");
   }
@@ -298,8 +302,7 @@ void TabSpecies::chkSpeciesIsSpatial_toggled(bool enabled) {
     SPDLOG_INFO("setting species {} isSpatial: {}",
                 currentSpeciesId.toStdString(), enabled);
     model.getSpecies().setIsSpatial(currentSpeciesId, enabled);
-    // update displayed info for this species
-    txtInitialConcentration_editingFinished();
+    listSpecies_currentItemChanged(ui->listSpecies->currentItem(), nullptr);
   }
 }
 
@@ -310,8 +313,7 @@ void TabSpecies::chkSpeciesIsConstant_toggled(bool enabled) {
     SPDLOG_INFO("setting species {} isConstant: {}", speciesID.toStdString(),
                 enabled);
     model.getSpecies().setIsConstant(speciesID, enabled);
-    // update displayed info for this species
-    txtInitialConcentration_editingFinished();
+    listSpecies_currentItemChanged(ui->listSpecies->currentItem(), nullptr);
   }
 }
 

--- a/gui/tabs/tabspecies.ui
+++ b/gui/tabs/tabspecies.ui
@@ -239,17 +239,17 @@
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>if &quot;Constant&quot; is checked: the species has a fixed concentration during the simulation</string>
-           </property>
-           <property name="statusTip">
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+            <string>if &quot;Constant&quot; is checked: the species concentration is fixed in time during the simulation</string>
+          </property>
+          <property name="statusTip">
             <string>'Constant': species concentration cannot be altered by the simulation</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-           </property>
+          </property>
+          <property name="whatsThis">
+            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a concentration that is fixed in time. If the species is also spatial, this fixed concentration may still vary with position within the compartment.&lt;/p&gt;</string>
+          </property>
            <property name="text">
             <string>species concentration is fixed throughout the whole simulation</string>
            </property>
@@ -444,17 +444,17 @@
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>A constant species has a fixed concentration</string>
-           </property>
-           <property name="statusTip">
-            <string>A constant species has a fixed concentration</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a fixed concentration. It keeps its initial concentration for the whole simulation.&lt;/p&gt;</string>
-           </property>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+            <string>A constant species has a concentration that is fixed in time</string>
+          </property>
+          <property name="statusTip">
+            <string>A constant species has a concentration that is fixed in time</string>
+          </property>
+          <property name="whatsThis">
+            <string>&lt;h4&gt;Constant&lt;/h4&gt;&lt;p&gt;A constant species has a concentration that is fixed in time. If the species is also spatial, this fixed concentration may still vary with position within the compartment.&lt;/p&gt;</string>
+          </property>
            <property name="text">
             <string>Constant:</string>
            </property>

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -117,17 +117,17 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     // toggle is spatial checkbox
     sendKeyEvents(chkSpeciesIsSpatial, {" "});
     REQUIRE(chkSpeciesIsSpatial->isChecked() == true);
-    REQUIRE(chkSpeciesIsConstant->isChecked() == false);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == true);
     REQUIRE(radInitialConcentrationUniform->isEnabled() == true);
     REQUIRE(radInitialConcentrationAnalytic->isEnabled() == true);
     REQUIRE(radInitialConcentrationImage->isEnabled() == true);
-    REQUIRE(radDiffusionConstantUniform->isEnabled() == true);
-    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == true);
-    REQUIRE(radDiffusionConstantImage->isEnabled() == true);
-    REQUIRE(txtDiffusionConstant->isEnabled() == true);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == false);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == false);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == false);
+    REQUIRE(txtDiffusionConstant->isEnabled() == false);
     sendKeyEvents(chkSpeciesIsSpatial, {" "});
     REQUIRE(chkSpeciesIsSpatial->isChecked() == false);
-    REQUIRE(chkSpeciesIsConstant->isChecked() == false);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == true);
     REQUIRE(radInitialConcentrationUniform->isEnabled() == true);
     REQUIRE(radInitialConcentrationAnalytic->isEnabled() == false);
     REQUIRE(radInitialConcentrationImage->isEnabled() == false);
@@ -137,10 +137,10 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(txtDiffusionConstant->isEnabled() == false);
     // toggle is constant checkbox
     sendMouseClick(chkSpeciesIsConstant);
-    REQUIRE(chkSpeciesIsConstant->isChecked() == true);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == false);
     REQUIRE(chkSpeciesIsSpatial->isChecked() == false);
     sendMouseClick(chkSpeciesIsConstant);
-    REQUIRE(chkSpeciesIsConstant->isChecked() == false);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == true);
     REQUIRE(chkSpeciesIsSpatial->isChecked() == false);
 
     // select second item in listSpecies: Outside / B [spatial species]
@@ -168,6 +168,33 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     mwt.addUserAction({"1", "+", "2"});
     mwt.start();
     sendMouseClick(btnEditAnalyticConcentration);
+    sendMouseClick(chkSpeciesIsConstant);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == true);
+    REQUIRE(chkSpeciesIsSpatial->isChecked() == true);
+    REQUIRE(radInitialConcentrationAnalytic->isChecked() == true);
+    REQUIRE(btnEditAnalyticConcentration->isEnabled() == true);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == false);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == false);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == false);
+    REQUIRE(txtDiffusionConstant->isEnabled() == false);
+    sendMouseClick(chkSpeciesIsConstant);
+    REQUIRE(chkSpeciesIsConstant->isChecked() == false);
+    REQUIRE(chkSpeciesIsSpatial->isChecked() == true);
+    REQUIRE(radInitialConcentrationAnalytic->isChecked() == true);
+    REQUIRE(radDiffusionConstantUniform->isEnabled() == true);
+    REQUIRE(radDiffusionConstantAnalytic->isEnabled() == true);
+    REQUIRE(radDiffusionConstantImage->isEnabled() == true);
+    sendKeyEvents(chkSpeciesIsSpatial, {" "});
+    REQUIRE(chkSpeciesIsSpatial->isChecked() == false);
+    REQUIRE(radInitialConcentrationUniform->isChecked() == true);
+    REQUIRE(radInitialConcentrationAnalytic->isEnabled() == false);
+    REQUIRE(radInitialConcentrationImage->isEnabled() == false);
+    REQUIRE(txtInitialConcentration->isEnabled() == true);
+    sendKeyEvents(chkSpeciesIsSpatial, {" "});
+    REQUIRE(chkSpeciesIsSpatial->isChecked() == true);
+    REQUIRE(radInitialConcentrationUniform->isChecked() == true);
+    REQUIRE(radInitialConcentrationAnalytic->isEnabled() == true);
+    REQUIRE(radInitialConcentrationImage->isEnabled() == true);
     // enable and edit image initial concentration
     REQUIRE(btnEditImageConcentration->isEnabled() == false);
     radInitialConcentrationImage->setChecked(true);


### PR DESCRIPTION
- making a species constant no longer forces it to be non-spatial
- constant and non-spatial species are still substituted out of simulations as before
- constant but spatially-varying species are now included as species in the simulations
- resolves #1133
