### PR TITLE
Exclude xcb and egl plugins from sme wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
         shell: ${{ matrix.platform.shell }}
     env:
       CIBUILDWHEEL_VERSION: "3.4"
-      CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_x86_64:2025.10.06"
-      CIBW_MANYLINUX_AARCH64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_aarch64:2025.10.06"
+      CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_x86_64:2026.03.31"
+      CIBW_MANYLINUX_AARCH64_IMAGE: "ghcr.io/spatial-model-editor/manylinux_aarch64:2026.03.31"
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
       MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
       MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,32 +31,6 @@ endif()
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 
-# "make test" excludes gui tests & uses all cores
-include(ProcessorCount)
-ProcessorCount(NPROC)
-set(CMAKE_CTEST_ARGUMENTS "-j${NPROC};--progress;--output-on-failure;-E;gui")
-
-# find required Qt modules
-find_package(
-  Qt6
-  CONFIG
-  REQUIRED
-  COMPONENTS Core
-             Gui
-             Widgets
-             OpenGLWidgets
-             OpenGL)
-get_target_property(
-  QtCore_location
-  Qt6::Core
-  LOCATION)
-message(STATUS "Found QtCore: ${QtCore_location}")
-
-# enable Qt utils: moc, uic, rcc
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTORCC ON)
-
 option(
   SME_USE_STATIC_LIBS
   "Use static versions of dependencies"
@@ -103,6 +77,40 @@ option(
   SME_BUILD_PYTHON_LIBRARY
   "Build python library"
   ON)
+
+# "make test" excludes gui tests & uses all cores
+include(ProcessorCount)
+ProcessorCount(NPROC)
+set(CMAKE_CTEST_ARGUMENTS "-j${NPROC};--progress;--output-on-failure;-E;gui")
+
+# find required Qt modules
+if(SME_BUILD_GUI)
+  find_package(
+    Qt6
+    CONFIG
+    REQUIRED
+    COMPONENTS Core
+               Gui
+               Widgets
+               OpenGLWidgets
+               OpenGL)
+else()
+  find_package(
+    Qt6
+    CONFIG
+    REQUIRED
+    COMPONENTS Core Gui)
+endif()
+get_target_property(
+  QtCore_location
+  Qt6::Core
+  LOCATION)
+message(STATUS "Found QtCore: ${QtCore_location}")
+
+# enable Qt utils: moc, uic, rcc
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
 
 if(NOT SME_BUILD_CORE)
   find_package(

--- a/core/common/src/serialization_t.cpp
+++ b/core/common/src/serialization_t.cpp
@@ -1,6 +1,5 @@
 #include "catch_wrapper.hpp"
 #include "model_test_utils.hpp"
-#include "qt_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/serialization.hpp"
 #include "sme/utils.hpp"

--- a/core/common/src/utils_t.cpp
+++ b/core/common/src/utils_t.cpp
@@ -1,5 +1,4 @@
 #include "catch_wrapper.hpp"
-#include "qt_test_utils.hpp"
 #include "sme/tiff.hpp"
 #include "sme/utils.hpp"
 #include <QDir>

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -1,8 +1,8 @@
 #include "catch_wrapper.hpp"
 #include "model_test_utils.hpp"
-#include "qt_test_utils.hpp"
 #include "sme/model.hpp"
 #include "sme/optimize.hpp"
+#include <QTest>
 #include <catch2/catch_test_macros.hpp>
 
 using namespace sme;
@@ -580,7 +580,7 @@ TEST_CASE("Start long optimization in another thread & stop early",
       std::function<void(double, const std::vector<double> &)>{});
   // wait until it starts running
   while (!optimization.getIsRunning()) {
-    sme::test::wait(10);
+    QTest::qWait(10);
   }
   // request it to stop early
   optimization.requestStop();

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -1,6 +1,5 @@
 #include "catch_wrapper.hpp"
 #include "model_test_utils.hpp"
-#include "qt_test_utils.hpp"
 #include "sme/mesh2d.hpp"
 #include "sme/model.hpp"
 #include "sme/serialization.hpp"

--- a/sme/CMakeLists.txt
+++ b/sme/CMakeLists.txt
@@ -24,4 +24,8 @@ qt_import_plugins(
   EXCLUDE_BY_TYPE
   printsupport
   EXCLUDE_BY_TYPE
-  sqldrivers)
+  sqldrivers
+  EXCLUDE_BY_TYPE
+  egldeviceintegrations
+  EXCLUDE_BY_TYPE
+  xcbglintegrations)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_executable(tests main.cpp)
-target_link_libraries(
-  tests
-  PRIVATE core_tests
-          $<$<BOOL:${SME_BUILD_GUI}>:gui_tests>
-          $<$<BOOL:${SME_BUILD_CLI}>:cli_tests>
-          ${SME_EXTRA_EXE_LIBS})
+target_link_libraries(tests PRIVATE core_tests ${SME_EXTRA_EXE_LIBS})
+if(SME_BUILD_GUI)
+  target_link_libraries(tests PRIVATE gui_tests)
+endif()
+if(SME_BUILD_CLI)
+  target_link_libraries(tests PRIVATE cli_tests)
+endif()
 if(SME_BUILD_GUI)
   target_compile_definitions(tests PRIVATE SME_ENABLE_GUI_TESTS)
 endif()
@@ -20,10 +21,12 @@ target_link_libraries(
   testlib
   PUBLIC Catch2::Catch2
          sme::core
-         Qt::Widgets
          Qt::Gui
          Qt::Core
          Qt::Test)
+if(SME_BUILD_GUI)
+  target_link_libraries(testlib PUBLIC Qt::Widgets)
+endif()
 add_subdirectory(test_utils)
 
 if(CMAKE_CXX_COMPILER_ID

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,7 +1,9 @@
 #include "catch_wrapper.hpp"
 #include "sme/logger.hpp"
-#include <QApplication>
 #include <catch2/catch_session.hpp>
+#ifdef SME_ENABLE_GUI_TESTS
+#include <QApplication>
+#endif
 #include <oneapi/tbb/global_control.h>
 
 int main(int argc, char *argv[]) {

--- a/test/test_utils/CMakeLists.txt
+++ b/test/test_utils/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(
   testlib
   PUBLIC catch_wrapper.cpp
          math_test_utils.cpp
-         model_test_utils.cpp
-         qt_test_utils.cpp)
+         model_test_utils.cpp)
+if(SME_BUILD_GUI)
+  target_sources(testlib PUBLIC qt_test_utils.cpp)
+endif()
 target_include_directories(testlib PUBLIC .)


### PR DESCRIPTION
- prevents xcb, opengl etc libs being linked and then bundled by auditwheel
- these could interfere with system libraries and cause crashes / hangs in conjunction with other python libraries
- resolves #1144
- manylinux -> 2026.03.31
