### PR TITLE
Add feature extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.12.0] - 2026-04-22
 ### Added
 - allow constant species to have spatially varying concentrations [#1133](https://github.com/spatial-model-editor/spatial-model-editor/issues/1133)
 - support for importing and exporting 2d and 3d Parametric (meshed) geometry [#1132](https://github.com/spatial-model-editor/spatial-model-editor/issues/1132)
@@ -11,6 +11,7 @@
 - support for cross diffusion terms [#1118](https://github.com/spatial-model-editor/spatial-model-editor/issues/1118)
 - support for non-unit storage terms [#1114](https://github.com/spatial-model-editor/spatial-model-editor/issues/1114)
 - dialog for importing analytic geometry [#1111](https://github.com/spatial-model-editor/spatial-model-editor/issues/1111)
+- add feature extraction and allow features to be used as targets in parameter optimisation [#1136](https://github.com/spatial-model-editor/spatial-model-editor/issues/1136)
 - Windows ARM64 binaries
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,6 @@ Implementation, test, and benchmark code for a component are co-located: `X.hpp`
 ## Building and testing
 
 You can assume the script `ci/local-dev-setup.sh` has been run.
-
 All commands run from `build-release/`:
 
 ```bash
@@ -31,8 +30,6 @@ ninja test                                      # run all non-gui tests in paral
 xvfb-run -a bash -c 'jwm & sleep 1 && ./test/tests "[gui]"'   # run GUI tests headlessly on Linux
 xvfb-run -a bash -c 'jwm & sleep 1 && ./test/tests "TestName"' # run a specific GUI test
 ```
-
-If running in a strict sandbox, ask for permission to run commands starting with `xvfb-run -a bash -c`.
 
 Python tests from `build-release/sme`:
 ```bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.24...4.2)
+cmake_minimum_required(VERSION 3.24...4.3)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
 # version number here is embedded in compiled executable
 project(
   SpatialModelEditor
-  VERSION 1.11.0
+  VERSION 1.12.0
   DESCRIPTION "Spatial Model Editor"
   LANGUAGES C CXX)
 
@@ -99,6 +99,14 @@ option(
   "Build python library"
   ON)
 
+if(MSVC
+   AND CMAKE_GENERATOR
+       MATCHES
+       "Ninja")
+  set_property(GLOBAL PROPERTY JOB_POOLS windows_link_pool=1)
+  set(CMAKE_JOB_POOL_LINK windows_link_pool)
+endif()
+
 # "make test" excludes gui tests & uses all cores
 include(ProcessorCount)
 ProcessorCount(NPROC)
@@ -174,14 +182,6 @@ endif()
 if(SME_BUILD_PYTHON_LIBRARY)
   add_subdirectory(ext/nanobind)
   add_subdirectory(sme)
-endif()
-
-if(MSVC
-   AND CMAKE_GENERATOR
-       MATCHES
-       "Ninja")
-  set_property(GLOBAL PROPERTY JOB_POOLS windows_link_pool=1)
-  set(CMAKE_JOB_POOL_LINK windows_link_pool)
 endif()
 
 # display sme configuration options

--- a/core/common/include/sme/id.hpp
+++ b/core/common/include/sme/id.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "sme/utils.hpp"
+#include <string>
+#include <string_view>
+
+namespace sme::common {
+
+/**
+ * @brief Convert a user-visible name to a valid SBML-style SId.
+ */
+inline std::string nameToSId(std::string_view name,
+                             std::string_view fallback = "_") {
+  const std::string charsToConvertToUnderscore = " -_/";
+  std::string id;
+  // remove any non-alphanumeric chars, convert spaces etc to underscores
+  for (auto c : name) {
+    if (sme::common::isalnum(c)) {
+      id.push_back(c);
+    } else if (charsToConvertToUnderscore.find(c) != std::string::npos) {
+      id.push_back('_');
+    }
+  }
+  if (id.empty()) {
+    id = fallback.empty() ? "_" : std::string{fallback};
+  }
+  // first char must be a letter or underscore
+  if (!sme::common::isalpha(id.front()) && id.front() != '_') {
+    id.insert(id.begin(), '_');
+  }
+  return id;
+}
+
+/**
+ * @brief Create a unique id/name by appending a postfix until available.
+ */
+template <typename IsAvailable>
+std::string makeUnique(std::string name, IsAvailable isAvailable,
+                       std::string_view postfix = "_") {
+  while (!isAvailable(name)) {
+    name.append(postfix);
+  }
+  return name;
+}
+
+} // namespace sme::common

--- a/core/common/src/CMakeLists.txt
+++ b/core/common/src/CMakeLists.txt
@@ -18,6 +18,7 @@ if(BUILD_TESTING)
   target_sources(
     core_tests
     PUBLIC image_stack_t.cpp
+           id_t.cpp
            image_stack_impl_t.cpp
            logger_t.cpp
            serialization_t.cpp

--- a/core/common/src/id_t.cpp
+++ b/core/common/src/id_t.cpp
@@ -1,0 +1,27 @@
+#include "catch_wrapper.hpp"
+#include "sme/id.hpp"
+#include <set>
+
+using namespace sme;
+
+TEST_CASE("Common id", "[core/common/id][core/common][core][id]") {
+  SECTION("nameToSId") {
+    REQUIRE(common::nameToSId("valid_id") == "valid_id");
+    REQUIRE(common::nameToSId("name with spaces") == "name_with_spaces");
+    REQUIRE(common::nameToSId("name-with-spaces") == "name_with_spaces");
+    REQUIRE(common::nameToSId("name/with/spaces") == "name_with_spaces");
+    REQUIRE(common::nameToSId("!? invalid / Chars!!-") == "_invalid___Chars_");
+    REQUIRE(common::nameToSId("1name") == "_1name");
+    REQUIRE(common::nameToSId("!@#", "feature") == "feature");
+  }
+  SECTION("makeUnique") {
+    const std::set<std::string> names{"ab", "abc", "_ab", "ab_"};
+    auto isAvailable = [&names](const std::string &name) {
+      return !names.contains(name);
+    };
+    REQUIRE(common::makeUnique("a", isAvailable, "_") == "a");
+    REQUIRE(common::makeUnique("ab", isAvailable, "_") == "ab__");
+    REQUIRE(common::makeUnique("ab", isAvailable, "1") == "ab1");
+    REQUIRE(common::makeUnique("abc", isAvailable, "_") == "abc_");
+  }
+}

--- a/core/model/include/sme/model.hpp
+++ b/core/model/include/sme/model.hpp
@@ -9,6 +9,7 @@
 #include "sme/image_stack.hpp"
 #include "sme/model_compartments.hpp"
 #include "sme/model_events.hpp"
+#include "sme/model_features.hpp"
 #include "sme/model_functions.hpp"
 #include "sme/model_geometry.hpp"
 #include "sme/model_math.hpp"
@@ -72,6 +73,7 @@ private:
   std::unique_ptr<ModelParameters> modelParameters;
   std::unique_ptr<ModelUnits> modelUnits;
   std::unique_ptr<ModelMath> modelMath;
+  std::unique_ptr<ModelFeatures> modelFeatures;
 
   void initModelData(bool emptySpatialModel = false);
   void setHasUnsavedChanges(bool unsavedChanges);
@@ -227,6 +229,14 @@ public:
    * @returns Vector of sampled-field colors.
    */
   [[nodiscard]] const std::vector<QRgb> &getSampledFieldColors() const;
+  /**
+   * @brief Mutable access to feature manager.
+   */
+  ModelFeatures &getFeatures();
+  /**
+   * @brief Immutable access to feature manager.
+   */
+  [[nodiscard]] const ModelFeatures &getFeatures() const;
 
   /**
    * @brief Construct empty model wrapper.

--- a/core/model/include/sme/model_features.hpp
+++ b/core/model/include/sme/model_features.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "sme/feature_eval.hpp"
+#include "sme/feature_options.hpp"
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace sme::simulate {
+class SimulationData;
+}
+
+namespace sme::model {
+
+class ModelCompartments;
+class ModelSpecies;
+class ModelGeometry;
+struct Settings;
+
+/**
+ * @brief Manager for feature extraction definitions and results.
+ */
+class ModelFeatures {
+private:
+  Settings *settings{nullptr};
+  const ModelCompartments *modelCompartments{nullptr};
+  const ModelSpecies *modelSpecies{nullptr};
+  const ModelGeometry *modelGeometry{nullptr};
+  simulate::SimulationData *simulationData{nullptr};
+  std::vector<std::vector<std::size_t>> cachedVoxelRegions;
+  bool hasUnsavedChanges{false};
+
+  void recomputeVoxelRegions(std::size_t featureIndex);
+  void ensureFeatureIdsValid();
+
+public:
+  ModelFeatures();
+  ModelFeatures(Settings *settings, const ModelCompartments *compartments,
+                const ModelSpecies *species, const ModelGeometry *geometry,
+                simulate::SimulationData *simData);
+
+  /**
+   * @brief Add a new feature definition.
+   * @returns Index of the newly added feature.
+   */
+  std::size_t add(const std::string &name, const std::string &compartmentId,
+                  const std::string &speciesId,
+                  const simulate::RoiSettings &roi,
+                  simulate::ReductionOp reduction);
+
+  /**
+   * @brief Remove a feature by index.
+   */
+  void remove(std::size_t featureIndex);
+
+  /**
+   * @brief Set feature name.
+   * @returns Unique feature name that was set.
+   */
+  std::string setName(std::size_t featureIndex, const std::string &name);
+
+  /**
+   * @brief Set feature compartment and species IDs.
+   */
+  void setCompartmentAndSpecies(std::size_t featureIndex,
+                                const std::string &compartmentId,
+                                const std::string &speciesId);
+
+  /**
+   * @brief Set feature ROI settings.
+   */
+  void setRoi(std::size_t featureIndex, const simulate::RoiSettings &roi);
+
+  /**
+   * @brief Set feature reduction operation.
+   */
+  void setReduction(std::size_t featureIndex, simulate::ReductionOp reduction);
+
+  /**
+   * @brief Get all feature definitions.
+   */
+  [[nodiscard]] const std::vector<simulate::FeatureDefinition> &
+  getFeatures() const;
+
+  /**
+   * @brief Number of defined features.
+   */
+  [[nodiscard]] std::size_t size() const;
+
+  /**
+   * @brief Number of regions for a feature.
+   */
+  [[nodiscard]] std::size_t nRegions(std::size_t featureIndex) const;
+
+  /**
+   * @brief Get cached ROI regions for a feature.
+   */
+  [[nodiscard]] const std::vector<std::size_t> &
+  getVoxelRegions(std::size_t featureIndex) const;
+
+  /**
+   * @brief Check if feature references valid compartment/species IDs.
+   */
+  [[nodiscard]] bool isValid(std::size_t featureIndex) const;
+
+  /**
+   * @brief Look up feature index from stable internal id.
+   *
+   * Returns ``size()`` if the id is not present.
+   */
+  [[nodiscard]] std::size_t getIndexFromId(const std::string &featureId) const;
+
+  /**
+   * @brief Evaluate all features at a given timepoint.
+   *
+   * Extracts species concentrations from SimulationData for the given
+   * timeIndex, applies ROI regions and reduction, and appends results.
+   */
+  void evaluateAtTimepoint(std::size_t timeIndex);
+
+  /**
+   * @brief Re-evaluate all features over all stored timepoints.
+   */
+  void reEvaluateAllTimepoints();
+
+  /**
+   * @brief Recompute ROI regions after geometry change.
+   */
+  void updateGeometry();
+
+  /**
+   * @brief Update the simulation data pointer (after SME file import).
+   */
+  void setSimulationDataPtr(simulate::SimulationData *simData);
+
+  void setHasUnsavedChanges(bool unsavedChanges);
+  [[nodiscard]] bool getHasUnsavedChanges() const;
+};
+
+} // namespace sme::model

--- a/core/model/include/sme/model_settings.hpp
+++ b/core/model/include/sme/model_settings.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "sme/feature_options.hpp"
 #include "sme/optimize_options.hpp"
 #include "sme/simulate_options.hpp"
 #include <QRgb>
@@ -98,6 +99,10 @@ struct DisplayOptions {
    * @brief Invert vertical image axis in views/export.
    */
   bool invertYAxis{false};
+  /**
+   * @brief Per-feature visibility flags.
+   */
+  std::vector<bool> showFeatures{};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -111,6 +116,12 @@ struct DisplayOptions {
          CEREAL_NVP(normaliseOverAllTimepoints),
          CEREAL_NVP(normaliseOverAllSpecies), CEREAL_NVP(showGeometryGrid),
          CEREAL_NVP(showGeometryScale), CEREAL_NVP(invertYAxis));
+    } else if (version == 2) {
+      ar(CEREAL_NVP(showSpecies), CEREAL_NVP(showMinMax),
+         CEREAL_NVP(normaliseOverAllTimepoints),
+         CEREAL_NVP(normaliseOverAllSpecies), CEREAL_NVP(showGeometryGrid),
+         CEREAL_NVP(showGeometryScale), CEREAL_NVP(invertYAxis),
+         CEREAL_NVP(showFeatures));
     }
   }
 };
@@ -187,6 +198,10 @@ struct Settings {
    * @brief Optional species storage coefficients.
    */
   std::map<std::string, double> speciesStorageValues{};
+  /**
+   * @brief Feature definitions for extracting scalar time-series from ROIs.
+   */
+  std::vector<simulate::FeatureDefinition> features{};
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -223,6 +238,14 @@ struct Settings {
          CEREAL_NVP(speciesAnalyticDiffusionConstants),
          CEREAL_NVP(speciesStorageValues),
          CEREAL_NVP(speciesCrossDiffusionConstants));
+    } else if (version == 6) {
+      ar(CEREAL_NVP(simulationSettings), CEREAL_NVP(displayOptions),
+         CEREAL_NVP(meshParameters), CEREAL_NVP(speciesColors),
+         CEREAL_NVP(optimizeOptions), CEREAL_NVP(sampledFieldColors),
+         CEREAL_NVP(speciesDiffusionConstantArrays),
+         CEREAL_NVP(speciesAnalyticDiffusionConstants),
+         CEREAL_NVP(speciesStorageValues),
+         CEREAL_NVP(speciesCrossDiffusionConstants), CEREAL_NVP(features));
     }
   }
 };
@@ -230,6 +253,6 @@ struct Settings {
 } // namespace sme::model
 
 CEREAL_CLASS_VERSION(sme::model::MeshParameters, 2);
-CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 1);
+CEREAL_CLASS_VERSION(sme::model::DisplayOptions, 2);
 CEREAL_CLASS_VERSION(sme::model::SimulationSettings, 1);
-CEREAL_CLASS_VERSION(sme::model::Settings, 5);
+CEREAL_CLASS_VERSION(sme::model::Settings, 6);

--- a/core/model/src/CMakeLists.txt
+++ b/core/model/src/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
           id.cpp
           model.cpp
           model_compartments.cpp
+          model_features.cpp
           model_events.cpp
           model_functions.cpp
           model_geometry.cpp
@@ -28,7 +29,8 @@ target_sources(
 if(BUILD_TESTING)
   target_sources(
     core_tests
-    PUBLIC geometry_t.cpp
+    PUBLIC model_features_t.cpp
+           geometry_t.cpp
            geometry_analytic_t.cpp
            geometry_impl_t.cpp
            geometry_parametric_t.cpp

--- a/core/model/src/id.cpp
+++ b/core/model/src/id.cpp
@@ -1,6 +1,6 @@
 #include "id.hpp"
+#include "sme/id.hpp"
 #include "sme/logger.hpp"
-#include "sme/utils.hpp"
 #include <QString>
 #include <QStringList>
 #include <memory>
@@ -21,36 +21,27 @@ bool isSpatialIdAvailable(const std::string &id, libsbml::Geometry *geom) {
 
 QString nameToUniqueSId(const QString &name, libsbml::Model *model) {
   SPDLOG_DEBUG("name: '{}'", name.toStdString());
-  const std::string charsToConvertToUnderscore = " -_/";
-  std::string id;
-  // remove any non-alphanumeric chars, convert spaces etc to underscores
-  for (auto c : name.toStdString()) {
-    if (sme::common::isalnum(c)) {
-      id.push_back(c);
-    } else if (charsToConvertToUnderscore.find(c) != std::string::npos) {
-      id.push_back('_');
-    }
-  }
-  // first char must be a letter or underscore
-  if (!sme::common::isalpha(id.front()) && id.front() != '_') {
-    id = "_" + id;
-  }
+  auto id{sme::common::nameToSId(name.toStdString())};
   SPDLOG_DEBUG("  -> '{}'", id);
   // ensure it is unique, i.e. doesn't clash with any other SId in model
-  while (!isSIdAvailable(id, model)) {
-    id.append("_");
-    SPDLOG_DEBUG("  -> '{}'", id);
+  auto uniqueId = sme::common::makeUnique(id, [model](const auto &candidate) {
+    return isSIdAvailable(candidate, model);
+  });
+  if (uniqueId != id) {
+    SPDLOG_DEBUG("  -> '{}'", uniqueId);
   }
-  return id.c_str();
+  return uniqueId.c_str();
 }
 
 QString makeUnique(const QString &name, const QStringList &names,
                    const QString &postfix) {
-  QString uniqueName{name};
-  while (names.contains(uniqueName)) {
-    uniqueName.append(postfix);
-  }
-  return uniqueName;
+  const auto uniqueName = sme::common::makeUnique(
+      name.toStdString(),
+      [&names](const auto &candidate) {
+        return !names.contains(candidate.c_str());
+      },
+      postfix.toStdString());
+  return uniqueName.c_str();
 }
 
 } // namespace sme::model

--- a/core/model/src/model.cpp
+++ b/core/model/src/model.cpp
@@ -104,6 +104,9 @@ void Model::initModelData(bool emptySpatialModel) {
         isNonSpatialModel);
     modelCompartments->setReactionsPtr(modelReactions.get());
     modelSpecies->setReactionsPtr(modelReactions.get());
+    modelFeatures = std::make_unique<ModelFeatures>(
+        settings.get(), modelCompartments.get(), modelSpecies.get(),
+        modelGeometry.get(), smeFileContents->simulationData.get());
   } catch (const std::runtime_error &e) {
     errorMessage = e.what();
     isValid = false;
@@ -121,6 +124,7 @@ void Model::setHasUnsavedChanges(bool unsavedChanges) {
   modelSpecies->setHasUnsavedChanges(unsavedChanges);
   modelReactions->setHasUnsavedChanges(unsavedChanges);
   modelEvents->setHasUnsavedChanges(unsavedChanges);
+  modelFeatures->setHasUnsavedChanges(unsavedChanges);
 }
 
 bool Model::getIsValid() const { return isValid; }
@@ -136,7 +140,8 @@ bool Model::getHasUnsavedChanges() const {
          modelParameters->getHasUnsavedChanges() ||
          modelSpecies->getHasUnsavedChanges() ||
          modelReactions->getHasUnsavedChanges() ||
-         modelEvents->getHasUnsavedChanges();
+         modelEvents->getHasUnsavedChanges() ||
+         modelFeatures->getHasUnsavedChanges();
 }
 
 const QString &Model::getCurrentFilename() const { return currentFilename; }
@@ -198,6 +203,7 @@ void Model::importFile(const std::string &filename) {
     modelCompartments->setSimulationDataPtr(
         smeFileContents->simulationData.get());
     modelSpecies->setSimulationDataPtr(smeFileContents->simulationData.get());
+    modelFeatures->setSimulationDataPtr(smeFileContents->simulationData.get());
   }
   setHasUnsavedChanges(false);
 }
@@ -321,6 +327,10 @@ Model::getOptimizeOptions() const {
   return settings->sampledFieldColors;
 }
 
+ModelFeatures &Model::getFeatures() { return *modelFeatures; }
+
+const ModelFeatures &Model::getFeatures() const { return *modelFeatures; }
+
 void Model::clear() {
   doc.reset();
   isValid = false;
@@ -336,6 +346,7 @@ void Model::clear() {
   modelEvents = std::make_unique<ModelEvents>();
   modelUnits = std::make_unique<ModelUnits>();
   modelMath = std::make_unique<ModelMath>();
+  modelFeatures = std::make_unique<ModelFeatures>();
   smeFileContents = std::make_unique<common::SmeFileContents>();
   smeFileContents->simulationData =
       std::make_unique<simulate::SimulationData>();

--- a/core/model/src/model_features.cpp
+++ b/core/model/src/model_features.cpp
@@ -1,0 +1,357 @@
+#include "sme/model_features.hpp"
+#include "id.hpp"
+#include "sme/logger.hpp"
+#include "sme/model_compartments.hpp"
+#include "sme/model_geometry.hpp"
+#include "sme/model_settings.hpp"
+#include "sme/model_species.hpp"
+#include "sme/simulate_data.hpp"
+#include "sme/utils.hpp"
+#include <algorithm>
+#include <optional>
+
+namespace sme::model {
+
+static std::string
+makeUniqueFeatureName(const std::string &name,
+                      const std::vector<simulate::FeatureDefinition> &features,
+                      std::optional<std::size_t> excludedIndex = std::nullopt) {
+  QStringList names;
+  for (std::size_t i = 0; i < features.size(); ++i) {
+    if (!excludedIndex.has_value() || i != *excludedIndex) {
+      names.push_back(QString::fromStdString(features[i].name));
+    }
+  }
+  return makeUnique(QString::fromStdString(name), names).toStdString();
+}
+
+ModelFeatures::ModelFeatures() = default;
+
+ModelFeatures::ModelFeatures(Settings *settings,
+                             const ModelCompartments *compartments,
+                             const ModelSpecies *species,
+                             const ModelGeometry *geometry,
+                             simulate::SimulationData *simData)
+    : settings(settings), modelCompartments(compartments),
+      modelSpecies(species), modelGeometry(geometry), simulationData(simData) {
+  ensureFeatureIdsValid();
+  cachedVoxelRegions.resize(settings->features.size());
+  for (std::size_t i = 0; i < settings->features.size(); ++i) {
+    if (isValid(i)) {
+      recomputeVoxelRegions(i);
+    }
+  }
+}
+
+void ModelFeatures::ensureFeatureIdsValid() {
+  if (settings == nullptr) {
+    return;
+  }
+  std::vector<simulate::FeatureDefinition> existingFeatures;
+  existingFeatures.reserve(settings->features.size());
+  for (auto &feature : settings->features) {
+    feature.name = makeUniqueFeatureName(feature.name, existingFeatures);
+    if (feature.id.empty() ||
+        std::ranges::any_of(existingFeatures, [&feature](const auto &existing) {
+          return existing.id == feature.id;
+        })) {
+      feature.id =
+          simulate::makeUniqueFeatureId(feature.name, existingFeatures);
+    }
+    existingFeatures.push_back(feature);
+  }
+}
+
+void ModelFeatures::recomputeVoxelRegions(std::size_t featureIndex) {
+  if (settings == nullptr || modelCompartments == nullptr ||
+      modelGeometry == nullptr) {
+    return;
+  }
+  const auto &feat = settings->features[featureIndex];
+  auto *comp = modelCompartments->getCompartment(feat.compartmentId.c_str());
+  if (comp == nullptr) {
+    cachedVoxelRegions[featureIndex].clear();
+    return;
+  }
+  cachedVoxelRegions[featureIndex] = simulate::computeVoxelRegions(
+      feat.roi, *comp, modelGeometry->getPhysicalOrigin(),
+      modelGeometry->getVoxelSize());
+}
+
+std::size_t ModelFeatures::add(const std::string &name,
+                               const std::string &compartmentId,
+                               const std::string &speciesId,
+                               const simulate::RoiSettings &roi,
+                               simulate::ReductionOp reduction) {
+  simulate::FeatureDefinition feat;
+  feat.name = makeUniqueFeatureName(name, settings->features);
+  feat.id = simulate::makeUniqueFeatureId(feat.name, settings->features);
+  feat.compartmentId = compartmentId;
+  feat.speciesId = speciesId;
+  feat.roi = roi;
+  feat.reduction = reduction;
+  settings->features.push_back(std::move(feat));
+  auto index = settings->features.size() - 1;
+  cachedVoxelRegions.emplace_back();
+  if (simulationData != nullptr) {
+    simulationData->featureResults.emplace_back();
+  }
+  if (isValid(index)) {
+    recomputeVoxelRegions(index);
+  }
+  hasUnsavedChanges = true;
+  return index;
+}
+
+void ModelFeatures::remove(std::size_t featureIndex) {
+  if (featureIndex >= settings->features.size()) {
+    return;
+  }
+  settings->features.erase(settings->features.begin() +
+                           static_cast<std::ptrdiff_t>(featureIndex));
+  cachedVoxelRegions.erase(cachedVoxelRegions.begin() +
+                           static_cast<std::ptrdiff_t>(featureIndex));
+  if (simulationData != nullptr &&
+      featureIndex < simulationData->featureResults.size()) {
+    simulationData->featureResults.erase(
+        simulationData->featureResults.begin() +
+        static_cast<std::ptrdiff_t>(featureIndex));
+  }
+  hasUnsavedChanges = true;
+}
+
+std::string ModelFeatures::setName(std::size_t featureIndex,
+                                   const std::string &name) {
+  if (featureIndex < settings->features.size()) {
+    settings->features[featureIndex].name =
+        makeUniqueFeatureName(name, settings->features, featureIndex);
+    hasUnsavedChanges = true;
+    return settings->features[featureIndex].name;
+  }
+  return {};
+}
+
+void ModelFeatures::setCompartmentAndSpecies(std::size_t featureIndex,
+                                             const std::string &compartmentId,
+                                             const std::string &speciesId) {
+  if (featureIndex >= settings->features.size()) {
+    return;
+  }
+  auto &feat = settings->features[featureIndex];
+  feat.compartmentId = compartmentId;
+  feat.speciesId = speciesId;
+  recomputeVoxelRegions(featureIndex);
+  hasUnsavedChanges = true;
+}
+
+void ModelFeatures::setRoi(std::size_t featureIndex,
+                           const simulate::RoiSettings &roi) {
+  if (featureIndex >= settings->features.size()) {
+    return;
+  }
+  settings->features[featureIndex].roi = roi;
+  if (isValid(featureIndex)) {
+    recomputeVoxelRegions(featureIndex);
+  }
+  hasUnsavedChanges = true;
+}
+
+void ModelFeatures::setReduction(std::size_t featureIndex,
+                                 simulate::ReductionOp reduction) {
+  if (featureIndex >= settings->features.size()) {
+    return;
+  }
+  settings->features[featureIndex].reduction = reduction;
+  hasUnsavedChanges = true;
+}
+
+const std::vector<simulate::FeatureDefinition> &
+ModelFeatures::getFeatures() const {
+  static const std::vector<simulate::FeatureDefinition> empty;
+  if (settings == nullptr) {
+    return empty;
+  }
+  return settings->features;
+}
+
+std::size_t ModelFeatures::size() const {
+  if (settings == nullptr) {
+    return 0;
+  }
+  return settings->features.size();
+}
+
+std::size_t ModelFeatures::nRegions(std::size_t featureIndex) const {
+  if (featureIndex >= settings->features.size()) {
+    return 0;
+  }
+  return simulate::getNumRegions(settings->features[featureIndex].roi);
+}
+
+const std::vector<std::size_t> &
+ModelFeatures::getVoxelRegions(std::size_t featureIndex) const {
+  return cachedVoxelRegions[featureIndex];
+}
+
+bool ModelFeatures::isValid(std::size_t featureIndex) const {
+  if (settings == nullptr || modelCompartments == nullptr ||
+      modelSpecies == nullptr) {
+    return false;
+  }
+  if (featureIndex >= settings->features.size()) {
+    return false;
+  }
+  const auto &feat = settings->features[featureIndex];
+  const auto &compIds = modelCompartments->getIds();
+  if (!compIds.contains(feat.compartmentId.c_str())) {
+    return false;
+  }
+  const auto specIds = modelSpecies->getIds(feat.compartmentId.c_str());
+  return specIds.contains(feat.speciesId.c_str());
+}
+
+std::size_t ModelFeatures::getIndexFromId(const std::string &featureId) const {
+  if (settings == nullptr) {
+    return 0;
+  }
+  for (std::size_t i = 0; i < settings->features.size(); ++i) {
+    if (settings->features[i].id == featureId) {
+      return i;
+    }
+  }
+  return settings->features.size();
+}
+
+// Cached index info for a feature, computed once and reused across timepoints
+struct FeatureIndices {
+  std::size_t simCompIndex{0};
+  std::size_t speciesIndex{0};
+  std::size_t nSimSpecies{0};
+  std::size_t nVoxels{0};
+  bool valid{false};
+};
+
+static FeatureIndices
+computeFeatureIndices(const simulate::FeatureDefinition &feat,
+                      const ModelCompartments &compartments,
+                      const ModelSpecies &species) {
+  FeatureIndices idx;
+  const auto &compIds = compartments.getIds();
+  auto compPos = compIds.indexOf(feat.compartmentId.c_str());
+  if (compPos < 0) {
+    return idx;
+  }
+  auto specIds = species.getIds(feat.compartmentId.c_str());
+  for (int i = 0; i < specIds.size(); ++i) {
+    if (species.isSimulatedSpecies(specIds[i])) {
+      if (specIds[i] == feat.speciesId.c_str()) {
+        idx.speciesIndex = idx.nSimSpecies;
+      }
+      ++idx.nSimSpecies;
+    }
+  }
+  if (idx.nSimSpecies == 0) {
+    return idx;
+  }
+  auto *comp = compartments.getCompartment(feat.compartmentId.c_str());
+  if (comp == nullptr) {
+    return idx;
+  }
+  idx.nVoxels = comp->nVoxels();
+  // find the simulation compartment index (only compartments with simulated
+  // species are included in concentration data)
+  for (int i = 0; i < compIds.size(); ++i) {
+    if (compIds[i] == feat.compartmentId.c_str()) {
+      idx.valid = true;
+      break;
+    }
+    auto sIds = species.getIds(compIds[i]);
+    for (const auto &s : sIds) {
+      if (species.isSimulatedSpecies(s)) {
+        ++idx.simCompIndex;
+        break;
+      }
+    }
+  }
+  return idx;
+}
+
+// Extract per-species concentration from interleaved SimulationData into buffer
+static void extractSpeciesConc(std::vector<double> &concs,
+                               const simulate::SimulationData &data,
+                               std::size_t timeIndex,
+                               std::size_t compartmentIndex,
+                               std::size_t speciesIndex, std::size_t nVoxels,
+                               std::size_t nSpecies) {
+  const auto &compConc = data.concentration[timeIndex][compartmentIndex];
+  std::size_t stride = nSpecies + data.concPadding[timeIndex];
+  concs.resize(nVoxels);
+  for (std::size_t ix = 0; ix < nVoxels; ++ix) {
+    concs[ix] = compConc[ix * stride + speciesIndex];
+  }
+}
+
+void ModelFeatures::evaluateAtTimepoint(std::size_t timeIndex) {
+  if (settings == nullptr || simulationData == nullptr ||
+      modelCompartments == nullptr || modelSpecies == nullptr) {
+    return;
+  }
+  simulationData->featureResults.resize(settings->features.size());
+  std::vector<double> concs; // reusable buffer
+  for (std::size_t fi = 0; fi < settings->features.size(); ++fi) {
+    if (!isValid(fi) || cachedVoxelRegions[fi].empty()) {
+      simulationData->featureResults[fi].values.emplace_back();
+      continue;
+    }
+    const auto &feat = settings->features[fi];
+    auto idx = computeFeatureIndices(feat, *modelCompartments, *modelSpecies);
+    if (!idx.valid ||
+        idx.simCompIndex >= simulationData->concentration[timeIndex].size()) {
+      simulationData->featureResults[fi].values.emplace_back();
+      continue;
+    }
+    extractSpeciesConc(concs, *simulationData, timeIndex, idx.simCompIndex,
+                       idx.speciesIndex, idx.nVoxels, idx.nSimSpecies);
+    auto vals = simulate::evaluateFeature(feat, concs, cachedVoxelRegions[fi]);
+    simulationData->featureResults[fi].values.push_back(std::move(vals));
+  }
+}
+
+void ModelFeatures::reEvaluateAllTimepoints() {
+  if (settings == nullptr || simulationData == nullptr) {
+    return;
+  }
+  // clear existing results
+  simulationData->featureResults.clear();
+  simulationData->featureResults.resize(settings->features.size());
+  // re-evaluate for each stored timepoint
+  for (std::size_t t = 0; t < simulationData->timePoints.size(); ++t) {
+    evaluateAtTimepoint(t);
+  }
+}
+
+void ModelFeatures::updateGeometry() {
+  if (settings == nullptr) {
+    return;
+  }
+  cachedVoxelRegions.resize(settings->features.size());
+  for (std::size_t i = 0; i < settings->features.size(); ++i) {
+    if (isValid(i)) {
+      recomputeVoxelRegions(i);
+    } else {
+      cachedVoxelRegions[i].clear();
+    }
+  }
+}
+
+void ModelFeatures::setSimulationDataPtr(simulate::SimulationData *simData) {
+  simulationData = simData;
+}
+
+void ModelFeatures::setHasUnsavedChanges(bool unsavedChanges) {
+  hasUnsavedChanges = unsavedChanges;
+}
+
+bool ModelFeatures::getHasUnsavedChanges() const { return hasUnsavedChanges; }
+
+} // namespace sme::model

--- a/core/model/src/model_features_t.cpp
+++ b/core/model/src/model_features_t.cpp
@@ -1,0 +1,130 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "sme/model.hpp"
+#include "sme/model_features.hpp"
+
+using namespace sme;
+using Mod = test::Mod;
+
+namespace {
+
+void removeAllFeatures(model::Model &m) {
+  auto &features = m.getFeatures();
+  while (features.size() > 0) {
+    features.remove(0);
+  }
+}
+
+} // namespace
+
+TEST_CASE("ModelFeatures",
+          "[core/model/model_features][core/model][core][model_features]") {
+  SECTION("default construction") {
+    model::ModelFeatures mf;
+    REQUIRE(mf.size() == 0);
+    REQUIRE(mf.getHasUnsavedChanges() == false);
+  }
+  SECTION("CRUD on VerySimpleModel") {
+    auto m{test::getExampleModel(Mod::VerySimpleModel)};
+    removeAllFeatures(m);
+    auto &mf{m.getFeatures()};
+    REQUIRE(mf.size() == 0);
+
+    // add a feature
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    auto idx =
+        mf.add("avg_A_c1", "c1", "A_c1", roi, simulate::ReductionOp::Average);
+    REQUIRE(idx == 0);
+    REQUIRE(mf.size() == 1);
+    REQUIRE(mf.getFeatures()[0].id == "avg_A_c1");
+    REQUIRE(mf.getFeatures()[0].name == "avg_A_c1");
+    REQUIRE(mf.getFeatures()[0].compartmentId == "c1");
+    REQUIRE(mf.getFeatures()[0].speciesId == "A_c1");
+    REQUIRE(mf.isValid(0));
+    REQUIRE(mf.nRegions(0) == 1);
+    REQUIRE(mf.getHasUnsavedChanges());
+
+    // add another feature
+    simulate::RoiSettings roi2;
+    roi2.roiType = simulate::RoiType::Depth;
+    roi2.numRegions = 3;
+    auto idx2 =
+        mf.add("depth_B_c2", "c2", "B_c2", roi2, simulate::ReductionOp::Max);
+    REQUIRE(idx2 == 1);
+    REQUIRE(mf.size() == 2);
+    REQUIRE(mf.getFeatures()[1].id == "depth_B_c2");
+    REQUIRE(mf.getFeatures()[0].id != mf.getFeatures()[1].id);
+    REQUIRE(mf.nRegions(1) == 3);
+
+    // rename
+    auto oldId = mf.getFeatures()[0].id;
+    REQUIRE(mf.setName(0, "renamed") == "renamed");
+    REQUIRE(mf.getFeatures()[0].id == oldId);
+    REQUIRE(mf.getFeatures()[0].name == "renamed");
+
+    // remove first
+    mf.remove(0);
+    REQUIRE(mf.size() == 1);
+    REQUIRE(mf.getFeatures()[0].name == "depth_B_c2");
+  }
+  SECTION("isValid with invalid references") {
+    auto m{test::getExampleModel(Mod::VerySimpleModel)};
+    removeAllFeatures(m);
+    auto &mf{m.getFeatures()};
+
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+
+    // invalid compartment
+    mf.add("bad_comp", "nonexistent", "A_c1", roi,
+           simulate::ReductionOp::Average);
+    REQUIRE(!mf.isValid(0));
+
+    // invalid species
+    mf.add("bad_spec", "c1", "nonexistent", roi,
+           simulate::ReductionOp::Average);
+    REQUIRE(!mf.isValid(1));
+
+    // valid
+    mf.add("good", "c1", "A_c1", roi, simulate::ReductionOp::Average);
+    REQUIRE(mf.isValid(2));
+  }
+  SECTION("getIndexFromId") {
+    auto m{test::getExampleModel(Mod::VerySimpleModel)};
+    removeAllFeatures(m);
+    auto &mf{m.getFeatures()};
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    mf.add("feat1", "c1", "A_c1", roi, simulate::ReductionOp::Average);
+    mf.add("feat1", "c1", "A_c1", roi, simulate::ReductionOp::Average);
+    REQUIRE(mf.getFeatures()[0].id == "feat1");
+    REQUIRE(mf.getFeatures()[0].name == "feat1");
+    REQUIRE(mf.getFeatures()[1].id == "feat1_");
+    REQUIRE(mf.getFeatures()[1].name == "feat1_");
+    REQUIRE(mf.setName(1, "feat1") == "feat1_");
+    REQUIRE(mf.getFeatures()[1].id == "feat1_");
+    REQUIRE(mf.getFeatures()[1].name == "feat1_");
+    REQUIRE(mf.getIndexFromId("feat1") == 0);
+    REQUIRE(mf.getIndexFromId("feat1_") == 1);
+    REQUIRE(mf.getIndexFromId("missing") == mf.size());
+  }
+  SECTION("voxel regions computed on add") {
+    auto m{test::getExampleModel(Mod::VerySimpleModel)};
+    removeAllFeatures(m);
+    auto &mf{m.getFeatures()};
+
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    const auto featureIndex =
+        mf.add("feat", "c1", "A_c1", roi, simulate::ReductionOp::Average);
+    REQUIRE(mf.isValid(featureIndex));
+    // voxel regions should be non-empty for a valid feature
+    const auto &regions = mf.getVoxelRegions(featureIndex);
+    REQUIRE(!regions.empty());
+    // default analytic expression "1" assigns every voxel to region 1
+    for (auto region : regions) {
+      REQUIRE(region == 1);
+    }
+  }
+}

--- a/core/model/src/xml_annotation_t.cpp
+++ b/core/model/src/xml_annotation_t.cpp
@@ -39,6 +39,7 @@ TEST_CASE("XML Annotations",
     auto &optCost{optimizeOptions.optCosts.emplace_back()};
     optCost.name = "myOptCost";
     optCost.targetValues = {1.0, 3.0, 5.0};
+    optCost.featureId = "myFeatureId";
     auto &optParam{optimizeOptions.optParams.emplace_back()};
     optParam.name = "myOptParam";
     settings.speciesStorageValues["A"] = 2.5;
@@ -76,6 +77,7 @@ TEST_CASE("XML Annotations",
     REQUIRE(newOptimizeOptions.optCosts[0].targetValues[0] == dbl_approx(1.0));
     REQUIRE(newOptimizeOptions.optCosts[0].targetValues[1] == dbl_approx(3.0));
     REQUIRE(newOptimizeOptions.optCosts[0].targetValues[2] == dbl_approx(5.0));
+    REQUIRE(newOptimizeOptions.optCosts[0].featureId == "myFeatureId");
     REQUIRE(newOptimizeOptions.optParams.size() == 1);
     REQUIRE(newOptimizeOptions.optParams[0].name == "myOptParam");
     REQUIRE(newSettings.speciesStorageValues.size() == 1);
@@ -125,8 +127,10 @@ TEST_CASE("XML Annotations",
     REQUIRE(optimizeOptions2.optCosts[0].targetValues[0] == dbl_approx(1.0));
     REQUIRE(optimizeOptions2.optCosts[0].targetValues[1] == dbl_approx(3.0));
     REQUIRE(optimizeOptions2.optCosts[0].targetValues[2] == dbl_approx(5.0));
+    REQUIRE(optimizeOptions2.optCosts[0].featureId == "myFeatureId");
     REQUIRE(optimizeOptions2.optCosts[1].name == "optCost2");
     REQUIRE(optimizeOptions2.optCosts[1].targetValues.empty());
+    REQUIRE(optimizeOptions2.optCosts[1].featureId.empty());
     REQUIRE(optimizeOptions2.optParams.size() == 1);
     REQUIRE(optimizeOptions2.optParams[0].name == "newOptParamName");
     REQUIRE(settings2.speciesStorageValues.size() == 1);

--- a/core/resources/models/ABtoC.xml
+++ b/core/resources/models/ABtoC.xml
@@ -4,7 +4,7 @@
     <annotation>
       <spatialModelEditor xmlns="https://github.com/spatial-model-editor">
         <settings>
-          <cereal_class_version>2</cereal_class_version>
+          <cereal_class_version>6</cereal_class_version>
           <simulationSettings>
             <cereal_class_version>1</cereal_class_version>
             <times size="dynamic">
@@ -65,7 +65,7 @@
             </maxAreas>
             <boundarySimplifierType>0</boundarySimplifierType>
           </meshParameters>
-          <speciesColours size="dynamic">
+          <speciesColors size="dynamic">
             <value0>
               <key>A</key>
               <value>4293263363</value>
@@ -78,7 +78,7 @@
               <key>C</key>
               <value>4294704896</value>
             </value2>
-          </speciesColours>
+          </speciesColors>
           <optimizeOptions>
             <cereal_class_version>0</cereal_class_version>
             <optAlgorithm>
@@ -90,10 +90,48 @@
             <optParams size="dynamic"/>
             <optCosts size="dynamic"/>
           </optimizeOptions>
-          <sampledFieldColours size="dynamic">
+          <sampledFieldColors size="dynamic">
             <value0>4278190592</value0>
             <value1>4287652289</value1>
-          </sampledFieldColours>
+          </sampledFieldColors>
+          <speciesDiffusionConstantArrays size="dynamic"/>
+          <speciesAnalyticDiffusionConstants size="dynamic"/>
+          <speciesStorageValues size="dynamic"/>
+          <speciesCrossDiffusionConstants size="dynamic"/>
+          <features size="dynamic">
+            <value0>
+              <cereal_class_version>0</cereal_class_version>
+              <id>A_average</id>
+              <name>A average</name>
+              <compartmentId>comp</compartmentId>
+              <speciesId>A</speciesId>
+              <roi>
+                <cereal_class_version>0</cereal_class_version>
+                <roiType>0</roiType>
+                <expression>1</expression>
+                <numRegions>1</numRegions>
+                <regionImage size="dynamic"/>
+                <parameters size="dynamic"/>
+              </roi>
+              <reduction>0</reduction>
+            </value0>
+            <value1>
+              <cereal_class_version>0</cereal_class_version>
+              <id>B_average</id>
+              <name>B average</name>
+              <compartmentId>comp</compartmentId>
+              <speciesId>B</speciesId>
+              <roi>
+                <cereal_class_version>0</cereal_class_version>
+                <roiType>0</roiType>
+                <expression>1</expression>
+                <numRegions>1</numRegions>
+                <regionImage size="dynamic"/>
+                <parameters size="dynamic"/>
+              </roi>
+              <reduction>0</reduction>
+            </value1>
+          </features>
         </settings>
       </spatialModelEditor>
     </annotation>

--- a/core/resources/models/very-simple-model.xml
+++ b/core/resources/models/very-simple-model.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by Spatial Model Editor version 1.11.0 on Wed Apr 22 09:46:40 2026 -->
 <sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:spatial="http://www.sbml.org/sbml/level3/version1/spatial/version1" level="3" version="2" spatial:required="true">
   <model id="very_simple_model" name="Very Simple Model" substanceUnits="substance" timeUnits="unit_of_time" volumeUnits="unit_of_volume" areaUnits="area" lengthUnits="unit_of_length" extentUnits="substance">
     <annotation>
       <spatialModelEditor xmlns="https://github.com/spatial-model-editor">
         <settings>
-          <cereal_class_version>2</cereal_class_version>
+          <cereal_class_version>6</cereal_class_version>
           <simulationSettings>
             <cereal_class_version>1</cereal_class_version>
             <times size="dynamic">
@@ -16,7 +17,7 @@
             <options>
               <cereal_class_version>0</cereal_class_version>
               <dune>
-                <cereal_class_version>0</cereal_class_version>
+                <cereal_class_version>2</cereal_class_version>
                 <discretization>0</discretization>
                 <integrator>Alexander2</integrator>
                 <dt>0.10000000000000001</dt>
@@ -26,10 +27,14 @@
                 <decrease>0.5</decrease>
                 <writeVTKfiles>false</writeVTKfiles>
                 <newtonRelErr>1e-08</newtonRelErr>
-                <newtonAbsErr>0.0</newtonAbsErr>
+                <newtonAbsErr>0</newtonAbsErr>
+                <linearSolver>RestartedGMRes</linearSolver>
+                <maxThreads>0</maxThreads>
               </dune>
               <pixel>
-                <cereal_class_version>0</cereal_class_version>
+                <cereal_class_version>1</cereal_class_version>
+                <backend>0</backend>
+                <gpuFloatPrecision>0</gpuFloatPrecision>
                 <integrator>1</integrator>
                 <maxErr>
                   <cereal_class_version>0</cereal_class_version>
@@ -46,7 +51,7 @@
             <simulatorType>0</simulatorType>
           </simulationSettings>
           <displayOptions>
-            <cereal_class_version>1</cereal_class_version>
+            <cereal_class_version>2</cereal_class_version>
             <showSpecies size="dynamic"/>
             <showMinMax>true</showMinMax>
             <normaliseOverAllTimepoints>true</normaliseOverAllTimepoints>
@@ -54,9 +59,10 @@
             <showGeometryGrid>false</showGeometryGrid>
             <showGeometryScale>false</showGeometryScale>
             <invertYAxis>false</invertYAxis>
+            <showFeatures size="dynamic"/>
           </displayOptions>
           <meshParameters>
-            <cereal_class_version>1</cereal_class_version>
+            <cereal_class_version>2</cereal_class_version>
             <maxPoints size="dynamic">
               <value0>12</value0>
               <value1>31</value1>
@@ -68,8 +74,10 @@
               <value2>30</value2>
             </maxAreas>
             <boundarySimplifierType>0</boundarySimplifierType>
+            <maxCellVolumes size="dynamic"/>
+            <meshSourceType>0</meshSourceType>
           </meshParameters>
-          <speciesColours size="dynamic">
+          <speciesColors size="dynamic">
             <value0>
               <key>A_c1</key>
               <value>4293269835</value>
@@ -94,7 +102,7 @@
               <key>B_c3</key>
               <value>4278223560</value>
             </value5>
-          </speciesColours>
+          </speciesColors>
           <optimizeOptions>
             <cereal_class_version>0</cereal_class_version>
             <optAlgorithm>
@@ -106,11 +114,72 @@
             <optParams size="dynamic"/>
             <optCosts size="dynamic"/>
           </optimizeOptions>
-          <sampledFieldColours size="dynamic">
+          <sampledFieldColors size="dynamic">
             <value0>4278190592</value0>
             <value1>4287652289</value1>
             <value2>4291134816</value2>
-          </sampledFieldColours>
+          </sampledFieldColors>
+          <speciesDiffusionConstantArrays size="dynamic"/>
+          <speciesAnalyticDiffusionConstants size="dynamic"/>
+          <speciesStorageValues size="dynamic">
+            <value0>
+              <key>A_c1</key>
+              <value>1</value>
+            </value0>
+            <value1>
+              <key>A_c2</key>
+              <value>1</value>
+            </value1>
+            <value2>
+              <key>A_c3</key>
+              <value>1</value>
+            </value2>
+            <value3>
+              <key>B_c1</key>
+              <value>1</value>
+            </value3>
+            <value4>
+              <key>B_c2</key>
+              <value>1</value>
+            </value4>
+            <value5>
+              <key>B_c3</key>
+              <value>1</value>
+            </value5>
+          </speciesStorageValues>
+          <speciesCrossDiffusionConstants size="dynamic"/>
+          <features size="dynamic">
+            <value0>
+              <cereal_class_version>0</cereal_class_version>
+              <id>depth</id>
+              <name>depth</name>
+              <compartmentId>c2</compartmentId>
+              <speciesId>A_c2</speciesId>
+              <roi>
+                <cereal_class_version>0</cereal_class_version>
+                <roiType>2</roiType>
+                <expression>1</expression>
+                <numRegions>4</numRegions>
+                <regionImage size="dynamic"/>
+                <parameters size="dynamic"/>
+              </roi>
+              <reduction>0</reduction>
+            </value0>
+            <value1>
+              <id>analytic</id>
+              <name>analytic</name>
+              <compartmentId>c2</compartmentId>
+              <speciesId>A_c2</speciesId>
+              <roi>
+                <roiType>0</roiType>
+                <expression>1 + sin((1/3)*x) + cos((1/5)*y) + cos((1/6)*x + (1/4)*y)</expression>
+                <numRegions>3</numRegions>
+                <regionImage size="dynamic"/>
+                <parameters size="dynamic"/>
+              </roi>
+              <reduction>0</reduction>
+            </value1>
+          </features>
         </settings>
       </spatialModelEditor>
     </annotation>

--- a/core/simulate/include/sme/feature_eval.hpp
+++ b/core/simulate/include/sme/feature_eval.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "sme/feature_options.hpp"
+#include "sme/geometry.hpp"
+#include "sme/voxel.hpp"
+#include <cstddef>
+#include <vector>
+
+namespace sme::simulate {
+
+/**
+ * @brief Compute per-voxel ROI region indices from ROI settings.
+ *
+ * @param roi ROI settings defining how voxels map to ROI regions.
+ * @param comp Compartment providing voxel positions and neighbors.
+ * @param origin Physical origin of the geometry.
+ * @param voxelSize Physical size of each voxel.
+ * @returns Vector of size nVoxels. Value = region index (0..numRegions),
+ *          where 0 means excluded.
+ */
+std::vector<std::size_t> computeVoxelRegions(const RoiSettings &roi,
+                                             const geometry::Compartment &comp,
+                                             const common::VoxelF &origin,
+                                             const common::VolumeF &voxelSize);
+
+/**
+ * @brief Depth regions via iterative erosion from outer boundary.
+ *
+ * Boundary voxels (where any neighbor == self via Neumann BC) = region 1.
+ * Each subsequent region is peeled inward.
+ *
+ * @param comp Compartment providing voxels and neighbor indices.
+ * @param numRegions Number of depth regions.
+ * @param regionThickness Number of voxel layers per depth region.
+ * @returns Vector of size nVoxels with region indices (1..numRegions).
+ *          Voxels deeper than ``numRegions * regionThickness`` are excluded
+ *          from the ROI.
+ *          0 means excluded.
+ */
+std::vector<std::size_t> computeDepthRegions(const geometry::Compartment &comp,
+                                             std::size_t numRegions,
+                                             std::size_t regionThickness = 1);
+
+/**
+ * @brief Axis slice regions across the compartment extent.
+ *
+ * Axis values: x=0, y=1, z=2. The y axis uses physical image orientation,
+ * matching analytic ROI coordinates.
+ *
+ * @param comp Compartment providing voxel positions.
+ * @param numRegions Number of axis bands.
+ * @param axis Axis index: x=0, y=1, z=2.
+ * @returns Vector of size nVoxels with region indices (1..numRegions).
+ *          0 means excluded.
+ */
+std::vector<std::size_t>
+computeAxisSliceRegions(const geometry::Compartment &comp,
+                        std::size_t numRegions, int axis = 0);
+
+/**
+ * @brief Apply reduction operation to concentrations in a specific region.
+ *
+ * @param op Reduction operation.
+ * @param concs Concentration values (one per voxel).
+ * @param voxelRegions ROI region indices (one per voxel, 0 = excluded).
+ * @param targetRegion Region index to reduce over.
+ * @returns Scalar result of the reduction.
+ */
+double applyReduction(ReductionOp op, const std::vector<double> &concs,
+                      const std::vector<std::size_t> &voxelRegions,
+                      std::size_t targetRegion);
+
+/**
+ * @brief Evaluate one feature at one timepoint.
+ *
+ * @param feature Feature definition.
+ * @param concs Concentration values for the species (one per voxel).
+ * @param voxelRegions Pre-computed ROI region indices for this feature.
+ * @returns Vector of ``numRegions`` scalars (one per region).
+ */
+std::vector<double>
+evaluateFeature(const FeatureDefinition &feature,
+                const std::vector<double> &concs,
+                const std::vector<std::size_t> &voxelRegions);
+
+/**
+ * @brief Number of regions for a given ROI settings.
+ */
+std::size_t getNumRegions(const RoiSettings &roi);
+
+} // namespace sme::simulate

--- a/core/simulate/include/sme/feature_options.hpp
+++ b/core/simulate/include/sme/feature_options.hpp
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <cereal/cereal.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/vector.hpp>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace sme::simulate {
+
+/**
+ * @brief ROI source type for feature extraction.
+ */
+enum class RoiType { Analytic, Image, Depth, AxisSlices };
+
+/**
+ * @brief Reduction operation applied over voxels in a region.
+ */
+enum class ReductionOp { Average, Sum, Min, Max };
+
+/**
+ * @brief Generic named ROI parameter value.
+ *
+ * Boolean parameters are stored in intValue and exposed through typed helpers.
+ */
+struct RoiParameterValue {
+  int intValue{0};
+  double doubleValue{0.0};
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(intValue), CEREAL_NVP(doubleValue));
+    }
+  }
+};
+
+/**
+ * @brief ROI settings defining how voxels are assigned to ROI regions.
+ */
+struct RoiSettings {
+  /**
+   * @brief Type of ROI source.
+   */
+  RoiType roiType{RoiType::Analytic};
+  /**
+   * @brief Analytic expression for regions (variables: x, y, z).
+   *
+   * The result is cast to ``int`` for each voxel:
+   * 0 = excluded, 1..N = region index.
+   */
+  std::string expression{"1"};
+  /**
+   * @brief Number of ROI regions.
+   */
+  std::size_t numRegions{1};
+  /**
+   * @brief Imported image regions (pixel values = region assignments).
+   *
+   * 0 = excluded, 1..N = region index.
+   */
+  std::vector<std::size_t> regionImage;
+  /**
+   * @brief Named parameters for ROI sources.
+   */
+  std::map<std::string, RoiParameterValue> parameters;
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(roiType), CEREAL_NVP(expression), CEREAL_NVP(numRegions),
+         CEREAL_NVP(regionImage), CEREAL_NVP(parameters));
+    }
+  }
+};
+
+/**
+ * @brief Defines a feature to extract from simulation results.
+ */
+struct FeatureDefinition {
+  /**
+   * @brief Stable internal feature id.
+   */
+  std::string id;
+  /**
+   * @brief User-visible feature name.
+   */
+  std::string name;
+  /**
+   * @brief SBML compartment id (by id for robustness across edits).
+   */
+  std::string compartmentId;
+  /**
+   * @brief SBML species id (by id for robustness across edits).
+   */
+  std::string speciesId;
+  /**
+   * @brief ROI settings.
+   */
+  RoiSettings roi;
+  /**
+   * @brief Reduction operation to apply per region.
+   */
+  ReductionOp reduction{ReductionOp::Average};
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(id), CEREAL_NVP(name), CEREAL_NVP(compartmentId),
+         CEREAL_NVP(speciesId), CEREAL_NVP(roi), CEREAL_NVP(reduction));
+    }
+  }
+};
+
+/**
+ * @brief Result of feature evaluation over simulation timepoints.
+ */
+struct FeatureResult {
+  /**
+   * @brief Feature values: ``values[timeIndex][regionIndex]``.
+   */
+  std::vector<std::vector<double>> values;
+
+  template <class Archive>
+  void serialize(Archive &ar, std::uint32_t const version) {
+    if (version == 0) {
+      ar(CEREAL_NVP(values));
+    }
+  }
+};
+
+namespace roi_param {
+inline constexpr auto axis = "axis";
+inline constexpr auto depthThicknessVoxels = "thickness_voxels";
+} // namespace roi_param
+
+std::string toString(RoiType roiType);
+std::string toString(ReductionOp reduction);
+int getRoiParameterInt(const RoiSettings &roi, const std::string &key,
+                       int defaultValue);
+double getRoiParameterDouble(const RoiSettings &roi, const std::string &key,
+                             double defaultValue);
+bool getRoiParameterBool(const RoiSettings &roi, const std::string &key,
+                         bool defaultValue);
+void setRoiParameterInt(RoiSettings &roi, const std::string &key, int value);
+void setRoiParameterDouble(RoiSettings &roi, const std::string &key,
+                           double value);
+void setRoiParameterBool(RoiSettings &roi, const std::string &key, bool value);
+std::string
+makeUniqueFeatureId(const std::string &name,
+                    const std::vector<FeatureDefinition> &existingFeatures);
+
+} // namespace sme::simulate
+
+CEREAL_CLASS_VERSION(sme::simulate::RoiParameterValue, 0);
+CEREAL_CLASS_VERSION(sme::simulate::RoiSettings, 0);
+CEREAL_CLASS_VERSION(sme::simulate::FeatureDefinition, 0);
+CEREAL_CLASS_VERSION(sme::simulate::FeatureResult, 0);

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -30,12 +30,22 @@ struct OptTimestep {
   std::vector<std::size_t> optCostIndices;
 };
 
+struct FeatureOptCost {
+  bool valid{false};
+  std::string errorMessage{};
+  FeatureDefinition feature{};
+  std::vector<std::size_t> voxelRegions{};
+  std::vector<std::size_t> imageIndices{};
+  std::vector<double> targetFeatureValues{};
+};
+
 struct OptConstData {
   std::string xmlModel{};
   OptimizeOptions optimizeOptions{};
   std::vector<OptTimestep> optTimesteps{};
   common::Volume imageSize{};
   std::vector<double> maxTargetValues{};
+  std::vector<FeatureOptCost> featureOptCosts{};
 };
 
 /**

--- a/core/simulate/include/sme/optimize_options.hpp
+++ b/core/simulate/include/sme/optimize_options.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "sme/feature_options.hpp"
 #include <array>
 #include <cereal/cereal.hpp>
 #include <cereal/types/string.hpp>
@@ -57,7 +58,7 @@ struct OptParam {
 /**
  * @brief Types of costs that can be used in optimization
  */
-enum class OptCostType { Concentration, ConcentrationDcdt };
+enum class OptCostType { Concentration, ConcentrationDcdt, Feature };
 
 /**
  * @brief Types of differences that can be used in costs
@@ -105,11 +106,13 @@ struct OptCost {
    */
   std::size_t speciesIndex;
   /**
-   * @brief The target values to compare with the species concentration or dcdt
+   * @brief The target image values for this observable
    *
-   * Should contain a value for each pixel in the image,
-   * including those outside of the compartment the species is located in.
-   * If empty, the target values are assumed to be zero everywhere.
+   * For concentration and feature observables this stores a concentration
+   * image. For dcdt observables this stores a dcdt image. It should contain a
+   * value for each pixel in the image, including those outside of the
+   * compartment the species is located in. If empty, the target values are
+   * assumed to be zero everywhere.
    */
   std::vector<double> targetValues;
   /**
@@ -119,6 +122,12 @@ struct OptCost {
    * avoid numerical issues caused by dividing by zero.
    */
   double epsilon{1e-15};
+  /**
+   * @brief Stable internal feature id for feature observables
+   *
+   * Empty for concentration and dcdt observables.
+   */
+  std::string featureId;
 
   template <class Archive>
   void serialize(Archive &ar, std::uint32_t const version) {
@@ -127,6 +136,11 @@ struct OptCost {
          CEREAL_NVP(id), CEREAL_NVP(simulationTime), CEREAL_NVP(weight),
          CEREAL_NVP(compartmentIndex), CEREAL_NVP(speciesIndex),
          CEREAL_NVP(targetValues), CEREAL_NVP(epsilon));
+    } else if (version == 1) {
+      ar(CEREAL_NVP(optCostType), CEREAL_NVP(optCostDiffType), CEREAL_NVP(name),
+         CEREAL_NVP(id), CEREAL_NVP(simulationTime), CEREAL_NVP(weight),
+         CEREAL_NVP(compartmentIndex), CEREAL_NVP(speciesIndex),
+         CEREAL_NVP(targetValues), CEREAL_NVP(epsilon), CEREAL_NVP(featureId));
     }
   }
 };
@@ -217,6 +231,6 @@ struct OptimizeOptions {
 } // namespace sme::simulate
 
 CEREAL_CLASS_VERSION(sme::simulate::OptimizeOptions, 0);
-CEREAL_CLASS_VERSION(sme::simulate::OptCost, 0);
+CEREAL_CLASS_VERSION(sme::simulate::OptCost, 1);
 CEREAL_CLASS_VERSION(sme::simulate::OptParam, 0);
 CEREAL_CLASS_VERSION(sme::simulate::OptAlgorithm, 0);

--- a/core/simulate/include/sme/simulate_data.hpp
+++ b/core/simulate/include/sme/simulate_data.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "sme/feature_options.hpp"
 #include "sme/simulate_options.hpp"
 #include <cereal/cereal.hpp>
 #include <cereal/types/string.hpp>
@@ -41,6 +42,10 @@ public:
    */
   std::string xmlModel;
   /**
+   * @brief Feature extraction results: one FeatureResult per feature.
+   */
+  std::vector<simulate::FeatureResult> featureResults;
+  /**
    * @brief Clear all stored data.
    */
   void clear();
@@ -71,10 +76,13 @@ public:
     if (version == 0) {
       ar(timePoints, concentration, avgMinMax, concentrationMax, concPadding,
          xmlModel);
+    } else if (version == 1) {
+      ar(timePoints, concentration, avgMinMax, concentrationMax, concPadding,
+         xmlModel, featureResults);
     }
   }
 };
 
 } // namespace sme::simulate
 
-CEREAL_CLASS_VERSION(sme::simulate::SimulationData, 0);
+CEREAL_CLASS_VERSION(sme::simulate::SimulationData, 1);

--- a/core/simulate/src/CMakeLists.txt
+++ b/core/simulate/src/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(
   core
   PRIVATE basesim.cpp
           dune_cell_data.cpp
+          feature_eval.cpp
+          feature_options.cpp
           duneconverter.cpp
           duneconverter_impl.cpp
           dunefunction.cpp
@@ -30,7 +32,9 @@ endif()
 if(BUILD_TESTING)
   target_sources(
     core_tests
-    PUBLIC duneconverter_t.cpp
+    PUBLIC feature_eval_t.cpp
+           feature_options_t.cpp
+           duneconverter_t.cpp
            duneconverter_impl_t.cpp
            dune_cell_data_t.cpp
            dunefunction_t.cpp

--- a/core/simulate/src/feature_eval.cpp
+++ b/core/simulate/src/feature_eval.cpp
@@ -1,0 +1,254 @@
+#include "sme/feature_eval.hpp"
+#include "sme/logger.hpp"
+#include "sme/symbolic.hpp"
+#include <algorithm>
+
+namespace sme::simulate {
+
+static constexpr std::size_t excludedRegion = 0;
+
+std::size_t getNumRegions(const RoiSettings &roi) { return roi.numRegions; }
+
+static std::vector<std::size_t> computeAnalyticRegions(
+    const RoiSettings &roi, const geometry::Compartment &comp,
+    const common::VoxelF &origin, const common::VolumeF &voxelSize) {
+  std::vector<std::size_t> regions(comp.nVoxels(), excludedRegion);
+  if (roi.numRegions == 0 || roi.expression.empty()) {
+    return regions;
+  }
+  common::Symbolic sym(roi.expression, {"x", "y", "z"});
+  if (!sym.isValid()) {
+    SPDLOG_WARN("Invalid ROI region expression: {}", roi.expression);
+    return regions;
+  }
+  sym.compile();
+  const auto &voxels = comp.getVoxels();
+  const auto &imgSize = comp.getImageSize();
+  std::vector<double> result(1);
+  std::vector<double> vars(3);
+  for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+    const auto &v = voxels[i];
+    vars[0] =
+        origin.p.x() + (static_cast<double>(v.p.x()) + 0.5) * voxelSize.width();
+    vars[1] = origin.p.y() +
+              (static_cast<double>(imgSize.height() - 1 - v.p.y()) + 0.5) *
+                  voxelSize.height();
+    vars[2] = origin.z + (static_cast<double>(v.z) + 0.5) * voxelSize.depth();
+    sym.eval(result, vars);
+    const auto region = static_cast<int>(result[0]);
+    if (region > 0 && static_cast<std::size_t>(region) <= roi.numRegions) {
+      regions[i] = static_cast<std::size_t>(region);
+    }
+  }
+  return regions;
+}
+
+static std::vector<std::size_t>
+computeImageRegions(const RoiSettings &roi, const geometry::Compartment &comp) {
+  std::vector<std::size_t> regions(comp.nVoxels(), excludedRegion);
+  if (roi.numRegions == 0 || roi.regionImage.empty()) {
+    return regions;
+  }
+  const auto &voxels = comp.getVoxels();
+  const auto &imgSize = comp.getImageSize();
+  for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+    const auto &v = voxels[i];
+    const auto imgIndex =
+        common::voxelArrayIndex(imgSize, v.p.x(), v.p.y(), v.z);
+    if (imgIndex < roi.regionImage.size()) {
+      const auto region = roi.regionImage[imgIndex];
+      if (region <= roi.numRegions) {
+        regions[i] = region;
+      }
+    }
+  }
+  return regions;
+}
+
+std::vector<std::size_t> computeDepthRegions(const geometry::Compartment &comp,
+                                             std::size_t numRegions,
+                                             std::size_t regionThickness) {
+  std::vector<std::size_t> regions(comp.nVoxels(), excludedRegion);
+  if (comp.nVoxels() == 0 || numRegions == 0) {
+    return regions;
+  }
+  regionThickness = std::max<std::size_t>(regionThickness, 1);
+  const auto &imgSize = comp.getImageSize();
+  const bool checkX = imgSize.width() > 1;
+  const bool checkY = imgSize.height() > 1;
+  const bool checkZ = imgSize.depth() > 1;
+  if (!checkX && !checkY && !checkZ) {
+    std::fill(regions.begin(), regions.end(), 1);
+    return regions;
+  }
+  for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+    if ((checkX && (comp.up_x(i) == i || comp.dn_x(i) == i)) ||
+        (checkY && (comp.up_y(i) == i || comp.dn_y(i) == i)) ||
+        (checkZ && (comp.up_z(i) == i || comp.dn_z(i) == i))) {
+      regions[i] = 1;
+    }
+  }
+  const auto maxLayer = numRegions * regionThickness;
+  std::vector<std::size_t> newRegion;
+  for (std::size_t layer = 2; layer <= maxLayer; ++layer) {
+    newRegion.clear();
+    for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+      if (regions[i] != excludedRegion) {
+        continue;
+      }
+      const auto checkNeighbor = [&](std::size_t ni) {
+        return ni != i && regions[ni] != excludedRegion;
+      };
+      if (checkNeighbor(comp.up_x(i)) || checkNeighbor(comp.dn_x(i)) ||
+          checkNeighbor(comp.up_y(i)) || checkNeighbor(comp.dn_y(i)) ||
+          checkNeighbor(comp.up_z(i)) || checkNeighbor(comp.dn_z(i))) {
+        newRegion.push_back(i);
+      }
+    }
+    const auto region = 1 + (layer - 1) / regionThickness;
+    for (auto idx : newRegion) {
+      regions[idx] = region;
+    }
+  }
+  return regions;
+}
+
+std::vector<std::size_t>
+computeAxisSliceRegions(const geometry::Compartment &comp,
+                        std::size_t numRegions, int axis) {
+  std::vector<std::size_t> regions(comp.nVoxels(), excludedRegion);
+  if (comp.nVoxels() == 0 || numRegions == 0) {
+    return regions;
+  }
+  axis = std::clamp(axis, 0, 2);
+  const auto &imgSize = comp.getImageSize();
+  const auto coordinate = [&](const common::Voxel &v) {
+    switch (axis) {
+    case 1:
+      return imgSize.height() - 1 - v.p.y();
+    case 2:
+      return static_cast<int>(v.z);
+    default:
+      return v.p.x();
+    }
+  };
+  const auto &voxels = comp.getVoxels();
+  auto [minVoxel, maxVoxel] =
+      std::ranges::minmax_element(voxels, {}, coordinate);
+  const auto minCoordinate = coordinate(*minVoxel);
+  const auto extent =
+      static_cast<std::size_t>(coordinate(*maxVoxel) - minCoordinate + 1);
+  for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+    const auto distance =
+        static_cast<std::size_t>(coordinate(voxels[i]) - minCoordinate);
+    regions[i] = std::min(numRegions, 1 + distance * numRegions / extent);
+  }
+  return regions;
+}
+
+std::vector<std::size_t> computeVoxelRegions(const RoiSettings &roi,
+                                             const geometry::Compartment &comp,
+                                             const common::VoxelF &origin,
+                                             const common::VolumeF &voxelSize) {
+  switch (roi.roiType) {
+  case RoiType::Analytic:
+    return computeAnalyticRegions(roi, comp, origin, voxelSize);
+  case RoiType::Image:
+    return computeImageRegions(roi, comp);
+  case RoiType::Depth:
+    return computeDepthRegions(
+        comp, roi.numRegions,
+        static_cast<std::size_t>(std::max(
+            1, getRoiParameterInt(roi, roi_param::depthThicknessVoxels, 1))));
+  case RoiType::AxisSlices:
+    return computeAxisSliceRegions(comp, roi.numRegions,
+                                   getRoiParameterInt(roi, roi_param::axis, 0));
+  }
+  return std::vector<std::size_t>(comp.nVoxels(), excludedRegion);
+}
+
+double applyReduction(ReductionOp op, const std::vector<double> &concs,
+                      const std::vector<std::size_t> &voxelRegions,
+                      std::size_t targetRegion) {
+  double result = 0.0;
+  std::size_t count = 0;
+  bool first = true;
+  for (std::size_t i = 0; i < concs.size(); ++i) {
+    if (voxelRegions[i] != targetRegion) {
+      continue;
+    }
+    const double c = concs[i];
+    if (first) {
+      if (op == ReductionOp::Min || op == ReductionOp::Max) {
+        result = c;
+      }
+      first = false;
+    }
+    switch (op) {
+    case ReductionOp::Average:
+    case ReductionOp::Sum:
+      result += c;
+      break;
+    case ReductionOp::Min:
+      result = std::min(result, c);
+      break;
+    case ReductionOp::Max:
+      result = std::max(result, c);
+      break;
+    }
+    ++count;
+  }
+  if (op == ReductionOp::Average && count > 0) {
+    result /= static_cast<double>(count);
+  }
+  if (first && (op == ReductionOp::Min || op == ReductionOp::Max)) {
+    result = 0.0;
+  }
+  return result;
+}
+
+std::vector<double>
+evaluateFeature(const FeatureDefinition &feature,
+                const std::vector<double> &concs,
+                const std::vector<std::size_t> &voxelRegions) {
+  const auto numRegions = getNumRegions(feature.roi);
+  std::vector<double> results(numRegions, 0.0);
+  std::vector<std::size_t> counts(numRegions, 0);
+  std::vector<bool> initialized(numRegions, false);
+  const auto op = feature.reduction;
+  for (std::size_t i = 0; i < concs.size(); ++i) {
+    const auto region = voxelRegions[i];
+    if (region == excludedRegion || region > numRegions) {
+      continue;
+    }
+    const auto regionIndex = region - 1;
+    const double c = concs[i];
+    if (!initialized[regionIndex]) {
+      initialized[regionIndex] = true;
+      if (op == ReductionOp::Min || op == ReductionOp::Max) {
+        results[regionIndex] = c;
+      }
+    }
+    switch (op) {
+    case ReductionOp::Average:
+    case ReductionOp::Sum:
+      results[regionIndex] += c;
+      break;
+    case ReductionOp::Min:
+      results[regionIndex] = std::min(results[regionIndex], c);
+      break;
+    case ReductionOp::Max:
+      results[regionIndex] = std::max(results[regionIndex], c);
+      break;
+    }
+    ++counts[regionIndex];
+  }
+  for (std::size_t regionIndex = 0; regionIndex < numRegions; ++regionIndex) {
+    if (op == ReductionOp::Average && counts[regionIndex] > 0) {
+      results[regionIndex] /= static_cast<double>(counts[regionIndex]);
+    }
+  }
+  return results;
+}
+
+} // namespace sme::simulate

--- a/core/simulate/src/feature_eval_t.cpp
+++ b/core/simulate/src/feature_eval_t.cpp
@@ -1,0 +1,430 @@
+#include "catch_wrapper.hpp"
+#include "sme/feature_eval.hpp"
+#include "sme/feature_options.hpp"
+#include "sme/geometry.hpp"
+#include <QImage>
+#include <algorithm>
+
+using namespace sme;
+
+static geometry::Compartment make5x5Compartment() {
+  QImage img(5, 5, QImage::Format_RGB32);
+  const auto col = qRgb(100, 100, 100);
+  img.fill(col);
+  common::ImageStack imgs(std::vector<QImage>{img});
+  return geometry::Compartment("comp", imgs, col);
+}
+
+static geometry::Compartment make3x3CrossCompartment() {
+  QImage img(3, 3, QImage::Format_RGB32);
+  const auto col = qRgb(200, 200, 200);
+  const auto bg = qRgb(0, 0, 0);
+  img.fill(bg);
+  img.setPixel(1, 0, col);
+  img.setPixel(0, 1, col);
+  img.setPixel(1, 1, col);
+  img.setPixel(2, 1, col);
+  img.setPixel(1, 2, col);
+  common::ImageStack imgs(std::vector<QImage>{img});
+  return geometry::Compartment("cross", imgs, col);
+}
+
+static geometry::Compartment make2x2x3Compartment() {
+  const auto col = qRgb(150, 150, 150);
+  std::vector<QImage> images;
+  for (int z = 0; z < 3; ++z) {
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.fill(col);
+    images.push_back(img);
+  }
+  common::ImageStack imgs(images);
+  return geometry::Compartment("comp3d", imgs, col);
+}
+
+TEST_CASE("FeatureEval",
+          "[core/simulate/feature_eval][core/simulate][core][feature_eval]") {
+  SECTION("getNumRegions") {
+    simulate::RoiSettings roi;
+    REQUIRE(simulate::getNumRegions(roi) == 1);
+
+    roi.roiType = simulate::RoiType::Image;
+    roi.numRegions = 5;
+    REQUIRE(simulate::getNumRegions(roi) == 5);
+
+    roi.roiType = simulate::RoiType::Depth;
+    roi.numRegions = 3;
+    REQUIRE(simulate::getNumRegions(roi) == 3);
+
+    roi.roiType = simulate::RoiType::AxisSlices;
+    roi.numRegions = 4;
+    REQUIRE(simulate::getNumRegions(roi) == 4);
+  }
+
+  SECTION("applyReduction: Average") {
+    std::vector<double> concs = {2.0, 4.0, 6.0, 8.0};
+    std::vector<std::size_t> regions = {1, 1, 2, 1};
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Average, concs,
+                                     regions,
+                                     1) == dbl_approx((2.0 + 4.0 + 8.0) / 3.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Average, concs,
+                                     regions, 2) == dbl_approx(6.0));
+  }
+
+  SECTION("applyReduction: Sum") {
+    std::vector<double> concs = {1.0, 2.0, 3.0};
+    std::vector<std::size_t> regions = {1, 1, 1};
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Sum, concs, regions,
+                                     1) == dbl_approx(6.0));
+  }
+
+  SECTION("applyReduction: Min/Max") {
+    std::vector<double> concs = {5.0, 1.0, 3.0, 7.0};
+    std::vector<std::size_t> regions = {1, 1, 2, 1};
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Min, concs, regions,
+                                     1) == dbl_approx(1.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Max, concs, regions,
+                                     1) == dbl_approx(7.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Min, concs, regions,
+                                     2) == dbl_approx(3.0));
+  }
+
+  SECTION("applyReduction: empty region") {
+    std::vector<double> concs = {1.0, 2.0};
+    std::vector<std::size_t> regions = {1, 1};
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Average, concs,
+                                     regions, 5) == dbl_approx(0.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Sum, concs, regions,
+                                     5) == dbl_approx(0.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Min, concs, regions,
+                                     5) == dbl_approx(0.0));
+    REQUIRE(simulate::applyReduction(simulate::ReductionOp::Max, concs, regions,
+                                     5) == dbl_approx(0.0));
+  }
+
+  SECTION("computeDepthRegions: 5x5 compartment") {
+    auto comp = make5x5Compartment();
+    REQUIRE(comp.nVoxels() == 25);
+    auto regions = simulate::computeDepthRegions(comp, 3);
+    REQUIRE(regions.size() == 25);
+    std::size_t count1 = 0, count2 = 0, count3 = 0;
+    for (auto region : regions) {
+      if (region == 1) {
+        ++count1;
+      } else if (region == 2) {
+        ++count2;
+      } else if (region == 3) {
+        ++count3;
+      }
+    }
+    REQUIRE(count1 == 16);
+    REQUIRE(count2 == 8);
+    REQUIRE(count3 == 1);
+  }
+
+  SECTION(
+      "computeDepthRegions: deeper voxels excluded beyond requested depth") {
+    auto comp = make5x5Compartment();
+    REQUIRE(comp.nVoxels() == 25);
+
+    auto regions1 = simulate::computeDepthRegions(comp, 1);
+    std::size_t count0 = 0, count1 = 0;
+    for (auto region : regions1) {
+      if (region == 0) {
+        ++count0;
+      } else if (region == 1) {
+        ++count1;
+      }
+    }
+    REQUIRE(count0 == 9);
+    REQUIRE(count1 == 16);
+
+    auto regions2 = simulate::computeDepthRegions(comp, 2);
+    std::size_t count00 = 0, count11 = 0, count22 = 0;
+    for (auto region : regions2) {
+      if (region == 0) {
+        ++count00;
+      } else if (region == 1) {
+        ++count11;
+      } else if (region == 2) {
+        ++count22;
+      }
+    }
+    REQUIRE(count00 == 1);
+    REQUIRE(count11 == 16);
+    REQUIRE(count22 == 8);
+  }
+
+  SECTION("computeDepthRegions: groups voxel layers by thickness") {
+    auto comp = make5x5Compartment();
+    REQUIRE(comp.nVoxels() == 25);
+
+    auto regions1 = simulate::computeDepthRegions(comp, 1, 2);
+    std::size_t count0 = 0, count1 = 0;
+    for (auto region : regions1) {
+      if (region == 0) {
+        ++count0;
+      } else if (region == 1) {
+        ++count1;
+      }
+    }
+    REQUIRE(count0 == 1);
+    REQUIRE(count1 == 24);
+
+    auto regions2 = simulate::computeDepthRegions(comp, 2, 2);
+    std::size_t count00 = 0, count11 = 0, count22 = 0;
+    for (auto region : regions2) {
+      if (region == 0) {
+        ++count00;
+      } else if (region == 1) {
+        ++count11;
+      } else if (region == 2) {
+        ++count22;
+      }
+    }
+    REQUIRE(count00 == 0);
+    REQUIRE(count11 == 24);
+    REQUIRE(count22 == 1);
+
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Depth;
+    roi.numRegions = 1;
+    simulate::setRoiParameterInt(roi, simulate::roi_param::depthThicknessVoxels,
+                                 2);
+    auto voxelRegions = simulate::computeVoxelRegions(roi, comp, {}, {});
+    REQUIRE(std::ranges::count(voxelRegions, 1) == 24);
+    REQUIRE(std::ranges::count(voxelRegions, 0) == 1);
+  }
+
+  SECTION("computeDepthRegions: single voxel") {
+    QImage img(1, 1, QImage::Format_RGB32);
+    const auto col = qRgb(50, 50, 50);
+    img.setPixel(0, 0, col);
+    common::ImageStack imgs(std::vector<QImage>{img});
+    geometry::Compartment comp("single", imgs, col);
+    auto regions = simulate::computeDepthRegions(comp, 3);
+    REQUIRE(regions.size() == 1);
+    REQUIRE(regions[0] == 1);
+  }
+
+  SECTION("computeDepthRegions: empty compartment") {
+    QImage img(1, 1, QImage::Format_RGB32);
+    img.fill(qRgb(0, 0, 0));
+    common::ImageStack imgs(std::vector<QImage>{img});
+    geometry::Compartment comp("empty", imgs, qRgb(255, 255, 255));
+    auto regions = simulate::computeDepthRegions(comp, 2);
+    REQUIRE(regions.empty());
+  }
+
+  SECTION("computeDepthRegions: cross-shaped compartment") {
+    auto comp = make3x3CrossCompartment();
+    REQUIRE(comp.nVoxels() == 5);
+    auto regions = simulate::computeDepthRegions(comp, 2);
+    REQUIRE(regions.size() == 5);
+    std::size_t count1 = 0, count2 = 0;
+    for (auto region : regions) {
+      if (region == 1) {
+        ++count1;
+      } else if (region == 2) {
+        ++count2;
+      }
+    }
+    REQUIRE(count1 == 4);
+    REQUIRE(count2 == 1);
+  }
+
+  SECTION("computeAxisSliceRegions: x bands split compartment extent") {
+    auto comp = make5x5Compartment();
+    REQUIRE(comp.nVoxels() == 25);
+    auto regions = simulate::computeAxisSliceRegions(comp, 2, 0);
+    REQUIRE(regions.size() == 25);
+    REQUIRE(std::ranges::count(regions, 1) == 15);
+    REQUIRE(std::ranges::count(regions, 2) == 10);
+  }
+
+  SECTION("computeAxisSliceRegions: y bands use physical image orientation") {
+    auto comp = make5x5Compartment();
+    auto regions = simulate::computeAxisSliceRegions(comp, 5, 1);
+    REQUIRE(regions.size() == comp.nVoxels());
+    for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+      const auto &voxel = comp.getVoxel(i);
+      if (voxel.p.y() == 0) {
+        REQUIRE(regions[i] == 5);
+      } else if (voxel.p.y() == 4) {
+        REQUIRE(regions[i] == 1);
+      }
+    }
+  }
+
+  SECTION("computeAxisSliceRegions: z bands split 3d compartment") {
+    auto comp = make2x2x3Compartment();
+    auto regions = simulate::computeAxisSliceRegions(comp, 3, 2);
+    REQUIRE(regions.size() == 12);
+    REQUIRE(std::ranges::count(regions, 1) == 4);
+    REQUIRE(std::ranges::count(regions, 2) == 4);
+    REQUIRE(std::ranges::count(regions, 3) == 4);
+  }
+
+  SECTION("computeVoxelRegions: axis slices use axis parameter") {
+    auto comp = make5x5Compartment();
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::AxisSlices;
+    roi.numRegions = 5;
+    simulate::setRoiParameterInt(roi, simulate::roi_param::axis, 1);
+    auto regions = simulate::computeVoxelRegions(roi, comp, {}, {});
+    for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+      const auto &voxel = comp.getVoxel(i);
+      if (voxel.p.y() == 0) {
+        REQUIRE(regions[i] == 5);
+      } else if (voxel.p.y() == 4) {
+        REQUIRE(regions[i] == 1);
+      }
+    }
+  }
+
+  SECTION("computeVoxelRegions: analytic expression uses integer cast") {
+    auto comp = make5x5Compartment();
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    roi.expression = "x";
+    roi.numRegions = 3;
+    common::VoxelF origin(0.0, 0.0, 0.0);
+    common::VolumeF voxelSize(1.0, 1.0, 1.0);
+    auto regions = simulate::computeVoxelRegions(roi, comp, origin, voxelSize);
+    REQUIRE(regions.size() == 25);
+    std::size_t count0 = 0, count1 = 0, count2 = 0, count3 = 0;
+    for (auto region : regions) {
+      if (region == 0) {
+        ++count0;
+      } else if (region == 1) {
+        ++count1;
+      } else if (region == 2) {
+        ++count2;
+      } else if (region == 3) {
+        ++count3;
+      }
+    }
+    REQUIRE(count0 == 10);
+    REQUIRE(count1 == 5);
+    REQUIRE(count2 == 5);
+    REQUIRE(count3 == 5);
+  }
+
+  SECTION("computeVoxelRegions: analytic y coordinate matches physical image "
+          "orientation") {
+    auto comp = make5x5Compartment();
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    roi.expression = "y";
+    roi.numRegions = 4;
+    common::VoxelF origin(0.0, 0.0, 0.0);
+    common::VolumeF voxelSize(1.0, 1.0, 1.0);
+    auto regions = simulate::computeVoxelRegions(roi, comp, origin, voxelSize);
+    REQUIRE(regions.size() == comp.nVoxels());
+
+    for (std::size_t i = 0; i < comp.nVoxels(); ++i) {
+      const auto &voxel = comp.getVoxel(i);
+      if (voxel.p.y() == 0) {
+        REQUIRE(regions[i] == 4);
+      } else if (voxel.p.y() == 4) {
+        REQUIRE(regions[i] == 0);
+      }
+    }
+  }
+
+  SECTION("computeVoxelRegions: image regions use direct values") {
+    auto comp = make5x5Compartment();
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Image;
+    roi.numRegions = 2;
+    roi.regionImage.reserve(25);
+    for (int y = 0; y < 5; ++y) {
+      for (int x = 0; x < 5; ++x) {
+        roi.regionImage.push_back(static_cast<std::size_t>(x));
+      }
+    }
+    common::VoxelF origin(0.0, 0.0, 0.0);
+    common::VolumeF voxelSize(1.0, 1.0, 1.0);
+    auto regions = simulate::computeVoxelRegions(roi, comp, origin, voxelSize);
+    REQUIRE(regions.size() == 25);
+    std::size_t count0 = 0, count1 = 0, count2 = 0;
+    for (auto region : regions) {
+      if (region == 0) {
+        ++count0;
+      } else if (region == 1) {
+        ++count1;
+      } else if (region == 2) {
+        ++count2;
+      }
+    }
+    REQUIRE(count0 == 15);
+    REQUIRE(count1 == 5);
+    REQUIRE(count2 == 5);
+  }
+
+  SECTION("evaluateFeature: one region -> one scalar") {
+    simulate::FeatureDefinition feat;
+    feat.name = "avg_conc";
+    feat.compartmentId = "comp";
+    feat.speciesId = "A";
+    feat.roi.roiType = simulate::RoiType::Analytic;
+    feat.roi.numRegions = 1;
+    feat.reduction = simulate::ReductionOp::Average;
+
+    std::vector<double> concs = {2.0, 4.0, 6.0, 8.0, 10.0};
+    std::vector<std::size_t> regions = {1, 1, 1, 1, 1};
+    auto results = simulate::evaluateFeature(feat, concs, regions);
+    REQUIRE(results.size() == 1);
+    REQUIRE(results[0] == dbl_approx(6.0));
+  }
+
+  SECTION("evaluateFeature: 3 regions -> 3 scalars") {
+    simulate::FeatureDefinition feat;
+    feat.name = "regioned";
+    feat.compartmentId = "comp";
+    feat.speciesId = "A";
+    feat.roi.roiType = simulate::RoiType::Image;
+    feat.roi.numRegions = 3;
+    feat.reduction = simulate::ReductionOp::Sum;
+
+    std::vector<double> concs = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    std::vector<std::size_t> regions = {1, 2, 3, 1, 2, 3};
+    auto results = simulate::evaluateFeature(feat, concs, regions);
+    REQUIRE(results.size() == 3);
+    REQUIRE(results[0] == dbl_approx(5.0));
+    REQUIRE(results[1] == dbl_approx(7.0));
+    REQUIRE(results[2] == dbl_approx(9.0));
+  }
+
+  SECTION("evaluateFeature: excluded voxels use region 0") {
+    simulate::FeatureDefinition feat;
+    feat.name = "partial";
+    feat.compartmentId = "comp";
+    feat.speciesId = "A";
+    feat.roi.roiType = simulate::RoiType::Analytic;
+    feat.roi.numRegions = 1;
+    feat.reduction = simulate::ReductionOp::Average;
+
+    std::vector<double> concs = {10.0, 20.0, 30.0, 40.0};
+    std::vector<std::size_t> regions = {1, 0, 1, 0};
+    auto results = simulate::evaluateFeature(feat, concs, regions);
+    REQUIRE(results.size() == 1);
+    REQUIRE(results[0] == dbl_approx(20.0));
+  }
+
+  SECTION("evaluateFeature: depth regions with reduction") {
+    simulate::FeatureDefinition feat;
+    feat.name = "depth_max";
+    feat.compartmentId = "comp";
+    feat.speciesId = "A";
+    feat.roi.roiType = simulate::RoiType::Depth;
+    feat.roi.numRegions = 2;
+    feat.reduction = simulate::ReductionOp::Max;
+
+    std::vector<double> concs = {1.0, 5.0, 3.0, 7.0, 2.0};
+    std::vector<std::size_t> regions = {1, 1, 1, 2, 2};
+    auto results = simulate::evaluateFeature(feat, concs, regions);
+    REQUIRE(results.size() == 2);
+    REQUIRE(results[0] == dbl_approx(5.0));
+    REQUIRE(results[1] == dbl_approx(7.0));
+  }
+}

--- a/core/simulate/src/feature_options.cpp
+++ b/core/simulate/src/feature_options.cpp
@@ -1,0 +1,81 @@
+#include "sme/feature_options.hpp"
+#include "sme/id.hpp"
+#include <algorithm>
+
+namespace sme::simulate {
+
+std::string toString(RoiType roiType) {
+  using enum RoiType;
+  switch (roiType) {
+  case Analytic:
+    return "Analytic";
+  case Image:
+    return "Image";
+  case Depth:
+    return "Depth";
+  case AxisSlices:
+    return "Axis slices";
+  default:
+    return "";
+  }
+}
+
+std::string toString(ReductionOp reduction) {
+  using enum ReductionOp;
+  switch (reduction) {
+  case Average:
+    return "Average";
+  case Sum:
+    return "Sum";
+  case Min:
+    return "Min";
+  case Max:
+    return "Max";
+  default:
+    return "";
+  }
+}
+
+int getRoiParameterInt(const RoiSettings &roi, const std::string &key,
+                       int defaultValue) {
+  auto it = roi.parameters.find(key);
+  return it == roi.parameters.end() ? defaultValue : it->second.intValue;
+}
+
+double getRoiParameterDouble(const RoiSettings &roi, const std::string &key,
+                             double defaultValue) {
+  auto it = roi.parameters.find(key);
+  return it == roi.parameters.end() ? defaultValue : it->second.doubleValue;
+}
+
+bool getRoiParameterBool(const RoiSettings &roi, const std::string &key,
+                         bool defaultValue) {
+  return getRoiParameterInt(roi, key, defaultValue ? 1 : 0) != 0;
+}
+
+void setRoiParameterInt(RoiSettings &roi, const std::string &key, int value) {
+  roi.parameters[key].intValue = value;
+}
+
+void setRoiParameterDouble(RoiSettings &roi, const std::string &key,
+                           double value) {
+  roi.parameters[key].doubleValue = value;
+}
+
+void setRoiParameterBool(RoiSettings &roi, const std::string &key, bool value) {
+  setRoiParameterInt(roi, key, value ? 1 : 0);
+}
+
+std::string
+makeUniqueFeatureId(const std::string &name,
+                    const std::vector<FeatureDefinition> &existingFeatures) {
+  return sme::common::makeUnique(
+      sme::common::nameToSId(name, "feature"),
+      [&existingFeatures](const std::string &candidate) {
+        return std::ranges::none_of(
+            existingFeatures,
+            [&candidate](const auto &f) { return f.id == candidate; });
+      });
+}
+
+} // namespace sme::simulate

--- a/core/simulate/src/feature_options_t.cpp
+++ b/core/simulate/src/feature_options_t.cpp
@@ -1,0 +1,141 @@
+#include "catch_wrapper.hpp"
+#include "sme/feature_options.hpp"
+#include <cereal/archives/json.hpp>
+#include <sstream>
+
+using namespace sme;
+
+TEST_CASE("FeatureOptions",
+          "[core/simulate/feature_options][core/simulate][core][feature_"
+          "options]") {
+  SECTION("toString helpers") {
+    REQUIRE(simulate::toString(simulate::RoiType::Analytic) == "Analytic");
+    REQUIRE(simulate::toString(simulate::RoiType::Image) == "Image");
+    REQUIRE(simulate::toString(simulate::RoiType::Depth) == "Depth");
+    REQUIRE(simulate::toString(simulate::RoiType::AxisSlices) == "Axis slices");
+    REQUIRE(simulate::toString(simulate::ReductionOp::Average) == "Average");
+    REQUIRE(simulate::toString(simulate::ReductionOp::Sum) == "Sum");
+    REQUIRE(simulate::toString(simulate::ReductionOp::Min) == "Min");
+    REQUIRE(simulate::toString(simulate::ReductionOp::Max) == "Max");
+  }
+  SECTION("RoiSettings serialization round-trip") {
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Image;
+    roi.expression = "int(x > 1)";
+    roi.numRegions = 5;
+    roi.regionImage = {0, 1, 2, 3, 0, 1};
+    simulate::setRoiParameterInt(roi, simulate::roi_param::axis, 2);
+    simulate::setRoiParameterInt(roi, simulate::roi_param::depthThicknessVoxels,
+                                 3);
+    simulate::setRoiParameterDouble(roi, "double_param", 1.5);
+    simulate::setRoiParameterBool(roi, "bool_param", true);
+
+    std::stringstream ss;
+    {
+      cereal::JSONOutputArchive oar(ss);
+      oar(roi);
+    }
+    std::string json = ss.str();
+    simulate::RoiSettings roi2;
+    {
+      std::istringstream iss(json);
+      cereal::JSONInputArchive iar(iss);
+      iar(roi2);
+    }
+    REQUIRE(roi2.roiType == simulate::RoiType::Image);
+    REQUIRE(roi2.expression == "int(x > 1)");
+    REQUIRE(roi2.numRegions == 5);
+    REQUIRE(roi2.regionImage == std::vector<std::size_t>{0, 1, 2, 3, 0, 1});
+    REQUIRE(simulate::getRoiParameterInt(roi2, simulate::roi_param::axis, 0) ==
+            2);
+    REQUIRE(simulate::getRoiParameterInt(
+                roi2, simulate::roi_param::depthThicknessVoxels, 1) == 3);
+    REQUIRE(simulate::getRoiParameterDouble(roi2, "double_param", 0.0) ==
+            dbl_approx(1.5));
+    REQUIRE(simulate::getRoiParameterBool(roi2, "bool_param", false) == true);
+  }
+  SECTION("FeatureDefinition serialization round-trip") {
+    simulate::FeatureDefinition feat;
+    feat.id = "core_concentration";
+    feat.name = "core_concentration";
+    feat.compartmentId = "comp1";
+    feat.speciesId = "specA";
+    feat.roi.roiType = simulate::RoiType::AxisSlices;
+    feat.roi.numRegions = 4;
+    simulate::setRoiParameterInt(feat.roi, simulate::roi_param::axis, 2);
+    feat.reduction = simulate::ReductionOp::Max;
+
+    std::stringstream ss;
+    {
+      cereal::JSONOutputArchive oar(ss);
+      oar(feat);
+    }
+    std::string json = ss.str();
+    simulate::FeatureDefinition feat2;
+    {
+      std::istringstream iss(json);
+      cereal::JSONInputArchive iar(iss);
+      iar(feat2);
+    }
+    REQUIRE(feat2.id == "core_concentration");
+    REQUIRE(feat2.name == "core_concentration");
+    REQUIRE(feat2.compartmentId == "comp1");
+    REQUIRE(feat2.speciesId == "specA");
+    REQUIRE(feat2.roi.roiType == simulate::RoiType::AxisSlices);
+    REQUIRE(feat2.roi.numRegions == 4);
+    REQUIRE(simulate::getRoiParameterInt(feat2.roi, simulate::roi_param::axis,
+                                         0) == 2);
+    REQUIRE(feat2.reduction == simulate::ReductionOp::Max);
+  }
+  SECTION("FeatureResult serialization round-trip") {
+    simulate::FeatureResult res;
+    res.values = {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
+
+    std::stringstream ss;
+    {
+      cereal::JSONOutputArchive oar(ss);
+      oar(res);
+    }
+    std::string json = ss.str();
+    simulate::FeatureResult res2;
+    {
+      std::istringstream iss(json);
+      cereal::JSONInputArchive iar(iss);
+      iar(res2);
+    }
+    REQUIRE(res2.values.size() == 2);
+    REQUIRE(res2.values[0] == std::vector<double>{1.0, 2.0, 3.0});
+    REQUIRE(res2.values[1] == std::vector<double>{4.0, 5.0, 6.0});
+  }
+  SECTION("default values") {
+    simulate::RoiSettings roi;
+    REQUIRE(roi.roiType == simulate::RoiType::Analytic);
+    REQUIRE(roi.expression == "1");
+    REQUIRE(roi.numRegions == 1);
+    REQUIRE(roi.regionImage.empty());
+    REQUIRE(roi.parameters.empty());
+    REQUIRE(simulate::getRoiParameterInt(roi, "missing", 3) == 3);
+    REQUIRE(simulate::getRoiParameterDouble(roi, "missing", 2.0) ==
+            dbl_approx(2.0));
+    REQUIRE(simulate::getRoiParameterBool(roi, "missing", true) == true);
+
+    simulate::FeatureDefinition feat;
+    REQUIRE(feat.id.empty());
+    REQUIRE(feat.name.empty());
+    REQUIRE(feat.compartmentId.empty());
+    REQUIRE(feat.speciesId.empty());
+    REQUIRE(feat.reduction == simulate::ReductionOp::Average);
+
+    simulate::FeatureResult res;
+    REQUIRE(res.values.empty());
+  }
+  SECTION("makeUniqueFeatureId") {
+    std::vector<simulate::FeatureDefinition> features{
+        {.id = "feature_a", .name = "feature a"},
+        {.id = "feature_a_", .name = "feature a_"}};
+    REQUIRE(simulate::makeUniqueFeatureId("feature a", features) ==
+            "feature_a__");
+    REQUIRE(simulate::makeUniqueFeatureId("123", {}) == "_123");
+    REQUIRE(simulate::makeUniqueFeatureId("!@#", {}) == "feature");
+  }
+}

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -3,6 +3,7 @@
 #include "sme/logger.hpp"
 #include "sme/model.hpp"
 #include "sme/utils.hpp"
+#include <fmt/core.h>
 #include <iostream>
 #include <pagmo/algorithms/bee_colony.hpp>
 #include <pagmo/algorithms/de.hpp>
@@ -73,6 +74,73 @@ getOptTimesteps(const OptimizeOptions &options) {
     }
   }
   return optTimesteps;
+}
+
+static FeatureOptCost resolveFeatureOptCost(const sme::model::Model &model,
+                                            const OptCost &optCost,
+                                            const common::Volume &imageSize) {
+  FeatureOptCost featureOptCost;
+  if (optCost.featureId.empty()) {
+    featureOptCost.errorMessage =
+        "Optimization: Feature target is missing a feature id";
+    return featureOptCost;
+  }
+  const auto featureIndex =
+      model.getFeatures().getIndexFromId(optCost.featureId);
+  if (featureIndex >= model.getFeatures().size()) {
+    featureOptCost.errorMessage =
+        fmt::format("Optimization: Feature '{}' not found", optCost.featureId);
+    return featureOptCost;
+  }
+  if (!model.getFeatures().isValid(featureIndex)) {
+    featureOptCost.errorMessage = fmt::format(
+        "Optimization: Feature '{}' is not valid", optCost.featureId);
+    return featureOptCost;
+  }
+  featureOptCost.feature = model.getFeatures().getFeatures()[featureIndex];
+  if (featureOptCost.feature.speciesId != optCost.id) {
+    featureOptCost.errorMessage =
+        fmt::format("Optimization: Feature '{}' does not match species '{}'",
+                    optCost.featureId, optCost.id);
+    return featureOptCost;
+  }
+  const auto *comp = model.getCompartments().getCompartment(
+      featureOptCost.feature.compartmentId.c_str());
+  if (comp == nullptr) {
+    featureOptCost.errorMessage =
+        fmt::format("Optimization: Feature '{}' compartment '{}' not found",
+                    optCost.featureId, featureOptCost.feature.compartmentId);
+    return featureOptCost;
+  }
+  featureOptCost.voxelRegions =
+      model.getFeatures().getVoxelRegions(featureIndex);
+  featureOptCost.imageIndices.reserve(comp->nVoxels());
+  std::vector<double> targetConcentrations(comp->nVoxels(), 0.0);
+  const auto &voxels = comp->getVoxels();
+  if (!optCost.targetValues.empty()) {
+    if (optCost.targetValues.size() != imageSize.nVoxels()) {
+      featureOptCost.errorMessage = fmt::format(
+          "Optimization: Target values size {} does not match image size {}",
+          optCost.targetValues.size(), imageSize.nVoxels());
+      return featureOptCost;
+    }
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+      const auto imageIndex =
+          common::voxelArrayIndex(imageSize, voxels[i], true);
+      featureOptCost.imageIndices.push_back(imageIndex);
+      targetConcentrations[i] = optCost.targetValues[imageIndex];
+    }
+  } else {
+    for (const auto &voxel : voxels) {
+      featureOptCost.imageIndices.push_back(
+          common::voxelArrayIndex(imageSize, voxel, true));
+    }
+  }
+  featureOptCost.targetFeatureValues =
+      evaluateFeature(featureOptCost.feature, targetConcentrations,
+                      featureOptCost.voxelRegions);
+  featureOptCost.valid = true;
+  return featureOptCost;
 }
 
 static std::unique_ptr<pagmo::algorithm>
@@ -181,6 +249,8 @@ Optimization::Optimization(sme::model::Model &model) {
   optConstData->xmlModel = model.getXml().toStdString();
   optConstData->optimizeOptions = model.getOptimizeOptions();
   optConstData->optTimesteps = getOptTimesteps(options);
+  optConstData->featureOptCosts.resize(
+      optConstData->optimizeOptions.optCosts.size());
   for (const auto &cost : model.getOptimizeOptions().optCosts) {
     if (cost.targetValues.empty()) {
       // empty vector is implicitly zero everywhere,
@@ -190,6 +260,19 @@ Optimization::Optimization(sme::model::Model &model) {
     } else {
       optConstData->maxTargetValues.push_back(
           sme::common::max(cost.targetValues));
+    }
+  }
+  for (std::size_t i = 0; i < optConstData->optimizeOptions.optCosts.size();
+       ++i) {
+    const auto &optCost = optConstData->optimizeOptions.optCosts[i];
+    if (optCost.optCostType != OptCostType::Feature) {
+      continue;
+    }
+    optConstData->featureOptCosts[i] =
+        resolveFeatureOptCost(model, optCost, optConstData->imageSize);
+    if (!optConstData->featureOptCosts[i].valid) {
+      errorMessage = optConstData->featureOptCosts[i].errorMessage;
+      return;
     }
   }
   modelQueue = std::make_unique<sme::simulate::ThreadsafeModelQueue>();

--- a/core/simulate/src/optimize_impl.cpp
+++ b/core/simulate/src/optimize_impl.cpp
@@ -3,6 +3,61 @@
 
 namespace sme::simulate {
 
+namespace {
+
+double calculateFieldCost(const OptCost &optCost,
+                          const std::vector<double> &values) {
+  double cost{0.0};
+  if (optCost.targetValues.empty()) {
+    for (auto value : values) {
+      cost += value * value;
+    }
+    return cost;
+  }
+  if (values.size() != optCost.targetValues.size()) {
+    SPDLOG_ERROR("Mismatch between size of values ({}) and target values ({})",
+                 values.size(), optCost.targetValues.size());
+    throw std::invalid_argument("Optimization: Target values size mismatch");
+  }
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    double diff{values[i] - optCost.targetValues[i]};
+    if (optCost.optCostDiffType == OptCostDiffType::Relative) {
+      diff /= (std::abs(optCost.targetValues[i]) + optCost.epsilon);
+    }
+    cost += diff * diff;
+  }
+  return cost;
+}
+
+double calculateFeatureCost(const OptCost &optCost,
+                            const FeatureOptCost &featureOptCost,
+                            const std::vector<double> &currentConcentrations) {
+  if (!featureOptCost.valid) {
+    throw std::invalid_argument(featureOptCost.errorMessage.empty()
+                                    ? "Optimization: Invalid feature target"
+                                    : featureOptCost.errorMessage);
+  }
+  const auto featureValues =
+      evaluateFeature(featureOptCost.feature, currentConcentrations,
+                      featureOptCost.voxelRegions);
+  if (featureValues.size() != featureOptCost.targetFeatureValues.size()) {
+    throw std::invalid_argument(
+        "Optimization: Feature target values size mismatch");
+  }
+  double cost{0.0};
+  for (std::size_t i = 0; i < featureValues.size(); ++i) {
+    double diff{featureValues[i] - featureOptCost.targetFeatureValues[i]};
+    if (optCost.optCostDiffType == OptCostDiffType::Relative) {
+      diff /=
+          (std::abs(featureOptCost.targetFeatureValues[i]) + optCost.epsilon);
+    }
+    cost += diff * diff;
+  }
+  return cost;
+}
+
+} // namespace
+
 void applyParameters(const pagmo::vector_double &values,
                      sme::model::Model *model) {
   const auto &optParams{model->getOptimizeOptions().optParams};
@@ -32,51 +87,59 @@ void applyParameters(const pagmo::vector_double &values,
   }
 }
 
-double calculateCosts(const std::vector<OptCost> &optCosts,
+double calculateCosts(const OptConstData &optConstData,
                       const std::vector<std::size_t> &optCostIndices,
                       const sme::simulate::Simulation &sim,
                       std::vector<std::vector<double>> &currentTargets) {
   double cost{0};
   for (const auto &optCostIndex : optCostIndices) {
-    const auto &optCost{optCosts[optCostIndex]};
+    const auto &optCost{optConstData.optimizeOptions.optCosts[optCostIndex]};
     auto &values{currentTargets[optCostIndex]};
     auto compIndex{optCost.compartmentIndex};
     auto specIndex{optCost.speciesIndex};
+    double optCostValue{0.0};
     switch (optCost.optCostType) {
     case OptCostType::Concentration:
       values = sim.getConcArray(sim.getTimePoints().size() - 1, compIndex,
                                 specIndex);
+      optCostValue = calculateFieldCost(optCost, values);
       break;
     case OptCostType::ConcentrationDcdt:
       values = sim.getDcdtArray(compIndex, specIndex);
+      optCostValue = calculateFieldCost(optCost, values);
       break;
-    default:
-      throw std::invalid_argument("Optimization: Invalid OptCostType");
-    }
-    if (optCost.targetValues.empty()) {
-      // default target is zero if not specified
-      for (auto value : values) {
-        cost += value * value;
-      }
-    } else {
-      if (values.size() != optCost.targetValues.size()) {
+    case OptCostType::Feature:
+      values = sim.getConcArray(sim.getTimePoints().size() - 1, compIndex,
+                                specIndex);
+      if (!optCost.targetValues.empty() &&
+          values.size() != optCost.targetValues.size()) {
         SPDLOG_ERROR(
             "Mismatch between size of values ({}) and target values ({})",
             values.size(), optCost.targetValues.size());
         throw std::invalid_argument(
             "Optimization: Target values size mismatch");
       }
-      for (std::size_t i = 0; i < values.size(); ++i) {
-        double diff{values[i] - optCost.targetValues[i]};
-        if (optCost.optCostDiffType == OptCostDiffType::Relative) {
-          diff /= (std::abs(optCost.targetValues[i]) + optCost.epsilon);
-        }
-        cost += diff * diff;
-      }
+      optCostValue = calculateFeatureCost(
+          optCost, optConstData.featureOptCosts[optCostIndex],
+          sim.getConc(sim.getTimePoints().size() - 1, compIndex, specIndex));
+      break;
+    default:
+      throw std::invalid_argument("Optimization: Invalid OptCostType");
     }
+    cost += optCostValue;
     cost *= optCost.weight;
   }
   return cost;
+}
+
+double calculateCosts(const std::vector<OptCost> &optCosts,
+                      const std::vector<std::size_t> &optCostIndices,
+                      const sme::simulate::Simulation &sim,
+                      std::vector<std::vector<double>> &currentTargets) {
+  OptConstData optConstData;
+  optConstData.optimizeOptions.optCosts = optCosts;
+  optConstData.featureOptCosts.resize(optCosts.size());
+  return calculateCosts(optConstData, optCostIndices, sim, currentTargets);
 }
 
 PagmoUDP::PagmoUDP(const OptConstData *optConstData,
@@ -109,8 +172,8 @@ PagmoUDP::fitness(const pagmo::vector_double &dv) const {
     if (m_optimization->getIsStopping()) {
       return {std::numeric_limits<double>::max()};
     }
-    cost += calculateCosts(m_optConstData->optimizeOptions.optCosts,
-                           optTimestep.optCostIndices, sim, currentTargets);
+    cost += calculateCosts(*m_optConstData, optTimestep.optCostIndices, sim,
+                           currentTargets);
   }
   if (m_optimization->setBestResults(cost, std::move(currentTargets))) {
     SPDLOG_INFO("Updated current best results with cost {}", cost);

--- a/core/simulate/src/optimize_impl.hpp
+++ b/core/simulate/src/optimize_impl.hpp
@@ -11,6 +11,10 @@ namespace sme::simulate {
 void applyParameters(const pagmo::vector_double &values,
                      sme::model::Model *model);
 
+double calculateCosts(const OptConstData &optConstData,
+                      const std::vector<std::size_t> &optCostIndices,
+                      const sme::simulate::Simulation &sim,
+                      std::vector<std::vector<double>> &currentTargets);
 double calculateCosts(const std::vector<OptCost> &optCosts,
                       const std::vector<std::size_t> &optCostIndices,
                       const sme::simulate::Simulation &sim,

--- a/core/simulate/src/optimize_impl_t.cpp
+++ b/core/simulate/src/optimize_impl_t.cpp
@@ -27,6 +27,50 @@ static double sum_of_square_differences(const std::vector<double> &a,
   return sum;
 }
 
+static simulate::OptConstData
+makeOptConstData(const model::Model &model,
+                 const std::vector<simulate::OptCost> &optCosts) {
+  simulate::OptConstData optConstData;
+  optConstData.imageSize = model.getGeometry().getImages().volume();
+  optConstData.optimizeOptions.optCosts = optCosts;
+  optConstData.featureOptCosts.resize(optCosts.size());
+  for (std::size_t i = 0; i < optCosts.size(); ++i) {
+    const auto &optCost = optCosts[i];
+    if (optCost.optCostType != simulate::OptCostType::Feature) {
+      continue;
+    }
+    const auto featureIndex =
+        model.getFeatures().getIndexFromId(optCost.featureId);
+    if (featureIndex >= model.getFeatures().size()) {
+      continue;
+    }
+    auto &featureOptCost = optConstData.featureOptCosts[i];
+    featureOptCost.feature = model.getFeatures().getFeatures()[featureIndex];
+    featureOptCost.voxelRegions =
+        model.getFeatures().getVoxelRegions(featureIndex);
+    const auto *comp = model.getCompartments().getCompartment(
+        featureOptCost.feature.compartmentId.c_str());
+    if (comp == nullptr) {
+      continue;
+    }
+    std::vector<double> targetConcentrations(comp->nVoxels(), 0.0);
+    const auto &voxels = comp->getVoxels();
+    for (std::size_t j = 0; j < voxels.size(); ++j) {
+      const auto imageIndex =
+          common::voxelArrayIndex(optConstData.imageSize, voxels[j], true);
+      featureOptCost.imageIndices.push_back(imageIndex);
+      if (!optCost.targetValues.empty()) {
+        targetConcentrations[j] = optCost.targetValues[imageIndex];
+      }
+    }
+    featureOptCost.targetFeatureValues =
+        simulate::evaluateFeature(featureOptCost.feature, targetConcentrations,
+                                  featureOptCost.voxelRegions);
+    featureOptCost.valid = true;
+  }
+  return optConstData;
+}
+
 TEST_CASE("Optimize applyParameters: parameters",
           "[core/simulate/optimize][core/simulate][core][optimize]") {
   auto model{getExampleModel(Mod::VerySimpleModel)};
@@ -97,8 +141,8 @@ TEST_CASE("Optimize calculateCosts: zero or no target values",
   std::vector<std::vector<double>> currentTargets(1, std::vector<double>{});
 
   // costs are zero if no OptCost supplied:
-  REQUIRE(simulate::calculateCosts({}, {}, sim, currentTargets) ==
-          dbl_approx(0.0));
+  REQUIRE(simulate::calculateCosts(std::vector<simulate::OptCost>{}, {}, sim,
+                                   currentTargets) == dbl_approx(0.0));
 
   // sum over initial concentration of A to get costConc vs 0
   auto conc{model.getSpecies().getField("A")->getConcentration()};
@@ -358,4 +402,53 @@ TEST_CASE("Optimize calculateCosts: invalid target values",
   optCostInvalid.targetValues = std::vector<double>(correctSize + 1, 1.5);
   REQUIRE_THROWS(
       simulate::calculateCosts({optCostInvalid}, {0}, sim, currentTargets));
+}
+
+TEST_CASE("Optimize calculateCosts: feature target values",
+          "[core/simulate/optimize][core/simulate][core][optimize]") {
+  auto model{getExampleModel(Mod::ABtoC)};
+  model.getSimulationSettings().simulatorType =
+      sme::simulate::SimulatorType::Pixel;
+  model.getSpecies().setInitialConcentration("A", 0.73);
+  const auto *comp{model.getSpecies().getField("A")->getCompartment()};
+  simulate::RoiSettings roi;
+  roi.roiType = simulate::RoiType::Analytic;
+  roi.expression = "1";
+  auto featureIndex = model.getFeatures().add("mean_A", comp->getId(), "A", roi,
+                                              simulate::ReductionOp::Average);
+  simulate::Simulation sim(model);
+  const auto compImgWidth{comp->getCompartmentImages()[0].width()};
+  const auto compImgHeight{comp->getCompartmentImages()[0].height()};
+  std::vector<double> target(
+      static_cast<std::size_t>(compImgWidth * compImgHeight), 0.0);
+  constexpr double targetPixel{2.0};
+  for (const auto &voxel : comp->getVoxels()) {
+    target[static_cast<std::size_t>(voxel.p.x()) +
+           static_cast<std::size_t>(compImgWidth) *
+               static_cast<std::size_t>(compImgHeight - 1 - voxel.p.y())] =
+        targetPixel;
+  }
+
+  simulate::OptCost optCostFeature{};
+  optCostFeature.optCostType = simulate::OptCostType::Feature;
+  optCostFeature.optCostDiffType = simulate::OptCostDiffType::Absolute;
+  optCostFeature.name = "name";
+  optCostFeature.id = "A";
+  optCostFeature.compartmentIndex = 0;
+  optCostFeature.speciesIndex = 0;
+  optCostFeature.targetValues = target;
+  optCostFeature.featureId = model.getFeatures().getFeatures()[featureIndex].id;
+
+  auto optConstData = makeOptConstData(model, {optCostFeature});
+  std::vector<std::vector<double>> currentTargets(1, std::vector<double>{});
+  REQUIRE(
+      simulate::calculateCosts(optConstData, {0}, sim, currentTargets) ==
+      Catch::Approx((targetPixel - 0.73) * (targetPixel - 0.73)).margin(1e-12));
+  REQUIRE(currentTargets[0] ==
+          sim.getConcArray(sim.getTimePoints().size() - 1, 0, 0));
+
+  optCostFeature.featureId = "missing_feature";
+  auto invalidOptConstData = makeOptConstData(model, {optCostFeature});
+  REQUIRE_THROWS(
+      simulate::calculateCosts(invalidOptConstData, {0}, sim, currentTargets));
 }

--- a/core/simulate/src/optimize_t.cpp
+++ b/core/simulate/src/optimize_t.cpp
@@ -497,6 +497,13 @@ TEST_CASE("Save and load model with optimization settings",
   optimizeOptions.optParams.push_back(
       {sme::simulate::OptParamType::DiffusionConstant, "optParamDiff", "A", "",
        0.1, 0.2});
+  simulate::RoiSettings roi;
+  roi.roiType = simulate::RoiType::Analytic;
+  roi.expression = "1";
+  auto featureIndex = model.getFeatures().add(
+      "mean_C", model.getSpecies().getField("C")->getCompartment()->getId(),
+      "C", roi, simulate::ReductionOp::Average);
+  const auto featureId{model.getFeatures().getFeatures()[featureIndex].id};
   // optimization cost: absolute difference of concentration of species C from
   // zero, after simulating for time 1
   optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Concentration,
@@ -508,6 +515,17 @@ TEST_CASE("Save and load model with optimization settings",
                                       0,
                                       2,
                                       {}});
+  optimizeOptions.optCosts.push_back({sme::simulate::OptCostType::Feature,
+                                      simulate::OptCostDiffType::Relative,
+                                      "optCostFeature",
+                                      "C",
+                                      2.0,
+                                      0.7,
+                                      0,
+                                      2,
+                                      {},
+                                      1e-14,
+                                      featureId});
   model.getOptimizeOptions() = optimizeOptions;
   // export model as xml
   constexpr auto tempfilename{"test_optimize_load_save.xml"};
@@ -520,7 +538,7 @@ TEST_CASE("Save and load model with optimization settings",
           sme::simulate::OptAlgorithmType::ABC);
   REQUIRE(options.optAlgorithm.islands == 1);
   REQUIRE(options.optAlgorithm.population == 3);
-  REQUIRE(options.optCosts.size() == 1);
+  REQUIRE(options.optCosts.size() == 2);
   REQUIRE(options.optCosts[0].optCostType ==
           sme::simulate::OptCostType::Concentration);
   REQUIRE(options.optCosts[0].optCostDiffType ==
@@ -532,6 +550,21 @@ TEST_CASE("Save and load model with optimization settings",
   REQUIRE(options.optCosts[0].compartmentIndex == 0);
   REQUIRE(options.optCosts[0].speciesIndex == 2);
   REQUIRE(options.optCosts[0].targetValues.empty());
+  REQUIRE(options.optCosts[0].featureId.empty());
+  REQUIRE(options.optCosts[1].optCostType ==
+          sme::simulate::OptCostType::Feature);
+  REQUIRE(options.optCosts[1].optCostDiffType ==
+          simulate::OptCostDiffType::Relative);
+  REQUIRE(options.optCosts[1].name == "optCostFeature");
+  REQUIRE(options.optCosts[1].id == "C");
+  REQUIRE(options.optCosts[1].simulationTime == dbl_approx(2.0));
+  REQUIRE(options.optCosts[1].weight == dbl_approx(0.7));
+  REQUIRE(options.optCosts[1].compartmentIndex == 0);
+  REQUIRE(options.optCosts[1].speciesIndex == 2);
+  REQUIRE(options.optCosts[1].targetValues.empty());
+  REQUIRE(options.optCosts[1].featureId == featureId);
+  REQUIRE(reloadedModel.getFeatures().getIndexFromId(featureId) !=
+          reloadedModel.getFeatures().size());
   REQUIRE(options.optParams.size() == 2);
   REQUIRE(options.optParams[0].optParamType ==
           sme::simulate::OptParamType::ReactionParameter);

--- a/core/simulate/src/simulate.cpp
+++ b/core/simulate/src/simulate.cpp
@@ -319,6 +319,7 @@ void Simulation::updateConcentrations(double t) {
       maxS[is] = std::max(maxS[is], a.back()[is].max);
     }
   }
+  model.getFeatures().evaluateAtTimepoint(data->timePoints.size() - 1);
 }
 
 Simulation::Simulation(model::Model &smeModel)

--- a/core/simulate/src/simulate_data.cpp
+++ b/core/simulate/src/simulate_data.cpp
@@ -46,6 +46,7 @@ void SimulationData::clear() {
   concentrationMax.clear();
   concPadding.clear();
   xmlModel.clear();
+  featureResults.clear();
 }
 
 std::size_t SimulationData::size() const { return timePoints.size(); }
@@ -89,6 +90,9 @@ void SimulationData::reserve(std::size_t n) {
   avgMinMax.reserve(n);
   concentrationMax.reserve(n);
   concPadding.reserve(n);
+  for (auto &fr : featureResults) {
+    fr.values.reserve(n);
+  }
 }
 
 void SimulationData::pop_back() {
@@ -97,6 +101,11 @@ void SimulationData::pop_back() {
   avgMinMax.pop_back();
   concentrationMax.pop_back();
   concPadding.pop_back();
+  for (auto &fr : featureResults) {
+    if (!fr.values.empty()) {
+      fr.values.pop_back();
+    }
+  }
 }
 
 } // namespace sme::simulate

--- a/gui/dialogs/dialoganalytic.cpp
+++ b/gui/dialogs/dialoganalytic.cpp
@@ -10,15 +10,16 @@
 #include <QPushButton>
 
 DialogAnalytic::DialogAnalytic(
-    const QString &analyticExpression, DialogAnalyticDataType dataType,
+    const QString &analyticExpression, DialogAnalyticDataType analyticDataType,
     const sme::model::SpeciesGeometry &speciesGeometry,
     const sme::model::ModelParameters &modelParameters,
     const sme::model::ModelFunctions &modelFunctions, bool invertYAxis,
-    QWidget *parent)
+    std::size_t maxNumRegions, QWidget *parent)
     : QDialog(parent), ui{std::make_unique<Ui::DialogAnalytic>()},
       voxelSize(speciesGeometry.voxelSize),
       voxels(speciesGeometry.compartmentVoxels),
       physicalOrigin(speciesGeometry.physicalOrigin),
+      dataType(analyticDataType), numRegions(maxNumRegions),
       imgs{speciesGeometry.compartmentImageSize,
            QImage::Format_ARGB32_Premultiplied},
       qpi(speciesGeometry.compartmentImageSize,
@@ -35,10 +36,18 @@ DialogAnalytic::DialogAnalytic(
     setWindowTitle("Diffusion constant");
     valueLabel = "diffusion constant";
     valueUnit = units.getDiffusion();
+  } else if (dataType == DialogAnalyticDataType::RoiRegion) {
+    setWindowTitle("ROI regions");
+    valueLabel = "ROI region";
+    ui->lblImage->setWhatsThis(
+        "<h4>ROI regions</h4>"
+        "<p>A preview of the ROI regions resulting from the supplied analytic "
+        "expression.</p>");
   }
   imgs.setVoxelSize(speciesGeometry.voxelSize);
   imgs.fill(0);
   values.resize(voxels.size(), 0.0);
+  roiRegions.resize(voxels.size(), 0);
   // add x,y,z variables
   const auto &spatialCoordinates{modelParameters.getSpatialCoordinates()};
   ui->txtExpression->addVariable(spatialCoordinates.x.id,
@@ -145,7 +154,7 @@ void DialogAnalytic::txtExpression_mathChanged(const QString &math, bool valid,
   if (std::ranges::find_if(std::as_const(values), [](auto c) {
         return std::isnan(c) || std::isinf(c);
       }) != values.cend()) {
-    // if concentration contains NaN or inf, show error message
+    // if the expression contains NaN or inf, show error message
     ui->lblExpressionStatus->setText(
         QString("%1 contains inf (infinity) or NaN (Not a Number)")
             .arg(valueLabel));
@@ -155,8 +164,10 @@ void DialogAnalytic::txtExpression_mathChanged(const QString &math, bool valid,
     ui->lblImage->setImage(imgs);
     return;
   }
-  if (*std::ranges::min_element(std::as_const(values)) < 0) {
-    // if concentration contains negative values, show error message
+  if ((dataType == DialogAnalyticDataType::Concentration ||
+       dataType == DialogAnalyticDataType::DiffusionConstant) &&
+      *std::ranges::min_element(std::as_const(values)) < 0) {
+    // concentration-like quantities cannot contain negative values
     ui->lblExpressionStatus->setText(
         QString("%1 cannot be negative").arg(valueLabel));
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
@@ -171,12 +182,31 @@ void DialogAnalytic::txtExpression_mathChanged(const QString &math, bool valid,
   ui->btnExportImage->setEnabled(true);
   displayExpression = math.toStdString();
   variableExpression = ui->txtExpression->getVariableMath();
-  // normalise displayed pixel intensity to max concentration
-  double maxConc{sme::common::max(values)};
-  for (std::size_t i = 0; i < voxels.size(); ++i) {
-    int intensity = static_cast<int>(255 * values[i] / maxConc);
-    imgs[voxels[i].z].setPixel(voxels[i].p,
-                               qRgb(intensity, intensity, intensity));
+  if (dataType == DialogAnalyticDataType::RoiRegion) {
+    imgs.fill(0);
+    sme::common::indexedColors indexedColors;
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+      const auto region = static_cast<int>(values[i]);
+      if (region > 0 && static_cast<std::size_t>(region) <= numRegions) {
+        roiRegions[i] = static_cast<std::size_t>(region);
+        imgs[voxels[i].z].setPixel(voxels[i].p,
+                                   indexedColors[roiRegions[i] - 1].rgb());
+      } else {
+        roiRegions[i] = 0;
+        imgs[voxels[i].z].setPixel(voxels[i].p, qRgb(0, 0, 0));
+      }
+    }
+  } else {
+    // normalise displayed pixel intensity to max scalar value
+    const double maxValue{sme::common::max(values)};
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+      int intensity = 0;
+      if (maxValue > 0) {
+        intensity = static_cast<int>(255 * values[i] / maxValue);
+      }
+      imgs[voxels[i].z].setPixel(voxels[i].p,
+                                 qRgb(intensity, intensity, intensity));
+    }
   }
   ui->lblImage->setImage(imgs);
 }
@@ -191,21 +221,37 @@ void DialogAnalytic::lblImage_mouseOver(const sme::common::Voxel &voxel) {
     return;
   }
   auto physical = physicalPoint(voxel);
-  ui->lblConcentration->setText(
-      QString("x: %1 %4, y: %2 %4, z: %3 %4, %5: %6 %7")
-          .arg(physical.p.x())
-          .arg(physical.p.y())
-          .arg(physical.z)
-          .arg(lengthUnit)
-          .arg(valueLabel)
-          .arg(values[*index])
-          .arg(valueUnit));
+  if (dataType == DialogAnalyticDataType::RoiRegion) {
+    ui->lblConcentration->setText(
+        QString(
+            "x: %1 %4, y: %2 %4, z: %3 %4, expression value: %5, region: %6")
+            .arg(physical.p.x())
+            .arg(physical.p.y())
+            .arg(physical.z)
+            .arg(lengthUnit)
+            .arg(values[*index])
+            .arg(roiRegions[*index]));
+  } else {
+    ui->lblConcentration->setText(
+        QString("x: %1 %4, y: %2 %4, z: %3 %4, %5: %6 %7")
+            .arg(physical.p.x())
+            .arg(physical.p.y())
+            .arg(physical.z)
+            .arg(lengthUnit)
+            .arg(valueLabel)
+            .arg(values[*index])
+            .arg(valueUnit));
+  }
 }
 
 void DialogAnalytic::btnExportImage_clicked() {
+  QString exportLabel{valueLabel};
+  if (dataType == DialogAnalyticDataType::RoiRegion) {
+    exportLabel = "roi-regions";
+  }
   QString filename = QFileDialog::getSaveFileName(
-      this, QString("Export %1 slice as image").arg(valueLabel),
-      QString("%1.png").arg(valueLabel), "PNG (*.png)");
+      this, QString("Export %1 slice as image").arg(exportLabel),
+      QString("%1.png").arg(exportLabel), "PNG (*.png)");
   if (filename.isEmpty()) {
     return;
   }

--- a/gui/dialogs/dialoganalytic.hpp
+++ b/gui/dialogs/dialoganalytic.hpp
@@ -19,7 +19,11 @@ class ModelParameters;
 class ModelFunctions;
 } // namespace sme::model
 
-enum class DialogAnalyticDataType { Concentration, DiffusionConstant };
+enum class DialogAnalyticDataType {
+  Concentration,
+  DiffusionConstant,
+  RoiRegion
+};
 
 class DialogAnalytic : public QDialog {
   Q_OBJECT
@@ -30,7 +34,8 @@ public:
                           const sme::model::SpeciesGeometry &speciesGeometry,
                           const sme::model::ModelParameters &modelParameters,
                           const sme::model::ModelFunctions &modelFunctions,
-                          bool invertYAxis, QWidget *parent = nullptr);
+                          bool invertYAxis, std::size_t numRegions = 1,
+                          QWidget *parent = nullptr);
   ~DialogAnalytic() override;
   const std::string &getExpression() const;
   const QImage &getImage() const;
@@ -45,10 +50,13 @@ private:
   QString lengthUnit;
   QString valueUnit;
   QString valueLabel;
+  DialogAnalyticDataType dataType;
+  std::size_t numRegions;
 
   sme::common::ImageStack imgs;
   sme::geometry::VoxelIndexer qpi;
   std::vector<double> values;
+  std::vector<std::size_t> roiRegions;
   std::string displayExpression;
   std::string variableExpression;
   bool expressionIsValid = false;

--- a/gui/dialogs/dialoganalytic_t.cpp
+++ b/gui/dialogs/dialoganalytic_t.cpp
@@ -1,5 +1,6 @@
 #include "catch_wrapper.hpp"
 #include "dialoganalytic.hpp"
+#include "math_test_utils.hpp"
 #include "model_test_utils.hpp"
 #include "qplaintextmathedit.hpp"
 #include "qt_test_utils.hpp"
@@ -126,6 +127,33 @@ TEST_CASE("DialogAnalytic",
       sendMouseClick(widgets.chkScale);
       REQUIRE(dia.isExpressionValid() == true);
       REQUIRE(dia.getExpression() == "10");
+    }
+  }
+  SECTION("ROI region expression") {
+    auto model{getExampleModel(Mod::ABtoC)};
+    auto compartmentVoxels = std::vector<sme::common::Voxel>{
+        {5, 5, 0}, {5, 6, 0}, {5, 7, 0}, {6, 6, 0}, {6, 7, 0}};
+    DialogAnalytic dia("x - 10", DialogAnalyticDataType::RoiRegion,
+                       {{10, 10, 1},
+                        compartmentVoxels,
+                        {0.0, 0.0, 0.0},
+                        {1.0, 1.0, 1.0},
+                        model.getUnits()},
+                       model.getParameters(), model.getFunctions(), false, 3);
+    dia.show();
+    DialogAnalyticWidgets widgets(&dia);
+    REQUIRE(dia.isExpressionValid() == true);
+    REQUIRE(symEq(dia.getExpression(), "x - 10"));
+    SECTION("editing to another negative expression remains valid") {
+      sendKeyEvents(widgets.txtExpression,
+                    {"Delete", "x", " ", "-", " ", "1", "0"});
+      REQUIRE(dia.isExpressionValid() == true);
+      REQUIRE(symEq(dia.getExpression(), "x - 20"));
+    }
+    SECTION("invalid syntax still disables acceptance") {
+      sendKeyEvents(widgets.txtExpression, {"Delete", "("});
+      REQUIRE(dia.isExpressionValid() == false);
+      REQUIRE(dia.getExpression().empty() == true);
     }
   }
 }

--- a/gui/dialogs/dialogdisplayoptions.cpp
+++ b/gui/dialogs/dialogdisplayoptions.cpp
@@ -30,7 +30,7 @@ DialogDisplayOptions::DialogDisplayOptions(
     const std::vector<QStringList> &speciesNames,
     const sme::model::DisplayOptions &displayOptions,
     const std::vector<PlotWrapperObservable> &plotWrapperObservables,
-    QWidget *parent)
+    const QStringList &featureLineNames, QWidget *parent)
     : QDialog(parent), ui{std::make_unique<Ui::DialogDisplayOptions>()},
       nSpecies(displayOptions.showSpecies.size()),
       observables(plotWrapperObservables) {
@@ -56,6 +56,22 @@ DialogDisplayOptions::DialogDisplayOptions(
   }
   ls->expandAll();
   ui->chkShowMinMaxRanges->setChecked(displayOptions.showMinMax);
+  // populate feature lines
+  auto *lf = ui->listFeatures;
+  lf->clear();
+  bool hasFeatures = !featureLineNames.isEmpty();
+  lf->setVisible(hasFeatures);
+  for (int i = 0; i < featureLineNames.size(); ++i) {
+    auto *item = new QTreeWidgetItem(lf, QStringList({featureLineNames[i]}));
+    item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
+                   Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
+    bool visible =
+        i < static_cast<int>(displayOptions.showFeatures.size())
+            ? displayOptions.showFeatures[static_cast<std::size_t>(i)]
+            : true;
+    checkItem(item, visible);
+    lf->addTopLevelItem(item);
+  }
   for (const auto &observable : observables) {
     auto *obs =
         new QTreeWidgetItem(ui->listObservables, {observable.expression});
@@ -95,6 +111,15 @@ std::vector<bool> DialogDisplayOptions::getShowSpecies() const {
       checked.push_back(comp->child(is)->checkState(0) ==
                         Qt::CheckState::Checked);
     }
+  }
+  return checked;
+}
+
+std::vector<bool> DialogDisplayOptions::getShowFeatures() const {
+  std::vector<bool> checked;
+  for (int i = 0; i < ui->listFeatures->topLevelItemCount(); ++i) {
+    checked.push_back(ui->listFeatures->topLevelItem(i)->checkState(0) ==
+                      Qt::CheckState::Checked);
   }
   return checked;
 }

--- a/gui/dialogs/dialogdisplayoptions.hpp
+++ b/gui/dialogs/dialogdisplayoptions.hpp
@@ -22,9 +22,10 @@ public:
       const std::vector<QStringList> &speciesNames,
       const sme::model::DisplayOptions &displayOptions,
       const std::vector<PlotWrapperObservable> &plotWrapperObservables,
-      QWidget *parent = nullptr);
+      const QStringList &featureLineNames = {}, QWidget *parent = nullptr);
   ~DialogDisplayOptions();
   std::vector<bool> getShowSpecies() const;
+  std::vector<bool> getShowFeatures() const;
   bool getShowMinMax() const;
   bool getNormaliseOverAllTimepoints() const;
   bool getNormaliseOverAllSpecies() const;

--- a/gui/dialogs/dialogdisplayoptions.ui
+++ b/gui/dialogs/dialogdisplayoptions.ui
@@ -17,7 +17,97 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
+   <item row="0" column="0" colspan="3">
+    <widget class="QTreeWidget" name="listSpecies">
+     <property name="toolTip">
+      <string>Select which species should be displayed in the plot and the concentration images</string>
+     </property>
+     <column>
+      <property name="text">
+       <string>Species to display</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QTreeWidget" name="listFeatures">
+     <property name="toolTip">
+      <string>Select which features should be displayed in the plot</string>
+     </property>
+     <column>
+      <property name="text">
+       <string>Features to display</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QCheckBox" name="chkShowMinMaxRanges">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Show min/max species concentration ranges on plot</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QTreeWidget" name="listObservables">
+     <property name="toolTip">
+      <string>Add custom observables to display in the plot, which can be functions of the species and of time (t)</string>
+     </property>
+     <column>
+      <property name="text">
+       <string>Custom observables</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="btnAddObservable">
+     <property name="text">
+      <string>&amp;Add</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="btnEditObservable">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>&amp;Edit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QPushButton" name="btnRemoveObservable">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>&amp;Remove</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="3">
+    <widget class="QLabel" name="lblNormalise">
+     <property name="text">
+      <string>Normalise concentration image color intensity to:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QComboBox" name="cmbNormaliseOverAllSpecies">
      <item>
       <property name="text">
@@ -31,66 +121,7 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QTreeWidget" name="listSpecies">
-     <property name="toolTip">
-      <string>Select which species should be displayed in the plot and the concentration images</string>
-     </property>
-     <column>
-      <property name="text">
-       <string>Species to display</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="btnEditObservable">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>&amp;Edit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QCheckBox" name="chkShowMinMaxRanges">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&amp;Show min/max species concentration ranges on plot</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="btnAddObservable">
-     <property name="text">
-      <string>&amp;Add</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QPushButton" name="btnRemoveObservable">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>&amp;Remove</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="3">
-    <widget class="QLabel" name="lblNormalise">
-     <property name="text">
-      <string>Normalise concentration image color intensity to:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
+   <item row="7" column="1" colspan="2">
     <widget class="QComboBox" name="cmbNormaliseOverAllTimepoints">
      <item>
       <property name="text">
@@ -104,26 +135,7 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QTreeWidget" name="listObservables">
-     <property name="toolTip">
-      <string>Add custom observables to display in the plot, which can be functions of the species and of time (t)</string>
-     </property>
-     <column>
-      <property name="text">
-       <string>Custom observables</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="3">
+   <item row="8" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -137,6 +149,7 @@
  </widget>
  <tabstops>
   <tabstop>listSpecies</tabstop>
+  <tabstop>listFeatures</tabstop>
   <tabstop>chkShowMinMaxRanges</tabstop>
   <tabstop>listObservables</tabstop>
   <tabstop>btnAddObservable</tabstop>

--- a/gui/dialogs/dialogdisplayoptions_t.cpp
+++ b/gui/dialogs/dialogdisplayoptions_t.cpp
@@ -13,6 +13,7 @@ using namespace sme::test;
 struct DialogDisplayOptionsWidgets {
   explicit DialogDisplayOptionsWidgets(const DialogDisplayOptions *dialog) {
     GET_DIALOG_WIDGET(QTreeWidget, listSpecies);
+    GET_DIALOG_WIDGET(QTreeWidget, listFeatures);
     GET_DIALOG_WIDGET(QCheckBox, chkShowMinMaxRanges);
     GET_DIALOG_WIDGET(QTreeWidget, listObservables);
     GET_DIALOG_WIDGET(QPushButton, btnAddObservable);
@@ -22,6 +23,7 @@ struct DialogDisplayOptionsWidgets {
     GET_DIALOG_WIDGET(QComboBox, cmbNormaliseOverAllTimepoints);
   }
   QTreeWidget *listSpecies;
+  QTreeWidget *listFeatures;
   QCheckBox *chkShowMinMaxRanges;
   QTreeWidget *listObservables;
   QPushButton *btnAddObservable;
@@ -245,5 +247,49 @@ TEST_CASE("DialogDisplayOptions",
       REQUIRE(dia.getObservables()[0].expression == "s1_c1*2");
       REQUIRE(dia.getObservables()[0].visible == true);
     }
+  }
+  SECTION("Feature visibility") {
+    QStringList compartments{"c1"};
+    std::vector<QStringList> species;
+    species.push_back({"s1"});
+    sme::model::DisplayOptions opts;
+    opts.showSpecies = {true};
+    opts.showFeatures = {true, false, true};
+    QStringList featureNames{"feat1", "feat2 [region 1]", "feat2 [region 2]"};
+    DialogDisplayOptions dia(compartments, species, opts, {}, featureNames);
+    dia.show();
+    DialogDisplayOptionsWidgets widgets(&dia);
+    SECTION("initial state matches showFeatures") {
+      REQUIRE(dia.getShowFeatures().size() == 3);
+      REQUIRE(dia.getShowFeatures()[0] == true);
+      REQUIRE(dia.getShowFeatures()[1] == false);
+      REQUIRE(dia.getShowFeatures()[2] == true);
+    }
+    SECTION("user unchecks first feature") {
+      widgets.listFeatures->topLevelItem(0)->setCheckState(
+          0, Qt::CheckState::Unchecked);
+      REQUIRE(dia.getShowFeatures()[0] == false);
+      REQUIRE(dia.getShowFeatures()[1] == false);
+      REQUIRE(dia.getShowFeatures()[2] == true);
+    }
+    SECTION("user checks second feature") {
+      widgets.listFeatures->topLevelItem(1)->setCheckState(
+          0, Qt::CheckState::Checked);
+      REQUIRE(dia.getShowFeatures()[0] == true);
+      REQUIRE(dia.getShowFeatures()[1] == true);
+      REQUIRE(dia.getShowFeatures()[2] == true);
+    }
+  }
+  SECTION("No features hides list") {
+    QStringList compartments{"c1"};
+    std::vector<QStringList> species;
+    species.push_back({"s1"});
+    sme::model::DisplayOptions opts;
+    opts.showSpecies = {true};
+    DialogDisplayOptions dia(compartments, species, opts, {});
+    dia.show();
+    DialogDisplayOptionsWidgets widgets(&dia);
+    REQUIRE(widgets.listFeatures->isVisible() == false);
+    REQUIRE(dia.getShowFeatures().empty());
   }
 }

--- a/gui/dialogs/dialogimagedata.cpp
+++ b/gui/dialogs/dialogimagedata.cpp
@@ -9,6 +9,26 @@
 #include <QPushButton>
 #include <QToolTip>
 
+static QString quantityNameFor(DialogImageDataDataType dataType) {
+  switch (dataType) {
+  case DialogImageDataDataType::Concentration:
+    return "concentration";
+  case DialogImageDataDataType::ConcentrationRateOfChange:
+    return "rate of change of concentration";
+  case DialogImageDataDataType::DiffusionConstant:
+    return "diffusion constant";
+  }
+  return {};
+}
+
+static QString quantityTitleName(DialogImageDataDataType dataType) {
+  auto name = quantityNameFor(dataType);
+  if (!name.isEmpty()) {
+    name[0] = name[0].toUpper();
+  }
+  return name;
+}
+
 DialogImageData::DialogImageData(
     const std::vector<double> &dataArray,
     const sme::model::SpeciesGeometry &speciesGeometry, bool invertYAxis,
@@ -25,19 +45,15 @@ DialogImageData::DialogImageData(
   ui->lblImage->setZSlider(ui->slideZIndex);
   const auto &units = speciesGeometry.modelUnits;
   lengthUnit = units.getLength().name;
+  quantityName = quantityNameFor(dataType);
+  setWindowTitle(QString("%1 image data").arg(quantityTitleName(dataType)));
   if (dataType == DialogImageDataDataType::Concentration) {
-    setWindowTitle("Concentration image data");
-    quantityName = "concentration";
     quantityUnit = units.getConcentration();
   } else if (dataType == DialogImageDataDataType::ConcentrationRateOfChange) {
-    setWindowTitle("Concentration rate of change image data");
-    quantityName = "concentration rate of change";
     quantityUnit = QString("%1/%2")
                        .arg(units.getConcentration())
                        .arg(units.getTime().name);
   } else if (dataType == DialogImageDataDataType::DiffusionConstant) {
-    setWindowTitle("Diffusion constant image data");
-    quantityName = "diffusion constant";
     quantityUnit = units.getDiffusion();
   }
 
@@ -50,6 +66,8 @@ DialogImageData::DialogImageData(
 
   ui->lblMinConcUnits->setText(quantityUnit);
   ui->lblMaxConcUnits->setText(quantityUnit);
+  ui->lblMinConcLabel->setText(QString("Minimum %1").arg(quantityName));
+  ui->lblMaxConcLabel->setText(QString("Maximum %1").arg(quantityName));
   imgs.setVoxelSize(speciesGeometry.voxelSize);
   imgs.fill(0);
 

--- a/gui/dialogs/dialogimagedata.ui
+++ b/gui/dialogs/dialogimagedata.ui
@@ -218,7 +218,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Mininum concentration</string>
+          <string>Minimum concentration</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>

--- a/gui/dialogs/dialogimagedata_t.cpp
+++ b/gui/dialogs/dialogimagedata_t.cpp
@@ -18,6 +18,8 @@ using Catch::Matchers::ContainsSubstring;
 
 struct DialogImageDataWidgets {
   explicit DialogImageDataWidgets(const DialogImageData *dialog) {
+    GET_DIALOG_WIDGET(QLabel, lblMinConcLabel);
+    GET_DIALOG_WIDGET(QLabel, lblMaxConcLabel);
     GET_DIALOG_WIDGET(QLineEdit, txtMinConc);
     GET_DIALOG_WIDGET(QLineEdit, txtMaxConc);
     GET_DIALOG_WIDGET(QCheckBox, chkGrid);
@@ -30,6 +32,8 @@ struct DialogImageDataWidgets {
     GET_DIALOG_WIDGET(QLabelMouseTracker, lblImage);
     GET_DIALOG_WIDGET(QLabel, lblConcentration);
   }
+  QLabel *lblMinConcLabel;
+  QLabel *lblMaxConcLabel;
   QLineEdit *txtMinConc;
   QLineEdit *txtMaxConc;
   QCheckBox *chkGrid;
@@ -64,6 +68,8 @@ TEST_CASE("DialogImageData", "[gui/dialogs/concentrationimage][gui/"
 
     const auto text{widgets.lblConcentration->text()};
     const auto lengthUnit{units.getLength().name};
+    REQUIRE(widgets.lblMinConcLabel->text() == "Minimum concentration");
+    REQUIRE(widgets.lblMaxConcLabel->text() == "Maximum concentration");
     REQUIRE(text.contains(QString("x=7 %1").arg(lengthUnit)));
     REQUIRE(text.contains(QString("y=13 %1").arg(lengthUnit)));
     REQUIRE(text.contains(QString("z=19 %1").arg(lengthUnit)));
@@ -83,21 +89,28 @@ TEST_CASE("DialogImageData", "[gui/dialogs/concentrationimage][gui/"
   SECTION("rate of change of concentration array of 0's") {
     DialogImageData dia(std::vector<double>(9, 0.0), specGeom, false,
                         DialogImageDataDataType::ConcentrationRateOfChange);
+    DialogImageDataWidgets widgets(&dia);
     for (const auto &a : dia.getImageArray()) {
       REQUIRE(a == dbl_approx(0));
     }
-    REQUIRE_THAT(dia.windowTitle().toStdString(),
-                 ContainsSubstring("rate of change", Catch::CaseSensitive::No));
+    REQUIRE(dia.windowTitle() == "Rate of change of concentration image data");
+    REQUIRE(widgets.lblMinConcLabel->text() ==
+            "Minimum rate of change of concentration");
+    REQUIRE(widgets.lblMaxConcLabel->text() ==
+            "Maximum rate of change of concentration");
   }
-  SECTION("rate of change of concentration array of 0's") {
+  SECTION("diffusion constant array of 0's") {
     DialogImageData dia(std::vector<double>(9, 0.0), specGeom, false,
                         DialogImageDataDataType::DiffusionConstant);
+    DialogImageDataWidgets widgets(&dia);
     for (const auto &a : dia.getImageArray()) {
       REQUIRE(a == dbl_approx(0));
     }
     REQUIRE_THAT(
         dia.windowTitle().toStdString(),
         ContainsSubstring("diffusion constant", Catch::CaseSensitive::No));
+    REQUIRE(widgets.lblMinConcLabel->text() == "Minimum diffusion constant");
+    REQUIRE(widgets.lblMaxConcLabel->text() == "Maximum diffusion constant");
   }
   SECTION("concentration array of 1's") {
     DialogImageData dia(std::vector<double>(9, 1.0), specGeom);

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -5,26 +5,13 @@
 
 static QString toQStr(double x) { return QString::number(x, 'g', 14); }
 
-static int toIndex(sme::simulate::OptCostType optCostType) {
-  switch (optCostType) {
-  case sme::simulate::OptCostType::Concentration:
-    return 0;
-  case sme::simulate::OptCostType::ConcentrationDcdt:
-    return 1;
-  default:
-    return 0;
+static QString targetValuesText(sme::simulate::OptCostType optCostType,
+                                bool wrap = false) {
+  if (optCostType == sme::simulate::OptCostType::ConcentrationDcdt) {
+    return wrap ? "Rate of change\nof concentration"
+                : "Rate of change of concentration";
   }
-}
-
-static sme::simulate::OptCostType toOptCostTypeEnum(int index) {
-  switch (index) {
-  case 0:
-    return sme::simulate::OptCostType::Concentration;
-  case 1:
-    return sme::simulate::OptCostType::ConcentrationDcdt;
-  default:
-    return sme::simulate::OptCostType::Concentration;
-  }
+  return "Concentration";
 }
 
 static int toIndex(sme::simulate::OptCostDiffType optCostDiffType) {
@@ -73,17 +60,9 @@ DialogOptCost::DialogOptCost(
     } else {
       m_optCost = defaultOptCosts.front();
     }
-    ui->cmbCostType->setCurrentIndex(toIndex(m_optCost.optCostType));
-    ui->cmbDiffType->setCurrentIndex(toIndex(m_optCost.optCostDiffType));
-    ui->txtSimulationTime->setText(QString::number(m_optCost.simulationTime));
-    ui->txtWeight->setText(QString::number(m_optCost.weight));
-    ui->txtEpsilon->setText(QString::number(m_optCost.epsilon));
-    ui->txtEpsilon->setEnabled(m_optCost.optCostDiffType ==
-                               sme::simulate::OptCostDiffType::Relative);
-    updateImage();
     for (const auto &defaultOptCost : defaultOptCosts) {
       ui->cmbSpecies->addItem(defaultOptCost.name.c_str());
-      if (defaultOptCost.name == m_optCost.name) {
+      if (defaultOptCost.id == m_optCost.id) {
         cmbIndex = ui->cmbSpecies->count() - 1;
       }
     }
@@ -101,7 +80,14 @@ DialogOptCost::DialogOptCost(
             &DialogOptCost::txtWeight_editingFinished);
     connect(ui->txtEpsilon, &QLineEdit::editingFinished, this,
             &DialogOptCost::txtEpsilon_editingFinished);
+    ui->cmbDiffType->setCurrentIndex(toIndex(m_optCost.optCostDiffType));
+    ui->txtSimulationTime->setText(QString::number(m_optCost.simulationTime));
+    ui->txtWeight->setText(QString::number(m_optCost.weight));
+    ui->txtEpsilon->setText(QString::number(m_optCost.epsilon));
+    ui->txtEpsilon->setEnabled(m_optCost.optCostDiffType ==
+                               sme::simulate::OptCostDiffType::Relative);
     ui->cmbSpecies->setCurrentIndex(cmbIndex);
+    cmbSpecies_currentIndexChanged(cmbIndex);
   }
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
           &DialogOptCost::accept);
@@ -115,23 +101,81 @@ DialogOptCost::~DialogOptCost() = default;
   return m_optCost;
 }
 
+void DialogOptCost::populateTargetTypes() {
+  m_targetTypeItems.clear();
+  ui->cmbCostType->blockSignals(true);
+  ui->cmbCostType->clear();
+  m_targetTypeItems.push_back(
+      {sme::simulate::OptCostType::Concentration, {}, "Concentration"});
+  m_targetTypeItems.push_back({sme::simulate::OptCostType::ConcentrationDcdt,
+                               {},
+                               "Rate of change of concentration"});
+  const auto featureIndex =
+      m_model.getFeatures().getIndexFromId(m_optCost.featureId);
+  const auto &features = m_model.getFeatures().getFeatures();
+  for (const auto &feature : features) {
+    if (feature.speciesId != m_optCost.id) {
+      continue;
+    }
+    m_targetTypeItems.push_back(
+        {sme::simulate::OptCostType::Feature, feature.id,
+         QString("Feature: %1").arg(QString::fromStdString(feature.name))});
+  }
+  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature &&
+      (m_optCost.featureId.empty() || featureIndex >= features.size())) {
+    m_targetTypeItems.push_back(
+        {sme::simulate::OptCostType::Feature, m_optCost.featureId,
+         QString("Feature: <missing> (%1)")
+             .arg(QString::fromStdString(m_optCost.featureId))});
+  }
+  int selectedIndex{0};
+  for (int i = 0; i < static_cast<int>(m_targetTypeItems.size()); ++i) {
+    const auto &item = m_targetTypeItems[static_cast<std::size_t>(i)];
+    ui->cmbCostType->addItem(item.label);
+    const bool sameType = item.optCostType == m_optCost.optCostType;
+    const bool sameFeature =
+        item.optCostType != sme::simulate::OptCostType::Feature ||
+        item.featureId == m_optCost.featureId;
+    if (sameType && sameFeature) {
+      selectedIndex = i;
+    }
+  }
+  ui->cmbCostType->setCurrentIndex(selectedIndex);
+  ui->cmbCostType->blockSignals(false);
+  updateTargetValuesLabel();
+}
+
 void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
   auto i{static_cast<std::size_t>(index)};
-  if (m_defaultOptCosts[i].name != m_optCost.name) {
+  if (i >= m_defaultOptCosts.size()) {
+    return;
+  }
+  if (m_defaultOptCosts[i].id != m_optCost.id) {
     m_optCost = m_defaultOptCosts[i];
-    ui->cmbCostType->setCurrentIndex(toIndex(m_optCost.optCostType));
     ui->cmbDiffType->setCurrentIndex(toIndex(m_optCost.optCostDiffType));
     ui->txtSimulationTime->setText(QString::number(m_optCost.simulationTime));
     ui->txtWeight->setText(QString::number(m_optCost.weight));
     ui->txtEpsilon->setText(QString::number(m_optCost.epsilon));
     ui->txtEpsilon->setEnabled(m_optCost.optCostDiffType ==
                                sme::simulate::OptCostDiffType::Relative);
-    updateImage();
   }
+  populateTargetTypes();
+  updateImage();
 }
 
 void DialogOptCost::cmbCostType_currentIndexChanged(int index) {
-  m_optCost.optCostType = toOptCostTypeEnum(index);
+  if (index < 0 ||
+      static_cast<std::size_t>(index) >= m_targetTypeItems.size()) {
+    return;
+  }
+  const auto &item = m_targetTypeItems[static_cast<std::size_t>(index)];
+  m_optCost.optCostType = item.optCostType;
+  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature) {
+    m_optCost.featureId = item.featureId;
+  } else {
+    m_optCost.featureId.clear();
+  }
+  updateTargetValuesLabel();
 }
 
 void DialogOptCost::cmbDiffType_currentIndexChanged(int index) {
@@ -146,7 +190,6 @@ void DialogOptCost::txtSimulationTime_editingFinished() {
 }
 
 void DialogOptCost::btnEditTargetValues_clicked() {
-  QString costType{ui->cmbCostType->currentText()};
   DialogImageDataDataType dataType{DialogImageDataDataType::Concentration};
   if (m_optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt) {
     dataType = DialogImageDataDataType::ConcentrationRateOfChange;
@@ -160,7 +203,11 @@ void DialogOptCost::btnEditTargetValues_clicked() {
       updateImage();
     }
   } catch (const std::invalid_argument &e) {
-    QMessageBox::warning(this, "Error editing target values image", e.what());
+    QMessageBox::warning(
+        this,
+        QString("Error editing %1 image")
+            .arg(targetValuesText(m_optCost.optCostType).toLower()),
+        e.what());
   }
 }
 
@@ -172,6 +219,13 @@ void DialogOptCost::txtWeight_editingFinished() {
 void DialogOptCost::txtEpsilon_editingFinished() {
   m_optCost.epsilon = ui->txtEpsilon->text().toDouble();
   ui->txtEpsilon->setText(toQStr(m_optCost.epsilon));
+}
+
+void DialogOptCost::updateTargetValuesLabel() {
+  const auto text{targetValuesText(m_optCost.optCostType)};
+  ui->lblTargetValuesLabel->setText(
+      QString("%1:").arg(targetValuesText(m_optCost.optCostType, true)));
+  ui->btnEditTargetValues->setText(QString("Edit %1").arg(text));
 }
 
 void DialogOptCost::updateImage() {

--- a/gui/dialogs/dialogoptcost.hpp
+++ b/gui/dialogs/dialogoptcost.hpp
@@ -22,10 +22,16 @@ public:
   [[nodiscard]] const sme::simulate::OptCost &getOptCost() const;
 
 private:
+  struct TargetTypeItem {
+    sme::simulate::OptCostType optCostType;
+    std::string featureId;
+    QString label;
+  };
   const sme::model::Model &m_model;
   const std::vector<sme::simulate::OptCost> &m_defaultOptCosts;
   std::unique_ptr<Ui::DialogOptCost> ui;
   sme::simulate::OptCost m_optCost;
+  std::vector<TargetTypeItem> m_targetTypeItems;
   void cmbSpecies_currentIndexChanged(int index);
   void cmbCostType_currentIndexChanged(int index);
   void cmbDiffType_currentIndexChanged(int index);
@@ -33,5 +39,7 @@ private:
   void btnEditTargetValues_clicked();
   void txtWeight_editingFinished();
   void txtEpsilon_editingFinished();
+  void populateTargetTypes();
+  void updateTargetValuesLabel();
   void updateImage();
 };

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -74,6 +74,9 @@
        <property name="text">
         <string>Simulation time:</string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
       </widget>
      </item>
      <item row="2" column="1">
@@ -99,7 +102,7 @@
      <item row="4" column="1">
       <widget class="QPushButton" name="btnEditTargetValues">
        <property name="text">
-        <string>Edit Target Values</string>
+        <string>Edit Concentration</string>
        </property>
       </widget>
      </item>
@@ -156,7 +159,7 @@
      <item row="3" column="0" rowspan="2">
       <widget class="QLabel" name="lblTargetValuesLabel">
        <property name="text">
-        <string>Target values:</string>
+        <string>Concentration:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -4,6 +4,7 @@
 #include "qt_test_utils.hpp"
 #include "sme/utils.hpp"
 #include <QComboBox>
+#include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 
@@ -14,6 +15,7 @@ struct DialogOptCostWidgets {
   explicit DialogOptCostWidgets(const DialogOptCost *dialog) {
     GET_DIALOG_WIDGET(QComboBox, cmbSpecies);
     GET_DIALOG_WIDGET(QComboBox, cmbCostType);
+    GET_DIALOG_WIDGET(QLabel, lblTargetValuesLabel);
     GET_DIALOG_WIDGET(QLineEdit, txtSimulationTime);
     GET_DIALOG_WIDGET(QPushButton, btnEditTargetValues);
     GET_DIALOG_WIDGET(QComboBox, cmbDiffType);
@@ -22,6 +24,7 @@ struct DialogOptCostWidgets {
   }
   QComboBox *cmbSpecies;
   QComboBox *cmbCostType;
+  QLabel *lblTargetValuesLabel;
   QLineEdit *txtSimulationTime;
   QPushButton *btnEditTargetValues;
   QComboBox *cmbDiffType;
@@ -94,10 +97,16 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().compartmentIndex == 0);
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::Concentration);
+    REQUIRE(widgets.lblTargetValuesLabel->text() == "Concentration:");
+    REQUIRE(widgets.btnEditTargetValues->text() == "Edit Concentration");
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
     REQUIRE(widgets.txtEpsilon->isEnabled());
     widgets.cmbCostType->setCurrentIndex(1);
+    REQUIRE(widgets.lblTargetValuesLabel->text() ==
+            "Rate of change\nof concentration:");
+    REQUIRE(widgets.btnEditTargetValues->text() ==
+            "Edit Rate of change of concentration");
     widgets.cmbDiffType->setCurrentIndex(0);
     REQUIRE(dia.getOptCost().name == "cell/Mt");
     REQUIRE(dia.getOptCost().id == "Mt");
@@ -237,7 +246,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().name == "cell/P0");
     REQUIRE(dia.getOptCost().optCostType ==
             simulate::OptCostType::ConcentrationDcdt);
-    REQUIRE(mwt.getResult() == "Concentration rate of change image data");
+    REQUIRE(mwt.getResult() == "Rate of change of concentration image data");
     // all pixels within compartment are set to 1.2
     REQUIRE(sme::common::max(dia.getOptCost().targetValues) == dbl_approx(1.2));
     // pixels outside of compartment are zero
@@ -301,5 +310,28 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
             simulate::OptCostType::Concentration);
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
+  }
+  SECTION("matching features appear in target type list") {
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    auto compId = model.getSpecies().getField("Mt")->getCompartment()->getId();
+    auto featureIndex = model.getFeatures().add(
+        "peripheral Mt", compId, "Mt", roi, simulate::ReductionOp::Average);
+    DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
+    REQUIRE(widgets.cmbCostType->count() == 3);
+    REQUIRE(widgets.cmbCostType->itemText(0) == "Concentration");
+    REQUIRE(widgets.cmbCostType->itemText(1) ==
+            "Rate of change of concentration");
+    REQUIRE(widgets.cmbCostType->itemText(2) == "Feature: peripheral Mt");
+    widgets.cmbCostType->setCurrentIndex(2);
+    REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
+    REQUIRE(dia.getOptCost().featureId ==
+            model.getFeatures().getFeatures()[featureIndex].id);
+    REQUIRE(widgets.lblTargetValuesLabel->text() == "Concentration:");
+    REQUIRE(widgets.btnEditTargetValues->text() == "Edit Concentration");
+    widgets.cmbSpecies->setCurrentIndex(0);
+    REQUIRE(widgets.cmbCostType->count() == 2);
   }
 }

--- a/gui/dialogs/dialogoptsetup.cpp
+++ b/gui/dialogs/dialogoptsetup.cpp
@@ -15,6 +15,8 @@ static QString toQStr(sme::simulate::OptCostType optCostType) {
     return "Concentration";
   case sme::simulate::OptCostType::ConcentrationDcdt:
     return "Rate of change of concentration";
+  case sme::simulate::OptCostType::Feature:
+    return "Feature";
   default:
     return "";
   }
@@ -31,10 +33,22 @@ static QString toQStr(sme::simulate::OptCostDiffType optCostDiffType) {
   }
 }
 
-static QString toQStr(const sme::simulate::OptCost &optCost) {
+static QString toQStr(const sme::simulate::OptCost &optCost,
+                      const sme::model::Model &model) {
+  QString targetType{toQStr(optCost.optCostType)};
+  if (optCost.optCostType == sme::simulate::OptCostType::Feature) {
+    QString featureName{"<missing>"};
+    const auto featureIndex{
+        model.getFeatures().getIndexFromId(optCost.featureId)};
+    if (featureIndex < model.getFeatures().size()) {
+      featureName = QString::fromStdString(
+          model.getFeatures().getFeatures()[featureIndex].name);
+    }
+    targetType = QString("Feature: %1").arg(featureName);
+  }
   return QString("%1 [%2 at t=%3, %4 difference]")
       .arg(optCost.name.c_str())
-      .arg(toQStr(optCost.optCostType))
+      .arg(targetType)
       .arg(toQStr(optCost.simulationTime))
       .arg(toQStr(optCost.optCostDiffType));
 }
@@ -188,7 +202,7 @@ DialogOptSetup::DialogOptSetup(const sme::model::Model &model, QWidget *parent)
   ui->spinPopulation->setValue(
       static_cast<int>(m_optimizeOptions.optAlgorithm.population));
   for (const auto &optCost : m_optimizeOptions.optCosts) {
-    ui->lstTargets->addItem(toQStr(optCost));
+    ui->lstTargets->addItem(toQStr(optCost, m_model));
   }
   for (const auto &optParam : m_optimizeOptions.optParams) {
     ui->lstParameters->addItem(toQStr(optParam));
@@ -268,7 +282,7 @@ void DialogOptSetup::btnAddTarget_clicked() {
   DialogOptCost dia(m_model, m_defaultOptCosts);
   if (dia.exec() == QDialog::Accepted) {
     m_optimizeOptions.optCosts.push_back(dia.getOptCost());
-    ui->lstTargets->addItem(toQStr(dia.getOptCost()));
+    ui->lstTargets->addItem(toQStr(dia.getOptCost(), m_model));
   }
 }
 
@@ -282,7 +296,7 @@ void DialogOptSetup::btnEditTarget_clicked() {
   if (dia.exec() == QDialog::Accepted) {
     m_optimizeOptions.optCosts[static_cast<std::size_t>(row)] =
         dia.getOptCost();
-    ui->lstTargets->item(row)->setText(toQStr(dia.getOptCost()));
+    ui->lstTargets->item(row)->setText(toQStr(dia.getOptCost(), m_model));
   }
 }
 

--- a/gui/dialogs/dialogsteadystate.cpp
+++ b/gui/dialogs/dialogsteadystate.cpp
@@ -306,7 +306,7 @@ DialogSteadystate::~DialogSteadystate() = default;
 void DialogSteadystate::displayOptionsClicked() {
   DialogDisplayOptions dialog(m_compartmentNames, m_speciesNames,
                               m_displayoptions,
-                              std::vector<PlotWrapperObservable>{}, this);
+                              std::vector<PlotWrapperObservable>{}, {}, this);
 
   // we don´t care about timepoints here
   dialog.ui->cmbNormaliseOverAllTimepoints->hide();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -21,6 +21,7 @@
 #include "sme/model.hpp"
 #include "sme/serialization.hpp"
 #include "tabevents.hpp"
+#include "tabfeatures.hpp"
 #include "tabfunctions.hpp"
 #include "tabgeometry.hpp"
 #include "tabparameters.hpp"
@@ -164,6 +165,10 @@ void MainWindow::setupTabs() {
   tabEvents = new TabEvents(model, ui->tabEvents);
   ui->tabEvents->layout()->addWidget(tabEvents);
 
+  tabFeatures =
+      new TabFeatures(model, ui->lblGeometry, ui->voxGeometry, ui->tabFeatures);
+  ui->tabFeatures->layout()->addWidget(tabFeatures);
+
   tabSimulate =
       new TabSimulate(model, ui->lblGeometry, ui->voxGeometry, ui->tabSimulate);
   ui->tabSimulate->layout()->addWidget(tabSimulate);
@@ -301,7 +306,8 @@ void MainWindow::tabMain_currentChanged(int index) {
     FUNCTIONS = 3,
     PARAMETERS = 4,
     EVENTS = 5,
-    SIMULATE = 6
+    FEATURES = 6,
+    SIMULATE = 7
   };
   ui->tabMain->setWhatsThis(ui->tabMain->tabWhatsThis(index));
   SPDLOG_DEBUG("Tab changed to {} [{}]", index,
@@ -324,6 +330,9 @@ void MainWindow::tabMain_currentChanged(int index) {
     break;
   case TabIndex::EVENTS:
     tabEvents->loadModelData();
+    break;
+  case TabIndex::FEATURES:
+    tabFeatures->loadModelData();
     break;
   case TabIndex::SIMULATE:
     tabSimulate->loadModelData();

--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -6,9 +6,10 @@
 #include <QMainWindow>
 #include <memory>
 
+class TabEvents;
+class TabFeatures;
 class TabFunctions;
 class TabGeometry;
-class TabEvents;
 class TabParameters;
 class TabReactions;
 class TabSimulate;
@@ -51,6 +52,7 @@ private:
   TabFunctions *tabFunctions;
   TabParameters *tabParameters;
   TabEvents *tabEvents;
+  TabFeatures *tabFeatures;
   TabSimulate *tabSimulate;
 
   QString getConvertedFilename(const QString &cpsFilename);

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -283,6 +283,12 @@
         </attribute>
         <layout class="QHBoxLayout" name="horizontalLayout_2"/>
        </widget>
+       <widget class="QWidget" name="tabFeatures">
+        <attribute name="title">
+         <string>Features</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_tabFeatures"/>
+       </widget>
        <widget class="QWidget" name="tabSimulate">
         <property name="whatsThis">
          <string>&lt;h4&gt;Simulate tab&lt;/h4&gt;

--- a/gui/mainwindow_t.cpp
+++ b/gui/mainwindow_t.cpp
@@ -225,6 +225,8 @@ TEST_CASE("MainWindow: tabs", tags) {
     sendKeyEvents(tabMain, {"Ctrl+Tab"});
     REQUIRE(tabMain->currentIndex() == 6);
     sendKeyEvents(tabMain, {"Ctrl+Tab"});
+    REQUIRE(tabMain->currentIndex() == 7);
+    sendKeyEvents(tabMain, {"Ctrl+Tab"});
     REQUIRE(tabMain->currentIndex() == 0);
     sendKeyEvents(tabMain, {"Ctrl+Tab"});
     REQUIRE(tabMain->currentIndex() == 1);
@@ -235,7 +237,7 @@ TEST_CASE("MainWindow: tabs", tags) {
     sendKeyEvents(tabMain, {"Ctrl+Shift+Tab"});
     REQUIRE(tabMain->currentIndex() == 0);
     sendKeyEvents(tabMain, {"Ctrl+Shift+Tab"});
-    REQUIRE(tabMain->currentIndex() == 6);
+    REQUIRE(tabMain->currentIndex() == 7);
   }
 }
 

--- a/gui/tabs/CMakeLists.txt
+++ b/gui/tabs/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(
   gui
   PRIVATE tabevents.cpp
           tabevents.ui
+          tabfeatures.cpp
+          tabfeatures.ui
           tabfunctions.cpp
           tabfunctions.ui
           tabgeometry.cpp
@@ -20,6 +22,7 @@ if(BUILD_TESTING)
   target_sources(
     gui_tests
     PUBLIC tabevents_t.cpp
+           tabfeatures_t.cpp
            tabfunctions_t.cpp
            tabgeometry_t.cpp
            tabparameters_t.cpp

--- a/gui/tabs/tabfeatures.cpp
+++ b/gui/tabs/tabfeatures.cpp
@@ -1,0 +1,526 @@
+#include "tabfeatures.hpp"
+#include "dialoganalytic.hpp"
+#include "guiutils.hpp"
+#include "qlabelmousetracker.hpp"
+#include "qvoxelrenderer.hpp"
+#include "sme/feature_options.hpp"
+#include "sme/geometry.hpp"
+#include "sme/image_stack.hpp"
+#include "sme/logger.hpp"
+#include "sme/model.hpp"
+#include "sme/utils.hpp"
+#include "ui_tabfeatures.h"
+#include <QFileDialog>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <algorithm>
+
+namespace {
+
+sme::simulate::RoiType currentRoiType(const QComboBox *combo) {
+  return static_cast<sme::simulate::RoiType>(combo->currentData().toInt());
+}
+
+int currentAxis(const QComboBox *combo) { return combo->currentData().toInt(); }
+
+} // namespace
+
+TabFeatures::TabFeatures(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
+                         QVoxelRenderer *voxelRenderer, QWidget *parent)
+    : QWidget{parent}, ui{std::make_unique<Ui::TabFeatures>()}, model{m},
+      lblGeometry{mouseTracker}, voxGeometry{voxelRenderer} {
+  ui->setupUi(this);
+  connect(ui->listFeatures, &QListWidget::currentRowChanged, this,
+          &TabFeatures::listFeatures_currentRowChanged);
+  connect(ui->btnAddFeature, &QPushButton::clicked, this,
+          &TabFeatures::btnAddFeature_clicked);
+  connect(ui->btnRemoveFeature, &QPushButton::clicked, this,
+          &TabFeatures::btnRemoveFeature_clicked);
+  connect(ui->txtFeatureName, &QLineEdit::editingFinished, this,
+          &TabFeatures::txtFeatureName_editingFinished);
+  connect(ui->cmbCompartment, qOverload<int>(&QComboBox::currentIndexChanged),
+          this, &TabFeatures::cmbCompartment_currentIndexChanged);
+  connect(ui->cmbSpecies, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &TabFeatures::cmbSpecies_currentIndexChanged);
+  connect(ui->cmbRoiType, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &TabFeatures::cmbRoiType_currentIndexChanged);
+  connect(ui->btnEditExpression, &QPushButton::clicked, this,
+          &TabFeatures::btnEditExpression_clicked);
+  connect(ui->spnNRegions, qOverload<int>(&QSpinBox::valueChanged), this,
+          &TabFeatures::spnNRegions_valueChanged);
+  connect(ui->btnImportImage, &QPushButton::clicked, this,
+          &TabFeatures::btnImportImage_clicked);
+  connect(ui->spnBuiltInThickness, qOverload<int>(&QSpinBox::valueChanged),
+          this, &TabFeatures::spnBuiltInThickness_valueChanged);
+  connect(ui->cmbBuiltInAxis, qOverload<int>(&QComboBox::currentIndexChanged),
+          this, &TabFeatures::cmbBuiltInAxis_currentIndexChanged);
+  connect(ui->cmbReduction, qOverload<int>(&QComboBox::currentIndexChanged),
+          this, &TabFeatures::cmbReduction_currentIndexChanged);
+  ui->cmbRoiType->addItem("Analytic",
+                          static_cast<int>(sme::simulate::RoiType::Analytic));
+  ui->cmbRoiType->addItem("Image",
+                          static_cast<int>(sme::simulate::RoiType::Image));
+  ui->cmbRoiType->addItem("Depth",
+                          static_cast<int>(sme::simulate::RoiType::Depth));
+  ui->cmbRoiType->addItem("Axis slices",
+                          static_cast<int>(sme::simulate::RoiType::AxisSlices));
+  ui->cmbBuiltInAxis->addItem("x", 0);
+  ui->cmbBuiltInAxis->addItem("y", 1);
+  ui->cmbBuiltInAxis->addItem("z", 2);
+  ui->cmbReduction->addItem("Average");
+  ui->cmbReduction->addItem("Sum");
+  ui->cmbReduction->addItem("Min");
+  ui->cmbReduction->addItem("Max");
+}
+
+TabFeatures::~TabFeatures() = default;
+
+void TabFeatures::loadModelData(const QString &selection) {
+  currentFeatureIndex = -1;
+  ui->listFeatures->clear();
+  const auto &features = model.getFeatures().getFeatures();
+  for (const auto &feat : features) {
+    auto *item = new QListWidgetItem(QString::fromStdString(feat.name));
+    item->setData(Qt::UserRole, QString::fromStdString(feat.id));
+    ui->listFeatures->addItem(item);
+  }
+  if (ui->listFeatures->count() > 0) {
+    int selectedIndex = 0;
+    if (!selection.isEmpty()) {
+      for (int i = 0; i < ui->listFeatures->count(); ++i) {
+        if (ui->listFeatures->item(i)->data(Qt::UserRole).toString() ==
+            selection) {
+          selectedIndex = i;
+          break;
+        }
+      }
+    }
+    ui->listFeatures->setCurrentRow(selectedIndex);
+  }
+  bool enable = ui->listFeatures->count() > 0;
+  enableWidgets(enable);
+}
+
+void TabFeatures::enableWidgets(bool enable) {
+  ui->txtFeatureName->setEnabled(enable);
+  ui->cmbCompartment->setEnabled(enable);
+  ui->cmbSpecies->setEnabled(enable);
+  ui->cmbRoiType->setEnabled(enable);
+  ui->stackRoiSettings->setEnabled(enable);
+  ui->cmbReduction->setEnabled(enable);
+  ui->btnRemoveFeature->setEnabled(enable);
+  ui->lblRegionColors->setEnabled(enable);
+  if (enable) {
+    updateRoiWidgetEnableState();
+  } else {
+    ui->txtExpression->setEnabled(false);
+    ui->btnEditExpression->setEnabled(false);
+    ui->spnNRegions->setEnabled(false);
+    ui->lblRegionColors->setNumberOfRegions(0);
+    ui->btnImportImage->setEnabled(false);
+    ui->lblBuiltInThicknessLabel->setEnabled(false);
+    ui->spnBuiltInThickness->setEnabled(false);
+    ui->lblBuiltInAxisLabel->setEnabled(false);
+    ui->cmbBuiltInAxis->setEnabled(false);
+  }
+}
+
+void TabFeatures::updateRoiWidgetEnableState() {
+  const auto roiType = currentRoiType(ui->cmbRoiType);
+  const bool analytic = roiType == sme::simulate::RoiType::Analytic;
+  const bool image = roiType == sme::simulate::RoiType::Image;
+  const bool depth = roiType == sme::simulate::RoiType::Depth;
+  const bool axis = roiType == sme::simulate::RoiType::AxisSlices;
+  if (analytic) {
+    ui->stackRoiSettings->setCurrentWidget(ui->pageRoiAnalytic);
+  } else if (image) {
+    ui->stackRoiSettings->setCurrentWidget(ui->pageRoiImage);
+  } else if (depth) {
+    ui->stackRoiSettings->setCurrentWidget(ui->pageRoiDepth);
+  } else if (axis) {
+    ui->stackRoiSettings->setCurrentWidget(ui->pageRoiAxis);
+  }
+  ui->txtExpression->setEnabled(analytic);
+  ui->btnEditExpression->setEnabled(analytic);
+  ui->spnNRegions->setEnabled(true);
+  ui->btnImportImage->setEnabled(image);
+  ui->lblBuiltInThicknessLabel->setEnabled(depth);
+  ui->spnBuiltInThickness->setEnabled(depth);
+  ui->lblBuiltInAxisLabel->setEnabled(axis);
+  ui->cmbBuiltInAxis->setEnabled(axis);
+  updateRegionColors();
+}
+
+void TabFeatures::updateRegionColors() {
+  if (!ui->lblRegionColors->isEnabled() || currentFeatureIndex < 0) {
+    ui->lblRegionColors->setNumberOfRegions(0);
+    return;
+  }
+
+  ui->lblRegionColors->setNumberOfRegions(
+      static_cast<std::size_t>(std::max(1, ui->spnNRegions->value())));
+}
+
+void TabFeatures::updateRoiImage() {
+  if (lblGeometry == nullptr || currentFeatureIndex < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  if (static_cast<std::size_t>(currentFeatureIndex) >= features.size()) {
+    return;
+  }
+  const auto &origin = model.getGeometry().getPhysicalOrigin();
+  if (!model.getFeatures().isValid(
+          static_cast<std::size_t>(currentFeatureIndex))) {
+    lblGeometry->setImage(model.getGeometry().getImages());
+    if (voxGeometry != nullptr) {
+      voxGeometry->setImage(model.getGeometry().getImages(), origin);
+    }
+    return;
+  }
+  const auto &regions = model.getFeatures().getVoxelRegions(
+      static_cast<std::size_t>(currentFeatureIndex));
+  const auto &feat = features[static_cast<std::size_t>(currentFeatureIndex)];
+  auto nRegions = sme::simulate::getNumRegions(feat.roi);
+  const auto *comp = model.getCompartments().getCompartment(
+      QString::fromStdString(feat.compartmentId));
+  if (comp == nullptr || regions.empty()) {
+    lblGeometry->setImage(model.getGeometry().getImages());
+    if (voxGeometry != nullptr) {
+      voxGeometry->setImage(model.getGeometry().getImages(), origin);
+    }
+    return;
+  }
+  const auto &vol = model.getGeometry().getImages().volume();
+  sme::common::ImageStack imageStack(
+      vol, sme::common::ImageStack::indexedImageFormat);
+  imageStack.fill(0);
+  // color table: index 0 = black background, indices 1..nRegions use the
+  // shared indexed plotting palette.
+  imageStack.setColor(0, qRgb(0, 0, 0));
+  sme::common::indexedColors indexedColors;
+  for (std::size_t region = 1; region <= nRegions; ++region) {
+    imageStack.setColor(static_cast<int>(region),
+                        indexedColors[region - 1].rgb());
+  }
+  const auto &voxels = comp->getVoxels();
+  for (std::size_t i = 0; i < voxels.size() && i < regions.size(); ++i) {
+    const auto &v = voxels[i];
+    if (static_cast<std::size_t>(v.z) < vol.depth()) {
+      imageStack[static_cast<std::size_t>(v.z)].setPixel(
+          v.p.x(), v.p.y(), static_cast<uint>(regions[i]));
+    }
+  }
+  lblGeometry->setImage(imageStack);
+  if (voxGeometry != nullptr) {
+    voxGeometry->setImage(imageStack, origin);
+  }
+}
+
+void TabFeatures::listFeatures_currentRowChanged(int row) {
+  currentFeatureIndex = -1;
+  ui->txtFeatureName->clear();
+  ui->cmbCompartment->clear();
+  ui->cmbSpecies->clear();
+  enableWidgets(false);
+  const auto &features = model.getFeatures().getFeatures();
+  if (row < 0 || static_cast<std::size_t>(row) >= features.size()) {
+    if (lblGeometry != nullptr) {
+      lblGeometry->setImage(model.getGeometry().getImages());
+    }
+    if (voxGeometry != nullptr) {
+      voxGeometry->setImage(model.getGeometry().getImages(),
+                            model.getGeometry().getPhysicalOrigin());
+    }
+    return;
+  }
+  currentFeatureIndex = row;
+  const auto &feat = features[static_cast<std::size_t>(row)];
+  SPDLOG_DEBUG("Feature {} selected", feat.name);
+  ui->txtFeatureName->setText(QString::fromStdString(feat.name));
+  // populate compartment combo
+  ui->cmbCompartment->blockSignals(true);
+  const auto &compIds = model.getCompartments().getIds();
+  const auto &compNames = model.getCompartments().getNames();
+  for (int i = 0; i < compIds.size(); ++i) {
+    ui->cmbCompartment->addItem(compNames[i], compIds[i]);
+  }
+  int compIdx = compIds.indexOf(QString::fromStdString(feat.compartmentId));
+  if (compIdx >= 0) {
+    ui->cmbCompartment->setCurrentIndex(compIdx);
+  }
+  ui->cmbCompartment->blockSignals(false);
+  // populate species combo for the selected compartment
+  ui->cmbSpecies->blockSignals(true);
+  QString compId = QString::fromStdString(feat.compartmentId);
+  auto specIds = model.getSpecies().getIds(compId);
+  auto specNames = model.getSpecies().getNames(compId);
+  for (int i = 0; i < specIds.size(); ++i) {
+    ui->cmbSpecies->addItem(specNames[i], specIds[i]);
+  }
+  int specIdx = specIds.indexOf(QString::fromStdString(feat.speciesId));
+  if (specIdx >= 0) {
+    ui->cmbSpecies->setCurrentIndex(specIdx);
+  }
+  ui->cmbSpecies->blockSignals(false);
+  ui->cmbRoiType->blockSignals(true);
+  ui->cmbRoiType->setCurrentIndex(
+      ui->cmbRoiType->findData(static_cast<int>(feat.roi.roiType)));
+  ui->cmbRoiType->blockSignals(false);
+  ui->txtExpression->setText(QString::fromStdString(feat.roi.expression));
+  ui->spnNRegions->setValue(static_cast<int>(feat.roi.numRegions));
+  ui->spnBuiltInThickness->blockSignals(true);
+  ui->spnBuiltInThickness->setValue(sme::simulate::getRoiParameterInt(
+      feat.roi, sme::simulate::roi_param::depthThicknessVoxels, 1));
+  ui->spnBuiltInThickness->blockSignals(false);
+  ui->cmbBuiltInAxis->blockSignals(true);
+  auto axisIndex =
+      ui->cmbBuiltInAxis->findData(sme::simulate::getRoiParameterInt(
+          feat.roi, sme::simulate::roi_param::axis, 0));
+  ui->cmbBuiltInAxis->setCurrentIndex(std::max(axisIndex, 0));
+  ui->cmbBuiltInAxis->blockSignals(false);
+  ui->cmbReduction->blockSignals(true);
+  ui->cmbReduction->setCurrentIndex(static_cast<int>(feat.reduction));
+  ui->cmbReduction->blockSignals(false);
+  enableWidgets(true);
+  updateRoiImage();
+}
+
+void TabFeatures::btnAddFeature_clicked() {
+  bool ok{false};
+  auto name = QInputDialog::getText(
+      this, "Add feature", "New feature name:", QLineEdit::Normal, {}, &ok);
+  if (ok && !name.isEmpty()) {
+    const auto &compIds = model.getCompartments().getIds();
+    std::string compartmentId;
+    std::string speciesId;
+    if (!compIds.isEmpty()) {
+      compartmentId = compIds[0].toStdString();
+      auto specIds = model.getSpecies().getIds(compIds[0]);
+      if (!specIds.isEmpty()) {
+        speciesId = specIds[0].toStdString();
+      }
+    }
+    sme::simulate::RoiSettings roi;
+    roi.roiType = sme::simulate::RoiType::Analytic;
+    roi.expression = "1";
+    auto featureIndex =
+        model.getFeatures().add(name.toStdString(), compartmentId, speciesId,
+                                roi, sme::simulate::ReductionOp::Average);
+    loadModelData(QString::fromStdString(
+        model.getFeatures().getFeatures()[featureIndex].id));
+  }
+}
+
+void TabFeatures::btnRemoveFeature_clicked() {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  auto result{
+      QMessageBox::question(this, "Remove feature?",
+                            QString("Remove feature '%1' from the model?")
+                                .arg(ui->listFeatures->currentItem()->text()),
+                            QMessageBox::Yes | QMessageBox::No)};
+  if (result == QMessageBox::Yes) {
+    SPDLOG_INFO("Removing feature {}", currentFeatureIndex);
+    model.getFeatures().remove(static_cast<std::size_t>(currentFeatureIndex));
+    loadModelData();
+  }
+}
+
+void TabFeatures::txtFeatureName_editingFinished() {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  const auto &name = ui->txtFeatureName->text();
+  const auto &features = model.getFeatures().getFeatures();
+  if (static_cast<std::size_t>(currentFeatureIndex) >= features.size() ||
+      name.toStdString() ==
+          features[static_cast<std::size_t>(currentFeatureIndex)].name) {
+    return;
+  }
+  const auto featureId =
+      features[static_cast<std::size_t>(currentFeatureIndex)].id;
+  auto newName = QString::fromStdString(model.getFeatures().setName(
+      static_cast<std::size_t>(currentFeatureIndex), name.toStdString()));
+  ui->txtFeatureName->setText(newName);
+  loadModelData(QString::fromStdString(featureId));
+}
+
+void TabFeatures::cmbCompartment_currentIndexChanged(int index) {
+  if (currentFeatureIndex < 0 || index < 0) {
+    return;
+  }
+  auto compId = ui->cmbCompartment->itemData(index).toString();
+  // update species list for new compartment
+  ui->cmbSpecies->blockSignals(true);
+  ui->cmbSpecies->clear();
+  auto specIds = model.getSpecies().getIds(compId);
+  auto specNames = model.getSpecies().getNames(compId);
+  for (int i = 0; i < specIds.size(); ++i) {
+    ui->cmbSpecies->addItem(specNames[i], specIds[i]);
+  }
+  ui->cmbSpecies->blockSignals(false);
+  QString specId;
+  if (!specIds.isEmpty()) {
+    specId = specIds[0];
+    ui->cmbSpecies->setCurrentIndex(0);
+  }
+  model.getFeatures().setCompartmentAndSpecies(
+      static_cast<std::size_t>(currentFeatureIndex), compId.toStdString(),
+      specId.toStdString());
+  updateRoiImage();
+}
+
+void TabFeatures::cmbSpecies_currentIndexChanged(int index) {
+  if (currentFeatureIndex < 0 || index < 0) {
+    return;
+  }
+  auto compId = ui->cmbCompartment->currentData().toString();
+  auto specId = ui->cmbSpecies->itemData(index).toString();
+  model.getFeatures().setCompartmentAndSpecies(
+      static_cast<std::size_t>(currentFeatureIndex), compId.toStdString(),
+      specId.toStdString());
+  updateRoiImage();
+}
+
+void TabFeatures::cmbRoiType_currentIndexChanged(int index) {
+  updateRoiWidgetEnableState();
+  if (currentFeatureIndex < 0 || index < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  roi.roiType = currentRoiType(ui->cmbRoiType);
+  if (roi.roiType == sme::simulate::RoiType::Depth) {
+    sme::simulate::setRoiParameterInt(
+        roi, sme::simulate::roi_param::depthThicknessVoxels,
+        ui->spnBuiltInThickness->value());
+  } else if (roi.roiType == sme::simulate::RoiType::AxisSlices) {
+    sme::simulate::setRoiParameterInt(roi, sme::simulate::roi_param::axis,
+                                      currentAxis(ui->cmbBuiltInAxis));
+  }
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  updateRoiImage();
+}
+
+void TabFeatures::btnEditExpression_clicked() {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  const auto *comp =
+      model.getCompartments().getCompartment(QString::fromStdString(
+          features[static_cast<std::size_t>(currentFeatureIndex)]
+              .compartmentId));
+  if (comp == nullptr) {
+    return;
+  }
+  sme::model::SpeciesGeometry compartmentGeometry{
+      comp->getImageSize(), comp->getVoxels(),
+      model.getGeometry().getPhysicalOrigin(),
+      model.getGeometry().getVoxelSize(), model.getUnits()};
+  DialogAnalytic dialog(
+      QString::fromStdString(roi.expression), DialogAnalyticDataType::RoiRegion,
+      compartmentGeometry, model.getParameters(), model.getFunctions(),
+      model.getDisplayOptions().invertYAxis, roi.numRegions, this);
+  if (dialog.exec() != QDialog::Accepted) {
+    return;
+  }
+  roi.expression = dialog.getExpression();
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  ui->txtExpression->setText(QString::fromStdString(roi.expression));
+  updateRoiImage();
+}
+
+void TabFeatures::spnNRegions_valueChanged(int value) {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  roi.numRegions = static_cast<std::size_t>(value);
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  updateRegionColors();
+  updateRoiImage();
+}
+
+void TabFeatures::btnImportImage_clicked() {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  QString filename = QFileDialog::getOpenFileName(
+      this, "Import ROI mask image", "",
+      "Image files (*.png *.bmp *.jpg *.tiff);;All files (*.*)");
+  if (filename.isEmpty()) {
+    return;
+  }
+  QImage img(filename);
+  if (img.isNull()) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  roi.regionImage.clear();
+  roi.regionImage.reserve(static_cast<std::size_t>(img.width() * img.height()));
+  for (int y = 0; y < img.height(); ++y) {
+    for (int x = 0; x < img.width(); ++x) {
+      roi.regionImage.push_back(
+          static_cast<std::size_t>(qGray(img.pixel(x, y))));
+    }
+  }
+  roi.roiType = sme::simulate::RoiType::Image;
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  ui->cmbRoiType->blockSignals(true);
+  ui->cmbRoiType->setCurrentIndex(
+      ui->cmbRoiType->findData(static_cast<int>(roi.roiType)));
+  ui->cmbRoiType->blockSignals(false);
+  updateRoiWidgetEnableState();
+  updateRoiImage();
+}
+
+void TabFeatures::spnBuiltInThickness_valueChanged(int value) {
+  if (currentFeatureIndex < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  if (roi.roiType != sme::simulate::RoiType::Depth) {
+    return;
+  }
+  sme::simulate::setRoiParameterInt(
+      roi, sme::simulate::roi_param::depthThicknessVoxels, value);
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  updateRoiImage();
+}
+
+void TabFeatures::cmbBuiltInAxis_currentIndexChanged(int index) {
+  if (currentFeatureIndex < 0 || index < 0) {
+    return;
+  }
+  const auto &features = model.getFeatures().getFeatures();
+  auto roi = features[static_cast<std::size_t>(currentFeatureIndex)].roi;
+  if (roi.roiType != sme::simulate::RoiType::AxisSlices) {
+    return;
+  }
+  sme::simulate::setRoiParameterInt(roi, sme::simulate::roi_param::axis,
+                                    currentAxis(ui->cmbBuiltInAxis));
+  model.getFeatures().setRoi(static_cast<std::size_t>(currentFeatureIndex),
+                             roi);
+  updateRoiImage();
+}
+
+void TabFeatures::cmbReduction_currentIndexChanged(int index) {
+  if (currentFeatureIndex < 0 || index < 0) {
+    return;
+  }
+  model.getFeatures().setReduction(
+      static_cast<std::size_t>(currentFeatureIndex),
+      static_cast<sme::simulate::ReductionOp>(index));
+}

--- a/gui/tabs/tabfeatures.hpp
+++ b/gui/tabs/tabfeatures.hpp
@@ -1,0 +1,53 @@
+// TabFeatures
+
+#pragma once
+
+#include <QWidget>
+#include <memory>
+
+class QLabelMouseTracker;
+class QVoxelRenderer;
+
+namespace Ui {
+class TabFeatures;
+}
+
+namespace sme::model {
+class Model;
+} // namespace sme::model
+
+class TabFeatures : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit TabFeatures(sme::model::Model &m,
+                       QLabelMouseTracker *mouseTracker = nullptr,
+                       QVoxelRenderer *voxelRenderer = nullptr,
+                       QWidget *parent = nullptr);
+  ~TabFeatures();
+  void loadModelData(const QString &selection = {});
+
+private:
+  std::unique_ptr<Ui::TabFeatures> ui;
+  sme::model::Model &model;
+  QLabelMouseTracker *lblGeometry;
+  QVoxelRenderer *voxGeometry;
+  int currentFeatureIndex{-1};
+  void enableWidgets(bool enable);
+  void updateRoiWidgetEnableState();
+  void updateRoiImage();
+  void updateRegionColors();
+  void listFeatures_currentRowChanged(int row);
+  void btnAddFeature_clicked();
+  void btnRemoveFeature_clicked();
+  void txtFeatureName_editingFinished();
+  void cmbCompartment_currentIndexChanged(int index);
+  void cmbSpecies_currentIndexChanged(int index);
+  void cmbRoiType_currentIndexChanged(int index);
+  void btnEditExpression_clicked();
+  void spnNRegions_valueChanged(int value);
+  void btnImportImage_clicked();
+  void spnBuiltInThickness_valueChanged(int value);
+  void cmbBuiltInAxis_currentIndexChanged(int index);
+  void cmbReduction_currentIndexChanged(int index);
+};

--- a/gui/tabs/tabfeatures.ui
+++ b/gui/tabs/tabfeatures.ui
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TabFeatures</class>
+ <widget class="QWidget" name="TabFeatures">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1110</width>
+    <height>755</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Features</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="leftPanel">
+      <layout class="QGridLayout" name="gridLeftPanel">
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="lblFeaturesLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Features:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QListWidget" name="listFeatures">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="btnAddFeature">
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPushButton" name="btnRemoveFeature">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="grpFeatureSettings">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Feature Settings</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayoutSettings">
+       <item>
+        <layout class="QGridLayout" name="gridFeatureSettings">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblNameLabel">
+           <property name="text">
+            <string>Name:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" colspan="2">
+          <widget class="QLineEdit" name="txtFeatureName"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblCompartmentLabel">
+           <property name="text">
+            <string>Compartment:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="2">
+          <widget class="QComboBox" name="cmbCompartment"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblSpeciesLabel">
+           <property name="text">
+            <string>Species:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1" colspan="2">
+          <widget class="QComboBox" name="cmbSpecies"/>
+         </item>
+         <item row="3" column="0" colspan="3">
+          <widget class="Line" name="lineRoiSeparator">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="lblNRegionsLabel">
+           <property name="text">
+            <string>Number of regions:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QSpinBox" name="spnNRegions">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="RegionColorsLabel" name="lblRegionColors">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="lblRoiTypeLabel">
+           <property name="text">
+            <string>ROI:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1" colspan="2">
+          <widget class="QComboBox" name="cmbRoiType"/>
+         </item>
+         <item row="6" column="1" colspan="2">
+          <widget class="QStackedWidget" name="stackRoiSettings">
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <widget class="QWidget" name="pageRoiAnalytic">
+            <layout class="QHBoxLayout" name="horizontalLayoutExpression">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLineEdit" name="txtExpression">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnEditExpression">
+               <property name="text">
+                <string>edit...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="pageRoiImage">
+            <layout class="QHBoxLayout" name="horizontalLayoutImage">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="btnImportImage">
+               <property name="text">
+                <string>import image...</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacerImage">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="pageRoiDepth">
+            <layout class="QHBoxLayout" name="horizontalLayoutDepth">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblBuiltInThicknessLabel">
+               <property name="text">
+                <string>Thickness (voxels):</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="spnBuiltInThickness">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>1000</number>
+               </property>
+               <property name="value">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacerDepth">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="pageRoiAxis">
+           <layout class="QHBoxLayout" name="horizontalLayoutAxis">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="lblBuiltInAxisLabel">
+              <property name="text">
+               <string>Axis:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="cmbBuiltInAxis"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacerAxis">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          </widget>
+         </item>
+         <item row="7" column="0" colspan="3">
+          <widget class="Line" name="lineReductionSeparator">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="lblReductionLabel">
+           <property name="text">
+            <string>Summary statistic:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1" colspan="2">
+          <widget class="QComboBox" name="cmbReduction"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RegionColorsLabel</class>
+   <extends>QLabel</extends>
+   <header>regioncolorslabel.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/gui/tabs/tabfeatures_t.cpp
+++ b/gui/tabs/tabfeatures_t.cpp
@@ -1,0 +1,252 @@
+#include "catch_wrapper.hpp"
+#include "model_test_utils.hpp"
+#include "qt_test_utils.hpp"
+#include "regioncolorslabel.hpp"
+#include "sme/feature_options.hpp"
+#include "sme/model.hpp"
+#include "tabfeatures.hpp"
+#include <QComboBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QStackedWidget>
+
+using namespace sme::test;
+
+TEST_CASE("TabFeatures", "[gui/tabs/features][gui/tabs][gui][features]") {
+  sme::model::Model model;
+  TabFeatures tab(model);
+  tab.show();
+  waitFor(&tab);
+  auto *listFeatures{tab.findChild<QListWidget *>("listFeatures")};
+  REQUIRE(listFeatures != nullptr);
+  auto *btnAddFeature{tab.findChild<QPushButton *>("btnAddFeature")};
+  REQUIRE(btnAddFeature != nullptr);
+  auto *btnRemoveFeature{tab.findChild<QPushButton *>("btnRemoveFeature")};
+  REQUIRE(btnRemoveFeature != nullptr);
+  auto *txtFeatureName{tab.findChild<QLineEdit *>("txtFeatureName")};
+  REQUIRE(txtFeatureName != nullptr);
+  auto *cmbCompartment{tab.findChild<QComboBox *>("cmbCompartment")};
+  REQUIRE(cmbCompartment != nullptr);
+  auto *cmbSpecies{tab.findChild<QComboBox *>("cmbSpecies")};
+  REQUIRE(cmbSpecies != nullptr);
+  auto *cmbRoiType{tab.findChild<QComboBox *>("cmbRoiType")};
+  REQUIRE(cmbRoiType != nullptr);
+  auto *stackRoiSettings{tab.findChild<QStackedWidget *>("stackRoiSettings")};
+  REQUIRE(stackRoiSettings != nullptr);
+  auto *pageRoiAnalytic{tab.findChild<QWidget *>("pageRoiAnalytic")};
+  REQUIRE(pageRoiAnalytic != nullptr);
+  auto *pageRoiImage{tab.findChild<QWidget *>("pageRoiImage")};
+  REQUIRE(pageRoiImage != nullptr);
+  auto *pageRoiDepth{tab.findChild<QWidget *>("pageRoiDepth")};
+  REQUIRE(pageRoiDepth != nullptr);
+  auto *pageRoiAxis{tab.findChild<QWidget *>("pageRoiAxis")};
+  REQUIRE(pageRoiAxis != nullptr);
+  auto *lblBuiltInThicknessLabel{
+      tab.findChild<QLabel *>("lblBuiltInThicknessLabel")};
+  REQUIRE(lblBuiltInThicknessLabel != nullptr);
+  auto *spnBuiltInThickness{tab.findChild<QSpinBox *>("spnBuiltInThickness")};
+  REQUIRE(spnBuiltInThickness != nullptr);
+  auto *lblBuiltInAxisLabel{tab.findChild<QLabel *>("lblBuiltInAxisLabel")};
+  REQUIRE(lblBuiltInAxisLabel != nullptr);
+  auto *cmbBuiltInAxis{tab.findChild<QComboBox *>("cmbBuiltInAxis")};
+  REQUIRE(cmbBuiltInAxis != nullptr);
+  auto *cmbReduction{tab.findChild<QComboBox *>("cmbReduction")};
+  REQUIRE(cmbReduction != nullptr);
+  auto *txtExpression{tab.findChild<QLineEdit *>("txtExpression")};
+  REQUIRE(txtExpression != nullptr);
+  auto *btnEditExpression{tab.findChild<QPushButton *>("btnEditExpression")};
+  REQUIRE(btnEditExpression != nullptr);
+  auto *btnImportImage{tab.findChild<QPushButton *>("btnImportImage")};
+  REQUIRE(btnImportImage != nullptr);
+  auto *spnNRegions{tab.findChild<QSpinBox *>("spnNRegions")};
+  REQUIRE(spnNRegions != nullptr);
+  auto *lblRegionColors{tab.findChild<RegionColorsLabel *>("lblRegionColors")};
+  REQUIRE(lblRegionColors != nullptr);
+  auto *gridFeatureSettings{
+      tab.findChild<QGridLayout *>("gridFeatureSettings")};
+  REQUIRE(gridFeatureSettings != nullptr);
+  ModalWidgetTimer mwt;
+  SECTION("very simple model") {
+    model = getExampleModel(Mod::VerySimpleModel);
+    while (model.getFeatures().size() > 0) {
+      model.getFeatures().remove(0);
+    }
+    tab.loadModelData();
+    REQUIRE(listFeatures->count() == 0);
+    REQUIRE(btnAddFeature->isEnabled() == true);
+    REQUIRE(btnRemoveFeature->isEnabled() == false);
+    REQUIRE(txtFeatureName->isEnabled() == false);
+    // all ROI widgets disabled when no feature selected
+    REQUIRE(txtExpression->isEnabled() == false);
+    REQUIRE(btnEditExpression->isEnabled() == false);
+    REQUIRE(spnNRegions->isEnabled() == false);
+    REQUIRE(lblRegionColors->isEnabled() == false);
+    REQUIRE(lblRegionColors->getNumberOfRegions() == 0);
+    REQUIRE(cmbRoiType->isEnabled() == false);
+    REQUIRE(stackRoiSettings->isEnabled() == false);
+    REQUIRE(btnImportImage->isEnabled() == false);
+    REQUIRE(lblBuiltInThicknessLabel->isEnabled() == false);
+    REQUIRE(spnBuiltInThickness->isEnabled() == false);
+    REQUIRE(lblBuiltInAxisLabel->isEnabled() == false);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == false);
+    // add feature - defaults to analytic ROI
+    mwt.addUserAction({"f", "1"});
+    mwt.start();
+    sendMouseClick(btnAddFeature);
+    REQUIRE(listFeatures->count() == 1);
+    REQUIRE(listFeatures->currentItem()->text() == "f1");
+    REQUIRE(txtFeatureName->isEnabled() == true);
+    REQUIRE(txtFeatureName->text() == "f1");
+    REQUIRE(cmbCompartment->isEnabled() == true);
+    REQUIRE(cmbCompartment->count() > 0);
+    REQUIRE(cmbSpecies->isEnabled() == true);
+    REQUIRE(cmbReduction->isEnabled() == true);
+    REQUIRE(btnRemoveFeature->isEnabled() == true);
+    REQUIRE(model.getFeatures().size() == 1);
+    // default is analytic: expression and labels enabled, others disabled
+    REQUIRE(cmbRoiType->isEnabled() == true);
+    REQUIRE(cmbRoiType->count() == 4);
+    REQUIRE(cmbRoiType->currentText() == "Analytic");
+    REQUIRE(stackRoiSettings->currentWidget() == pageRoiAnalytic);
+    REQUIRE(txtExpression->isEnabled() == true);
+    REQUIRE(txtExpression->isReadOnly() == true);
+    REQUIRE(txtExpression->text() == "1");
+    REQUIRE(btnEditExpression->isEnabled() == true);
+    REQUIRE(spnNRegions->isEnabled() == true);
+    REQUIRE(spnNRegions->value() == 1);
+    int nRegionsRow{};
+    int nRegionsColumn{};
+    int nRegionsRowSpan{};
+    int nRegionsColumnSpan{};
+    gridFeatureSettings->getItemPosition(
+        gridFeatureSettings->indexOf(spnNRegions), &nRegionsRow,
+        &nRegionsColumn, &nRegionsRowSpan, &nRegionsColumnSpan);
+    int regionColorsRow{};
+    int regionColorsColumn{};
+    int regionColorsRowSpan{};
+    int regionColorsColumnSpan{};
+    gridFeatureSettings->getItemPosition(
+        gridFeatureSettings->indexOf(lblRegionColors), &regionColorsRow,
+        &regionColorsColumn, &regionColorsRowSpan, &regionColorsColumnSpan);
+    REQUIRE(nRegionsRow == regionColorsRow);
+    REQUIRE(nRegionsColumn < regionColorsColumn);
+    REQUIRE(nRegionsColumnSpan == 1);
+    REQUIRE(lblRegionColors->isEnabled() == true);
+    REQUIRE(lblRegionColors->getNumberOfRegions() == 1);
+    REQUIRE(btnImportImage->isEnabled() == false);
+    REQUIRE(spnBuiltInThickness->isEnabled() == false);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == false);
+    spnNRegions->setValue(3);
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.numRegions == 3);
+    REQUIRE(lblRegionColors->getNumberOfRegions() == 3);
+    // edit ROI analytic expression via dialog
+    mwt.addUserAction({"Delete", "2"});
+    mwt.start();
+    sendMouseClick(btnEditExpression);
+    REQUIRE(txtExpression->text() == "2");
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.expression == "2");
+    // edit name
+    txtFeatureName->setFocus();
+    sendKeyEvents(txtFeatureName,
+                  {"Backspace", "Backspace", "m", "y", "f", "Enter"});
+    REQUIRE(txtFeatureName->text() == "myf");
+    REQUIRE(listFeatures->currentItem()->text() == "myf");
+    // change reduction
+    cmbReduction->setCurrentIndex(1); // Sum
+    REQUIRE(model.getFeatures().getFeatures()[0].reduction ==
+            sme::simulate::ReductionOp::Sum);
+    // switch to image ROI: import button enabled, labels remain editable
+    cmbRoiType->setCurrentIndex(cmbRoiType->findText("Image"));
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.roiType ==
+            sme::simulate::RoiType::Image);
+    REQUIRE(stackRoiSettings->currentWidget() == pageRoiImage);
+    REQUIRE(txtExpression->isEnabled() == false);
+    REQUIRE(btnEditExpression->isEnabled() == false);
+    REQUIRE(spnNRegions->isEnabled() == true);
+    REQUIRE(btnImportImage->isEnabled() == true);
+    REQUIRE(spnBuiltInThickness->isEnabled() == false);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == false);
+    // switch to depth ROI: thickness enabled, labels remain editable
+    cmbRoiType->setCurrentIndex(cmbRoiType->findText("Depth"));
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.roiType ==
+            sme::simulate::RoiType::Depth);
+    REQUIRE(stackRoiSettings->currentWidget() == pageRoiDepth);
+    REQUIRE(txtExpression->isEnabled() == false);
+    REQUIRE(btnEditExpression->isEnabled() == false);
+    REQUIRE(spnNRegions->isEnabled() == true);
+    REQUIRE(btnImportImage->isEnabled() == false);
+    REQUIRE(lblBuiltInThicknessLabel->isEnabled() == true);
+    REQUIRE(spnBuiltInThickness->isEnabled() == true);
+    REQUIRE(spnBuiltInThickness->value() == 1);
+    spnBuiltInThickness->setValue(2);
+    REQUIRE(sme::simulate::getRoiParameterInt(
+                model.getFeatures().getFeatures()[0].roi,
+                sme::simulate::roi_param::depthThicknessVoxels, 1) == 2);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == false);
+    // switch to axis slices ROI: axis enabled, thickness disabled
+    cmbRoiType->setCurrentIndex(cmbRoiType->findText("Axis slices"));
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.roiType ==
+            sme::simulate::RoiType::AxisSlices);
+    REQUIRE(stackRoiSettings->currentWidget() == pageRoiAxis);
+    REQUIRE(txtExpression->isEnabled() == false);
+    REQUIRE(btnEditExpression->isEnabled() == false);
+    REQUIRE(spnNRegions->isEnabled() == true);
+    REQUIRE(btnImportImage->isEnabled() == false);
+    REQUIRE(spnBuiltInThickness->isEnabled() == false);
+    REQUIRE(lblBuiltInAxisLabel->isEnabled() == true);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == true);
+    REQUIRE(cmbBuiltInAxis->count() == 3);
+    REQUIRE(cmbBuiltInAxis->currentText() == "x");
+    cmbBuiltInAxis->setCurrentIndex(cmbBuiltInAxis->findText("y"));
+    REQUIRE(sme::simulate::getRoiParameterInt(
+                model.getFeatures().getFeatures()[0].roi,
+                sme::simulate::roi_param::axis, 0) == 1);
+    // switch to analytic ROI
+    cmbRoiType->setCurrentIndex(cmbRoiType->findText("Analytic"));
+    REQUIRE(model.getFeatures().getFeatures()[0].roi.roiType ==
+            sme::simulate::RoiType::Analytic);
+    REQUIRE(stackRoiSettings->currentWidget() == pageRoiAnalytic);
+    REQUIRE(txtExpression->isEnabled() == true);
+    REQUIRE(btnEditExpression->isEnabled() == true);
+    REQUIRE(spnNRegions->isEnabled() == true);
+    REQUIRE(btnImportImage->isEnabled() == false);
+    REQUIRE(spnBuiltInThickness->isEnabled() == false);
+    REQUIRE(cmbBuiltInAxis->isEnabled() == false);
+    // add second feature
+    mwt.addUserAction({"f", "2"});
+    mwt.start();
+    sendMouseClick(btnAddFeature);
+    REQUIRE(listFeatures->count() == 2);
+    REQUIRE(model.getFeatures().size() == 2);
+    txtFeatureName->setFocus();
+    txtFeatureName->clear();
+    sendKeyEvents(txtFeatureName, {"m", "y", "f", "Enter"});
+    REQUIRE(txtFeatureName->text() == "myf_");
+    REQUIRE(listFeatures->currentItem()->text() == "myf_");
+    REQUIRE(model.getFeatures().getFeatures()[1].name == "myf_");
+    // remove feature & confirm
+    mwt.addUserAction({"Enter"});
+    mwt.start();
+    sendMouseClick(btnRemoveFeature);
+    REQUIRE(listFeatures->count() == 1);
+    REQUIRE(model.getFeatures().size() == 1);
+    // remove feature & cancel
+    mwt.addUserAction({"Esc"});
+    mwt.start();
+    sendMouseClick(btnRemoveFeature);
+    REQUIRE(listFeatures->count() == 1);
+    REQUIRE(model.getFeatures().size() == 1);
+    // remove feature & confirm
+    mwt.addUserAction({"Enter"});
+    mwt.start();
+    sendMouseClick(btnRemoveFeature);
+    REQUIRE(listFeatures->count() == 0);
+    REQUIRE(model.getFeatures().size() == 0);
+    REQUIRE(btnRemoveFeature->isEnabled() == false);
+    REQUIRE(txtFeatureName->isEnabled() == false);
+  }
+}

--- a/gui/tabs/tabsimulate.cpp
+++ b/gui/tabs/tabsimulate.cpp
@@ -5,6 +5,7 @@
 #include "guiutils.hpp"
 #include "qlabelmousetracker.hpp"
 #include "qvoxelrenderer.hpp"
+#include "sme/feature_options.hpp"
 #include "sme/logger.hpp"
 #include "sme/mesh2d.hpp"
 #include "sme/mesh3d.hpp"
@@ -18,6 +19,7 @@
 #include <QProgressDialog>
 #include <QtConcurrent/QtConcurrent>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 
@@ -157,6 +159,38 @@ static void importModelTimesAndIntervals(
                                QMessageBox::No) == QMessageBox::Yes;
 }
 
+[[nodiscard]] static QColor
+featureSpeciesColor(const sme::simulate::Simulation &simulation,
+                    const sme::simulate::FeatureDefinition &feature,
+                    const QColor &fallback) {
+  for (std::size_t ic = 0; ic < simulation.getCompartmentIds().size(); ++ic) {
+    if (simulation.getCompartmentIds()[ic] != feature.compartmentId) {
+      continue;
+    }
+    const auto &speciesIds = simulation.getSpeciesIds(ic);
+    for (std::size_t is = 0; is < speciesIds.size(); ++is) {
+      if (speciesIds[is] == feature.speciesId) {
+        return simulation.getSpeciesColors(ic)[is];
+      }
+    }
+  }
+  return fallback;
+}
+
+[[nodiscard]] static QCPScatterStyle::ScatterShape
+featureScatterShape(std::size_t lineIndex) {
+  static constexpr std::array shapes{
+      QCPScatterStyle::ScatterShape::ssTriangle,
+      QCPScatterStyle::ScatterShape::ssSquare,
+      QCPScatterStyle::ScatterShape::ssDiamond,
+      QCPScatterStyle::ScatterShape::ssCircle,
+      QCPScatterStyle::ScatterShape::ssCross,
+      QCPScatterStyle::ScatterShape::ssPlus,
+      QCPScatterStyle::ScatterShape::ssTriangleInverted,
+      QCPScatterStyle::ScatterShape::ssStar};
+  return shapes[lineIndex % shapes.size()];
+}
+
 void TabSimulate::loadModelData() {
   if (sim != nullptr && sim->getIsRunning()) {
     return;
@@ -283,12 +317,35 @@ void TabSimulate::loadModelData() {
       plt->addAvMinMaxLine(name, col);
     }
   }
+  // add feature lines
+  featureLineNames.clear();
+  const auto &features = model.getFeatures().getFeatures();
+  sme::common::indexedColors featureColors;
+  for (std::size_t fi = 0; fi < features.size(); ++fi) {
+    auto nRegions = sme::simulate::getNumRegions(features[fi].roi);
+    auto fallbackColor = featureColors[nSpecies + fi];
+    auto featureColor = featureSpeciesColor(*sim, features[fi], fallbackColor);
+    for (std::size_t li = 0; li < nRegions; ++li) {
+      QString name = QString::fromStdString(features[fi].name);
+      if (nRegions > 1) {
+        name = QString("%1 [region %2]").arg(name).arg(li + 1);
+      }
+      auto scatterShape = featureScatterShape(
+          static_cast<std::size_t>(featureLineNames.size()));
+      plt->addFeatureLine(name, featureColor, scatterShape);
+      featureLineNames.push_back(name);
+    }
+  }
   displayOptions = model.getDisplayOptions();
   if (displayOptions.showSpecies.size() != nSpecies) {
     // show species count doesn't match actual number of species
     // user probably added/removed species to model
     // just set all species visible in this case
     displayOptions.showSpecies.resize(nSpecies, true);
+  }
+  auto nFeatures = static_cast<std::size_t>(featureLineNames.size());
+  if (displayOptions.showFeatures.size() != nFeatures) {
+    displayOptions.showFeatures.resize(nFeatures, true);
   }
   updateSpeciesToDraw();
   updatePlotAndImages();
@@ -453,6 +510,18 @@ void TabSimulate::updatePlotAndImages() {
         ++speciesIndex;
       }
     }
+    // add feature data points
+    const auto &simData = sim->getSimulationData();
+    int featureLineIndex = 0;
+    for (std::size_t fi = 0; fi < simData.featureResults.size(); ++fi) {
+      const auto &fr = simData.featureResults[fi];
+      if (i < fr.values.size()) {
+        for (std::size_t bi = 0; bi < fr.values[i].size(); ++bi) {
+          plt->addFeaturePoint(featureLineIndex, time.back(), fr.values[i][bi]);
+          ++featureLineIndex;
+        }
+      }
+    }
     lblGeometry->setImage(images.back());
     voxGeometry->setImage(images.back());
     plt->plot->rescaleAxes(true);
@@ -488,7 +557,8 @@ void TabSimulate::finalizePlotAndImages() {
     plt->addObservableLine(obs, sme::common::indexedColors()[colorIndex]);
     ++colorIndex;
   }
-  plt->update(displayOptions.showSpecies, displayOptions.showMinMax);
+  plt->update(displayOptions.showSpecies, displayOptions.showMinMax,
+              displayOptions.showFeatures);
   updateSpeciesToDraw();
   // update all images
   for (int iTime = 0; iTime < time.size(); ++iTime) {
@@ -514,10 +584,11 @@ void TabSimulate::finalizePlotAndImages() {
 
 void TabSimulate::btnDisplayOptions_clicked() {
   DialogDisplayOptions dialog(compartmentNames, speciesNames, displayOptions,
-                              observables);
+                              observables, featureLineNames);
   if (dialog.exec() == QDialog::Accepted) {
     displayOptions.showMinMax = dialog.getShowMinMax();
     displayOptions.showSpecies = dialog.getShowSpecies();
+    displayOptions.showFeatures = dialog.getShowFeatures();
     displayOptions.normaliseOverAllTimepoints =
         dialog.getNormaliseOverAllTimepoints();
     displayOptions.normaliseOverAllSpecies =

--- a/gui/tabs/tabsimulate.hpp
+++ b/gui/tabs/tabsimulate.hpp
@@ -55,6 +55,7 @@ private:
   std::vector<QStringList> speciesNames;
   std::vector<std::vector<std::size_t>> compartmentSpeciesToDraw;
   std::vector<PlotWrapperObservable> observables;
+  QStringList featureLineNames;
   QFuture<std::size_t> simSteps;
   QFutureWatcher<std::size_t> simWatcher;
   QTimer plotRefreshTimer;

--- a/gui/tabs/tabsimulate_t.cpp
+++ b/gui/tabs/tabsimulate_t.cpp
@@ -42,6 +42,48 @@ bool isGpuRuntimeUnavailable(const std::string &msg) {
 TEST_CASE("TabSimulate", "[gui/tabs/simulate][gui/tabs][gui][simulate]") {
   QLabelMouseTracker mouseTracker;
   QVoxelRenderer voxelRenderer;
+  SECTION("Feature plot lines use species colours and region names") {
+    auto model{getExampleModel(Mod::ABtoC)};
+    while (model.getFeatures().size() > 0) {
+      model.getFeatures().remove(0);
+    }
+    model.getSimulationSettings().simulatorType =
+        sme::simulate::SimulatorType::Pixel;
+    QRgb speciesColor{qRgb(12, 34, 56)};
+    model.getSpecies().setColor("A", speciesColor);
+    sme::simulate::RoiSettings roi;
+    roi.roiType = sme::simulate::RoiType::Depth;
+    roi.numRegions = 2;
+    model.getFeatures().add("feature", "comp", "A", roi,
+                            sme::simulate::ReductionOp::Average);
+
+    TabSimulate tab(model, &mouseTracker, &voxelRenderer);
+    tab.show();
+    waitFor(&tab);
+    auto *plot{tab.findChild<QCustomPlot *>("plot")};
+    REQUIRE(plot != nullptr);
+
+    QCPGraph *region1{nullptr};
+    QCPGraph *region2{nullptr};
+    for (int i = 0; i < plot->graphCount(); ++i) {
+      if (plot->graph(i)->name() == "feature [region 1]") {
+        region1 = plot->graph(i);
+      } else if (plot->graph(i)->name() == "feature [region 2]") {
+        region2 = plot->graph(i);
+      }
+    }
+
+    REQUIRE(region1 != nullptr);
+    REQUIRE(region2 != nullptr);
+    REQUIRE(region1->pen().color().rgb() == speciesColor);
+    REQUIRE(region2->pen().color().rgb() == speciesColor);
+    REQUIRE(region1->pen().style() == Qt::DashLine);
+    REQUIRE(region2->pen().style() == Qt::DashLine);
+    REQUIRE(region1->scatterStyle().shape() ==
+            QCPScatterStyle::ScatterShape::ssTriangle);
+    REQUIRE(region2->scatterStyle().shape() ==
+            QCPScatterStyle::ScatterShape::ssSquare);
+  }
   SECTION("Many actions") {
     // load model & do initial simulation
     auto model{getExampleModel(Mod::ABtoC)};

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -144,6 +144,13 @@ void TabSpecies::listSpecies_currentItemChanged(QTreeWidgetItem *current,
   if ((current == nullptr) || (current->parent() == nullptr)) {
     // user selection is not a species
     enableWidgets(false);
+    currentSpeciesId.clear();
+    if (lblGeometry != nullptr) {
+      lblGeometry->setImage(model.getGeometry().getImages());
+    }
+    if (voxGeometry != nullptr) {
+      voxGeometry->setImage(model.getGeometry().getImages());
+    }
     return;
   }
   SPDLOG_DEBUG("item {} / {} selected",

--- a/gui/widgets/CMakeLists.txt
+++ b/gui/widgets/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   PRIVATE plotwrapper.cpp
           gpumemoryusagebarwidget.cpp
           memoryusagebarwidget.cpp
+          regioncolorslabel.cpp
           qlabelslice.cpp
           qlabelmousetracker.cpp
           qplaintextmathedit.cpp
@@ -17,6 +18,7 @@ if(BUILD_TESTING)
     PUBLIC plotwrapper_t.cpp
            gpumemoryusagebarwidget_t.cpp
            memoryusagebarwidget_t.cpp
+           regioncolorslabel_t.cpp
            qlabelslice_t.cpp
            qlabelmousetracker_t.cpp
            qplaintextmathedit_t.cpp

--- a/gui/widgets/plotwrapper.cpp
+++ b/gui/widgets/plotwrapper.cpp
@@ -44,6 +44,7 @@ void PlotWrapper::addAvMinMaxLine(const QString &name, QColor col) {
   plot->legend->removeItem(plot->legend->itemCount() - 1);
   species.push_back(name.toStdString());
   concs.emplace_back();
+  featureGraphOffset = 3 * static_cast<int>(species.size());
 }
 
 void PlotWrapper::addAvMinMaxPoint(
@@ -54,6 +55,27 @@ void PlotWrapper::addAvMinMaxPoint(
   concs[static_cast<std::size_t>(lineIndex)].push_back(concentration);
   if (plot->graph(0)->dataCount() > times.size()) {
     times.push_back(time);
+  }
+}
+
+void PlotWrapper::addFeatureLine(const QString &name, QColor col,
+                                 QCPScatterStyle::ScatterShape scatterShape) {
+  SPDLOG_DEBUG("Adding feature line '{}', color {:x}", name.toStdString(),
+               col.rgb());
+  auto *g = plot->addGraph();
+  QPen pen(col);
+  pen.setStyle(Qt::DashLine);
+  g->setPen(pen);
+  g->setName(name);
+  g->setScatterStyle(QCPScatterStyle(scatterShape));
+  featureNames.push_back(name.toStdString());
+}
+
+void PlotWrapper::addFeaturePoint(int featureLineIndex, double time,
+                                  double value) {
+  int graphIndex = featureGraphOffset + featureLineIndex;
+  if (graphIndex < plot->graphCount()) {
+    plot->graph(graphIndex)->addData({time}, {value}, true);
   }
 }
 
@@ -98,9 +120,10 @@ void PlotWrapper::addObservableLine(
 
 void PlotWrapper::clearObservableLines() {
   SPDLOG_TRACE("Clearing {} observables", observables.size());
-  int nSpecies{static_cast<int>(species.size())};
+  int nFeatures{static_cast<int>(featureNames.size())};
+  int obsStart{featureGraphOffset + nFeatures};
   int nObservables{static_cast<int>(observables.size())};
-  for (int i = 3 * nSpecies + nObservables - 1; i >= 3 * nSpecies; --i) {
+  for (int i = obsStart + nObservables - 1; i >= obsStart; --i) {
     if (plot->removeGraph(i)) {
       SPDLOG_TRACE("Removed graph {}", i);
     } else {
@@ -120,7 +143,8 @@ void PlotWrapper::setVerticalLine(double x) {
 }
 
 void PlotWrapper::update(const std::vector<bool> &speciesVisible,
-                         bool showMinMax) {
+                         bool showMinMax,
+                         const std::vector<bool> &featureVisible) {
   int iSpecies = 0;
   plot->legend->clearItems();
   for (bool visible : speciesVisible) {
@@ -136,9 +160,19 @@ void PlotWrapper::update(const std::vector<bool> &speciesVisible,
     }
     ++iSpecies;
   }
+  for (std::size_t fi = 0; fi < featureNames.size(); ++fi) {
+    int graphIdx = featureGraphOffset + static_cast<int>(fi);
+    bool visible = fi < featureVisible.size() ? featureVisible[fi] : true;
+    auto *g = plot->graph(graphIdx);
+    g->setVisible(visible);
+    if (visible) {
+      g->addToLegend();
+    }
+  }
   int iObs = 0;
+  int nFeatures{static_cast<int>(featureNames.size())};
   for (const auto &observable : observables) {
-    auto *g = plot->graph(3 * static_cast<int>(species.size()) + iObs);
+    auto *g = plot->graph(featureGraphOffset + nFeatures + iObs);
     g->setVisible(observable.visible);
     if (observable.visible) {
       g->addToLegend();
@@ -156,6 +190,8 @@ void PlotWrapper::clear() {
   species.clear();
   concs.clear();
   times.clear();
+  featureNames.clear();
+  featureGraphOffset = 0;
 }
 
 double PlotWrapper::xValue(const QMouseEvent *event) const {
@@ -171,14 +207,18 @@ double PlotWrapper::xValue(const QMouseEvent *event) const {
 
 const QVector<double> &PlotWrapper::getTimepoints() const { return times; }
 
-static QString makeCSVHeader(const std::vector<std::string> &species) {
+static QString makeCSVHeader(const std::vector<std::string> &species,
+                             const std::vector<std::string> &featureNames) {
   QString csv;
-  if (species.empty()) {
+  if (species.empty() && featureNames.empty()) {
     return {};
   }
   std::string header("time, ");
   for (const auto &spec : species) {
     header.append(fmt::format("{0} (avg), {0} (min), {0} (max), ", spec));
+  }
+  for (const auto &feat : featureNames) {
+    header.append(fmt::format("{0}, ", feat));
   }
   csv.append(header.c_str());
   csv.chop(2);
@@ -187,7 +227,7 @@ static QString makeCSVHeader(const std::vector<std::string> &species) {
 }
 
 QString PlotWrapper::getDataAsCSV() const {
-  auto csv{makeCSVHeader(species)};
+  auto csv{makeCSVHeader(species, featureNames)};
   for (std::size_t it = 0; it < static_cast<std::size_t>(times.size()); ++it) {
     double t = times[static_cast<int>(it)];
     std::string row{fmt::format("{:.14e}, ", t)};
@@ -195,6 +235,17 @@ QString PlotWrapper::getDataAsCSV() const {
       const auto &c = concs[ic][it];
       row.append(
           fmt::format("{:.14e}, {:.14e}, {:.14e}, ", c.avg, c.min, c.max));
+    }
+    for (std::size_t fi = 0; fi < featureNames.size(); ++fi) {
+      int graphIdx = featureGraphOffset + static_cast<int>(fi);
+      auto *g = plot->graph(graphIdx);
+      auto data = g->data();
+      if (static_cast<int>(it) < data->size()) {
+        row.append(fmt::format("{:.14e}, ",
+                               (data->begin() + static_cast<int>(it))->value));
+      } else {
+        row.append("nan, ");
+      }
     }
     csv.append(row.c_str());
     csv.chop(2);

--- a/gui/widgets/plotwrapper.hpp
+++ b/gui/widgets/plotwrapper.hpp
@@ -18,6 +18,8 @@ private:
   std::vector<PlotWrapperObservable> observables;
   std::vector<std::vector<sme::simulate::AvgMinMax>> concs;
   QVector<double> times;
+  std::vector<std::string> featureNames;
+  int featureGraphOffset{0};
 
 public:
   QCustomPlot *plot;
@@ -25,11 +27,16 @@ public:
   void addAvMinMaxLine(const QString &name, QColor col);
   void addAvMinMaxPoint(int lineIndex, double time,
                         const sme::simulate::AvgMinMax &concentration);
+  void addFeatureLine(const QString &name, QColor col,
+                      QCPScatterStyle::ScatterShape scatterShape =
+                          QCPScatterStyle::ScatterShape::ssTriangle);
+  void addFeaturePoint(int featureLineIndex, double time, double value);
   void addObservableLine(const PlotWrapperObservable &plotWrapperObservable,
                          const QColor &col);
   void clearObservableLines();
   void setVerticalLine(double x);
-  void update(const std::vector<bool> &speciesVisible, bool showMinMax);
+  void update(const std::vector<bool> &speciesVisible, bool showMinMax,
+              const std::vector<bool> &featureVisible = {});
   void clear();
   double xValue(const QMouseEvent *event) const;
   const QVector<double> &getTimepoints() const;

--- a/gui/widgets/plotwrapper_t.cpp
+++ b/gui/widgets/plotwrapper_t.cpp
@@ -105,3 +105,19 @@ TEST_CASE("PlotWrapper",
   REQUIRE(p.plot->graphCount() == 0);
   REQUIRE(p.getTimepoints().size() == 0);
 }
+
+TEST_CASE("PlotWrapper feature lines",
+          "[gui/widgets/plotwrapper][gui/widgets][gui][plotwrapper]") {
+  QWidget parent;
+  PlotWrapper p("title", &parent);
+  QColor featureColor(12, 34, 56);
+  p.addFeatureLine("feature region", featureColor,
+                   QCPScatterStyle::ScatterShape::ssSquare);
+
+  REQUIRE(p.plot->graphCount() == 1);
+  REQUIRE(p.plot->graph(0)->name() == "feature region");
+  REQUIRE(p.plot->graph(0)->pen().color() == featureColor);
+  REQUIRE(p.plot->graph(0)->pen().style() == Qt::DashLine);
+  REQUIRE(p.plot->graph(0)->scatterStyle().shape() ==
+          QCPScatterStyle::ScatterShape::ssSquare);
+}

--- a/gui/widgets/regioncolorslabel.cpp
+++ b/gui/widgets/regioncolorslabel.cpp
@@ -1,0 +1,107 @@
+#include "regioncolorslabel.hpp"
+#include "sme/utils.hpp"
+#include <QPainter>
+#include <algorithm>
+#include <limits>
+
+namespace {
+
+constexpr int fixedHeight{24};
+constexpr int preferredWidth{160};
+
+QColor textColorForBackground(const QColor &background) {
+  const auto luminance = 0.2126 * background.redF() +
+                         0.7152 * background.greenF() +
+                         0.0722 * background.blueF();
+  return luminance > 0.55 ? QColor{0, 0, 0} : QColor{255, 255, 255};
+}
+
+} // namespace
+
+RegionColorsLabel::RegionColorsLabel(QWidget *parent) : QLabel(parent) {
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  setMinimumHeight(fixedHeight);
+  setMaximumHeight(fixedHeight);
+  setFrameShape(QFrame::NoFrame);
+  setText({});
+}
+
+void RegionColorsLabel::setNumberOfRegions(std::size_t numRegions) {
+  if (nRegions == numRegions) {
+    return;
+  }
+  nRegions = numRegions;
+  update();
+}
+
+std::size_t RegionColorsLabel::getNumberOfRegions() const { return nRegions; }
+
+QSize RegionColorsLabel::sizeHint() const {
+  return {preferredWidth, fixedHeight};
+}
+
+QSize RegionColorsLabel::minimumSizeHint() const { return {0, fixedHeight}; }
+
+void RegionColorsLabel::paintEvent(QPaintEvent *event) {
+  QLabel::paintEvent(event);
+  if (!isEnabled() || nRegions == 0) {
+    return;
+  }
+
+  const QRect regionRect{rect()};
+  if (regionRect.width() <= 0 || regionRect.height() <= 0) {
+    return;
+  }
+
+  const auto nRegionsInt{static_cast<int>(std::min(
+      nRegions, static_cast<std::size_t>(std::numeric_limits<int>::max())))};
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, false);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
+
+  sme::common::indexedColors indexedColors;
+  for (int region = 0; region < nRegionsInt; ++region) {
+    const int x0 =
+        regionRect.left() + static_cast<int>(static_cast<long long>(region) *
+                                             regionRect.width() / nRegionsInt);
+    const int x1 = regionRect.left() +
+                   static_cast<int>(static_cast<long long>(region + 1) *
+                                    regionRect.width() / nRegionsInt);
+    const QRect rect{x0, regionRect.top(), std::max(1, x1 - x0),
+                     regionRect.height()};
+    painter.fillRect(rect, indexedColors[static_cast<std::size_t>(region)]);
+  }
+
+  painter.setPen(QColor{0, 0, 0, 120});
+  for (int region = 1; region < nRegionsInt; ++region) {
+    const int x =
+        regionRect.left() + static_cast<int>(static_cast<long long>(region) *
+                                             regionRect.width() / nRegionsInt);
+    painter.drawLine(x, regionRect.top(), x, regionRect.bottom());
+  }
+
+  const int regionWidth{std::max(1, regionRect.width() / nRegionsInt)};
+  if (regionRect.height() < 14 || regionWidth < 14) {
+    return;
+  }
+
+  auto font = this->font();
+  font.setBold(true);
+  font.setPixelSize(
+      std::max(8, std::min(regionRect.height() - 4, regionWidth / 2)));
+  painter.setFont(font);
+  painter.setRenderHint(QPainter::TextAntialiasing, true);
+  for (int region = 0; region < nRegionsInt; ++region) {
+    const int x0 =
+        regionRect.left() + static_cast<int>(static_cast<long long>(region) *
+                                             regionRect.width() / nRegionsInt);
+    const int x1 = regionRect.left() +
+                   static_cast<int>(static_cast<long long>(region + 1) *
+                                    regionRect.width() / nRegionsInt);
+    const QRect rect{x0, regionRect.top(), std::max(1, x1 - x0),
+                     regionRect.height()};
+    const auto &background{indexedColors[static_cast<std::size_t>(region)]};
+    painter.setPen(textColorForBackground(background));
+    painter.drawText(rect, Qt::AlignCenter, QString::number(region + 1));
+  }
+}

--- a/gui/widgets/regioncolorslabel.hpp
+++ b/gui/widgets/regioncolorslabel.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QLabel>
+#include <QSize>
+#include <cstddef>
+
+class RegionColorsLabel : public QLabel {
+  Q_OBJECT
+
+public:
+  explicit RegionColorsLabel(QWidget *parent = nullptr);
+
+  void setNumberOfRegions(std::size_t nRegions);
+  [[nodiscard]] std::size_t getNumberOfRegions() const;
+  [[nodiscard]] QSize sizeHint() const override;
+  [[nodiscard]] QSize minimumSizeHint() const override;
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+
+private:
+  std::size_t nRegions{};
+};

--- a/gui/widgets/regioncolorslabel_t.cpp
+++ b/gui/widgets/regioncolorslabel_t.cpp
@@ -1,0 +1,95 @@
+#include "catch_wrapper.hpp"
+#include "qt_test_utils.hpp"
+#include "regioncolorslabel.hpp"
+#include "sme/utils.hpp"
+#include <QColor>
+#include <QImage>
+#include <QSizePolicy>
+#include <algorithm>
+
+using namespace sme::test;
+
+namespace {
+
+QImage render(const QWidget &widget) {
+  QImage image(widget.size(), QImage::Format_ARGB32);
+  image.fill(Qt::transparent);
+  const_cast<QWidget &>(widget).render(&image);
+  return image;
+}
+
+int regionCenterX(const QRect &rect, int region, int nRegions) {
+  return rect.left() + static_cast<int>(static_cast<long long>(2 * region + 1) *
+                                        rect.width() / (2 * nRegions));
+}
+
+QRect regionRect(const QRect &rect, int region, int nRegions) {
+  const int x0 = rect.left() + static_cast<int>(static_cast<long long>(region) *
+                                                rect.width() / nRegions);
+  const int x1 =
+      rect.left() + static_cast<int>(static_cast<long long>(region + 1) *
+                                     rect.width() / nRegions);
+  return {x0, rect.top(), std::max(1, x1 - x0), rect.height()};
+}
+
+bool containsTextPixels(const QImage &image, const QRect &cell,
+                        QRgb backgroundColor) {
+  const QRect textArea{
+      QRect{cell.center().x() - 10, cell.top() + 2, 20, cell.height() - 4}
+          .intersected(cell.adjusted(2, 2, -2, -2))};
+  for (int y = textArea.top(); y <= textArea.bottom(); ++y) {
+    for (int x = textArea.left(); x <= textArea.right(); ++x) {
+      if (QColor(image.pixel(x, y)).rgb() != backgroundColor) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+TEST_CASE("RegionColorsLabel",
+          "[gui/widgets/regioncolorslabel][gui/widgets][gui][features]") {
+  RegionColorsLabel label;
+
+  REQUIRE(label.getNumberOfRegions() == 0);
+  REQUIRE(label.pixmap().isNull());
+  REQUIRE(label.sizePolicy().horizontalPolicy() == QSizePolicy::Expanding);
+  REQUIRE(label.sizePolicy().verticalPolicy() == QSizePolicy::Fixed);
+  REQUIRE(label.minimumHeight() == 24);
+  REQUIRE(label.maximumHeight() == 24);
+  REQUIRE(label.frameShape() == QFrame::NoFrame);
+
+  label.resize(300, 24);
+  label.setNumberOfRegions(3);
+  label.show();
+  waitFor(&label);
+
+  REQUIRE(label.getNumberOfRegions() == 3);
+  REQUIRE(label.pixmap().isNull());
+
+  const auto image = render(label);
+  const auto rect = label.rect();
+  const int y = rect.top();
+  sme::common::indexedColors indexedColors;
+  REQUIRE(QColor(image.pixel(rect.left(), rect.top())).rgb() ==
+          indexedColors[0].rgb());
+  REQUIRE(QColor(image.pixel(regionCenterX(rect, 0, 3), y)).rgb() ==
+          indexedColors[0].rgb());
+  REQUIRE(QColor(image.pixel(regionCenterX(rect, 1, 3), y)).rgb() ==
+          indexedColors[1].rgb());
+  REQUIRE(QColor(image.pixel(regionCenterX(rect, 2, 3), y)).rgb() ==
+          indexedColors[2].rgb());
+
+  REQUIRE(containsTextPixels(image, regionRect(rect, 0, 3),
+                             indexedColors[0].rgb()));
+  REQUIRE(containsTextPixels(image, regionRect(rect, 1, 3),
+                             indexedColors[1].rgb()));
+  REQUIRE(containsTextPixels(image, regionRect(rect, 2, 3),
+                             indexedColors[2].rgb()));
+
+  label.setNumberOfRegions(0);
+  REQUIRE(label.getNumberOfRegions() == 0);
+  REQUIRE(label.pixmap().isNull());
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sme"
-version = "1.11.0"
+version = "1.12.0"
 description = "Spatial Model Editor python bindings"
 readme = "README.md"
 license = {text = "MIT"}
@@ -57,4 +57,4 @@ SME_LOG_LEVEL = "OFF"
 build-verbosity = 3
 test-extras = "test"
 test-command = "python -m pytest {project}/sme/test -v"
-skip = 'cp38-* *-manylinux_i686 *-musllinux* *-win32 cp3??t-win*'
+skip = 'cp38-* *-manylinux_i686 *-musllinux* *-win32'

--- a/sme/src/sme_model.cpp
+++ b/sme/src/sme_model.cpp
@@ -406,9 +406,11 @@ void bindModel(nanobind::module_ &m) {
 
 static std::vector<SimulationResult>
 constructSimulationResults(const ::sme::simulate::Simulation *sim,
-                           bool getDcdt) {
+                           const ::sme::model::Model &model, bool getDcdt) {
   std::vector<SimulationResult> results;
   const auto timePoints{sim->getTimePoints()};
+  const auto &features{model.getFeatures().getFeatures()};
+  const auto &featureResults{sim->getSimulationData().featureResults};
   results.reserve(timePoints.size());
   for (std::size_t i = 0; i < timePoints.size(); ++i) {
     auto &result = results.emplace_back();
@@ -432,6 +434,18 @@ constructSimulationResults(const ::sme::simulate::Simulation *sim,
                 as_ndarray(std::move(dcdts[si]), shape);
           }
         }
+      }
+    }
+    for (std::size_t fi = 0; fi < features.size() && fi < featureResults.size();
+         ++fi) {
+      const auto &values{featureResults[fi].values};
+      if (i < values.size()) {
+        auto featureValues{values[i]};
+        auto nFeatureValues{featureValues.size()};
+        const auto &featureName{features[fi].name};
+        result.feature_values[nanobind::str(featureName.data(),
+                                            featureName.size())] =
+            as_ndarray(std::move(featureValues), {nFeatureValues});
       }
     }
   }
@@ -597,7 +611,7 @@ std::vector<SimulationResult> Model::simulateString(
     throw std::runtime_error(fmt::format("Error during simulation: {}", e));
   }
   if (returnResults) {
-    return constructSimulationResults(sim.get(), true);
+    return constructSimulationResults(sim.get(), *s, true);
   }
   return {};
 }
@@ -633,7 +647,7 @@ std::vector<SimulationResult> Model::getSimulationResults() {
   if (const auto &e{sim->errorMessage()}; !e.empty()) {
     throw std::runtime_error(fmt::format("Error in simulation setup: {}", e));
   }
-  return constructSimulationResults(sim.get(), false);
+  return constructSimulationResults(sim.get(), *s, false);
 }
 
 std::string Model::getStr() const {

--- a/sme/src/sme_simulationresult.cpp
+++ b/sme/src/sme_simulationresult.cpp
@@ -101,6 +101,13 @@ void bindSimulationResult(nanobind::module_ &m) {
                         >>> import matplotlib.pyplot as plt  # doctest: +SKIP
                         >>> imgplot = plt.imshow(b_cell[0])  # doctest: +SKIP
                     )")
+      .def_ro("feature_values", &SimulationResult::feature_values,
+              R"(
+                    Dict[str, numpy.ndarray]: calculated feature values at this timepoint
+
+                    for each feature, the values are provided as a 1d array
+                    with one value per feature region.
+                    )")
       .def_ro("species_dcdt", &SimulationResult::species_dcdt,
               R"(
                     Dict[str, numpy.ndarray]: the species concentration rate of change at this timepoint

--- a/sme/src/sme_simulationresult.hpp
+++ b/sme/src/sme_simulationresult.hpp
@@ -15,6 +15,7 @@ struct SimulationResult {
   double timePoint{0.0};
   nanobind::ndarray<nanobind::numpy, std::uint8_t> concentration_image{};
   nanobind::dict species_concentration{};
+  nanobind::dict feature_values{};
   nanobind::dict species_dcdt{};
   [[nodiscard]] std::string getStr() const;
   [[nodiscard]] std::string getName() const;

--- a/sme/test/test_model.py
+++ b/sme/test/test_model.py
@@ -267,6 +267,39 @@ def test_simulate():
     assert len(m.simulation_results()) == 3
 
 
+def test_simulation_result_feature_values():
+    m = sme.open_example_model("ABtoC")
+    sim_results = m.simulate(0.001, 0.001, simulator_type=sme.SimulatorType.Pixel)
+    assert len(sim_results) == 2
+
+    first_result = sim_results[0]
+    assert set(first_result.feature_values.keys()) == {"A average", "B average"}
+    assert first_result.feature_values["A average"].shape == (1,)
+    assert first_result.feature_values["A average"].dtype == np.float64
+    assert first_result.feature_values["B average"].shape == (1,)
+
+    mask = m.compartments["comp"].geometry_mask
+    a_concentration = first_result.species_concentration["A"]
+    b_concentration = first_result.species_concentration["B"]
+    assert first_result.feature_values["A average"][0] == pytest.approx(
+        np.mean(a_concentration[mask])
+    )
+    assert first_result.feature_values["B average"][0] == pytest.approx(
+        np.mean(b_concentration[mask])
+    )
+
+    saved_results = m.simulation_results()
+    assert len(saved_results) == len(sim_results)
+    assert np.allclose(
+        saved_results[0].feature_values["A average"],
+        first_result.feature_values["A average"],
+    )
+    assert np.allclose(
+        saved_results[0].feature_values["B average"],
+        first_result.feature_values["B average"],
+    )
+
+
 def test_simulate_3d():
     for sim_type in [sme.SimulatorType.DUNE, sme.SimulatorType.Pixel]:
         m = sme.open_example_model("very-simple-model-3d")


### PR DESCRIPTION
- a feature consists of
  - a data source: compartment & species
  - a region of interest (ROI): a set of voxels
  - a summary statistic: such as average, or sum
  - the number of sub-regions (default: 1)
- ROIs can be defined in different ways
  - a built-in one can be selected
  - a tiff image can be provided with 0 for outside ROI, 1 for inside ROI
  - an analytic function can be provided that evaluates to 0 outside ROI, 1 inside the ROI
- ROIs can also have multiple regions
  - e.g. tiff image can have 0, 1, 2, 3 values
  - each non-zero value corresponds to the voxels for that region within the ROI
  - for analytic expressions, the expression is evaluated at each voxel then rounded down to the nearest integer value to assign to a sub-region
- add Features tab to mainwindow
  - add, remove, edit model features
- allow features to be used as optimisation targets
- resolves #1136
- bump version to 1.12.0
