### PR TITLE
Improve ImageSlice dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- ImageSlice dialog now uses the currently selected z-slice, mouseover text reports physical `x/y/z/t` values, geometry image has grid and scale overlays [#577](https://github.com/spatial-model-editor/spatial-model-editor/issues/577)
+
 ## [1.12.0] - 2026-04-22
 ### Added
 - allow constant species to have spatially varying concentrations [#1133](https://github.com/spatial-model-editor/spatial-model-editor/issues/1133)

--- a/gui/dialogs/dialogimageslice.cpp
+++ b/gui/dialogs/dialogimageslice.cpp
@@ -1,5 +1,6 @@
 #include "dialogimageslice.hpp"
 #include "sme/logger.hpp"
+#include "sme/model_geometry.hpp"
 #include "sme/simulate.hpp"
 #include "ui_dialogimageslice.h"
 #include <QFileDialog>
@@ -27,6 +28,15 @@ void setAxisRange(QCPAxis *axis, double minValue, double maxValue) {
   axis->setRange(minValue, maxValue);
 }
 
+QString toQStr(double x) { return QString::number(x, 'g', 14); }
+
+QString formatValueWithUnit(double value, const QString &unit) {
+  if (unit.isEmpty()) {
+    return toQStr(value);
+  }
+  return QString("%1 %2").arg(toQStr(value), unit);
+}
+
 } // namespace
 
 DialogImageSlice::DialogImageSlice(
@@ -40,9 +50,25 @@ DialogImageSlice::DialogImageSlice(
       endPoint{geometryImage.volume().width() - 1, 0} {
   ui->setupUi(this);
 
+  if (!geometryImage.empty()) {
+    zIndex = static_cast<std::size_t>(
+        std::clamp(plotData.zIndex, 0,
+                   static_cast<int>(geometryImage.volume().depth()) - 1));
+  }
+
   ui->lblImage->setAspectRatioMode(Qt::IgnoreAspectRatio);
   ui->lblImage->setTransformationMode(Qt::FastTransformation);
-  ui->lblSlice->setImage(geometryImage[z_index], invertYAxis);
+  ui->lblSlice->setImage(geometryImage[zIndex], invertYAxis);
+  ui->lblSlice->setPhysicalUnits(plotData.lengthUnit);
+  if (plotData.geometry != nullptr) {
+    ui->lblSlice->setPhysicalOrigin(plotData.geometry->getPhysicalOrigin());
+  }
+  ui->lblSlice->setPhysicalSize(
+      {geometryImage.voxelSize().width() *
+           static_cast<double>(geometryImage.volume().width()),
+       geometryImage.voxelSize().height() *
+           static_cast<double>(geometryImage.volume().height()),
+       1.0});
   initConcentrationPlot();
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
@@ -67,6 +93,10 @@ DialogImageSlice::DialogImageSlice(
               lbl->setTransformationMode(Qt::FastTransformation);
             }
           });
+  connect(ui->chkGrid, &QCheckBox::toggled, this,
+          [lbl = ui->lblSlice](bool checked) { lbl->displayGrid(checked); });
+  connect(ui->chkScale, &QCheckBox::toggled, this,
+          [lbl = ui->lblSlice](bool checked) { lbl->displayScale(checked); });
   connect(ui->lblSlice, &QLabelSlice::mouseDown, this,
           &DialogImageSlice::lblSlice_mouseDown);
   connect(ui->lblSlice, &QLabelSlice::sliceDrawn, this,
@@ -137,7 +167,7 @@ void DialogImageSlice::updateSlicePlotData() {
   double distance{0.0};
   distanceAlongSlice.push_back(0.0);
   sliceArrayIndices.push_back(sme::common::voxelArrayIndex(
-      volume, pixels.front().x(), pixels.front().y(), z_index));
+      volume, pixels.front().x(), pixels.front().y(), zIndex));
   for (std::size_t i = 1; i < pixels.size(); ++i) {
     const auto dx{static_cast<double>(pixels[i].x() - pixels[i - 1].x()) *
                   voxelSize.width()};
@@ -146,7 +176,7 @@ void DialogImageSlice::updateSlicePlotData() {
     distance += std::hypot(dx, dy);
     distanceAlongSlice.push_back(distance);
     sliceArrayIndices.push_back(sme::common::voxelArrayIndex(
-        volume, pixels[i].x(), pixels[i].y(), z_index));
+        volume, pixels[i].x(), pixels[i].y(), zIndex));
   }
   fixedAxisRangesValid = false;
 }
@@ -207,7 +237,7 @@ void DialogImageSlice::updateSlicedImage() {
   for (const auto &img : imgs) {
     int y = np - 1;
     for (const auto &pixel : pixels) {
-      slice[0].setPixel(t, y, img[z_index].pixel(pixel));
+      slice[0].setPixel(t, y, img[zIndex].pixel(pixel));
       --y;
     }
     ++t;
@@ -226,10 +256,9 @@ void DialogImageSlice::updateDisplayedSlicedImage() {
 void DialogImageSlice::updateSelectedTimepointText() {
   QString text;
   if (!time.isEmpty()) {
-    text = QString("Displayed timepoint: %1").arg(time[selectedTimepointIndex]);
-    if (!plotData.timeUnit.isEmpty()) {
-      text.append(QString(" %1").arg(plotData.timeUnit));
-    }
+    text = QString("Displayed time: %1")
+               .arg(formatValueWithUnit(time[selectedTimepointIndex],
+                                        plotData.timeUnit));
   }
   ui->lblSelectedTimepoint->setText(text);
 }
@@ -344,6 +373,17 @@ void DialogImageSlice::cmbSliceType_activated(int index) {
       QPoint(imgs[0].volume().width() / 2, imgs[0].volume().height() / 2));
 }
 
+QString
+DialogImageSlice::formatPhysicalPoint(const sme::common::Voxel &voxel) const {
+  if (plotData.geometry != nullptr) {
+    return plotData.geometry->getPhysicalPointAsString(voxel);
+  }
+  return QString("x: %1, y: %2, z: %3")
+      .arg(voxel.p.x())
+      .arg(voxel.p.y())
+      .arg(voxel.z);
+}
+
 void DialogImageSlice::lblSlice_mouseDown(QPoint point) {
   if (sliceType == SliceType::Horizontal) {
     horizontal = point.y();
@@ -374,7 +414,8 @@ void DialogImageSlice::lblSlice_mouseWheelEvent(int delta) {
 
 void DialogImageSlice::lblSlice_mouseOver(QPoint point) {
   ui->lblMouseLocation->setText(
-      QString("Mouse location: (x=%1, y=%2)").arg(point.x()).arg(point.y()));
+      QString("Mouse location: %1")
+          .arg(formatPhysicalPoint({point.x(), point.y(), zIndex})));
 }
 
 void DialogImageSlice::lblImage_mouseOver(const sme::common::Voxel &voxel) {
@@ -382,13 +423,18 @@ void DialogImageSlice::lblImage_mouseOver(const sme::common::Voxel &voxel) {
       ui->lblSlice->getSlicePixels().empty()) {
     return;
   }
-  double t = time[voxel.p.x()];
+  if (voxel.p.x() < 0 || voxel.p.x() >= static_cast<int>(time.size())) {
+    return;
+  }
   auto i{static_cast<std::size_t>(slice[0].height() - 1 - voxel.p.y())};
+  if (i >= ui->lblSlice->getSlicePixels().size()) {
+    return;
+  }
   const auto &p = ui->lblSlice->getSlicePixels()[i];
-  ui->lblMouseLocation->setText(QString("Mouse location: (x=%1, y=%2, t=%3)")
-                                    .arg(p.x())
-                                    .arg(p.y())
-                                    .arg(t));
+  ui->lblMouseLocation->setText(
+      QString("Mouse location: %1, t: %2")
+          .arg(formatPhysicalPoint({p.x(), p.y(), zIndex}))
+          .arg(formatValueWithUnit(time[voxel.p.x()], plotData.timeUnit)));
 }
 
 void DialogImageSlice::slideTimepoint_valueChanged(int value) {

--- a/gui/dialogs/dialogimageslice.hpp
+++ b/gui/dialogs/dialogimageslice.hpp
@@ -14,16 +14,22 @@ namespace sme::simulate {
 class Simulation;
 }
 
+namespace sme::model {
+class ModelGeometry;
+}
+
 enum class SliceType { Horizontal, Vertical, Custom };
 
 struct DialogImageSlicePlotData {
   const sme::simulate::Simulation *simulation{nullptr};
+  const sme::model::ModelGeometry *geometry{nullptr};
   QStringList compartmentNames{};
   std::vector<std::vector<std::size_t>> speciesToDraw{};
   QString timeUnit{};
   QString lengthUnit{};
   QString concentrationUnit{};
   int timepointIndex{-1};
+  int zIndex{0};
 };
 
 class DialogImageSlice : public QDialog {
@@ -39,12 +45,11 @@ public:
   QImage getSlicedImage() const;
 
 private:
-  // todo: don't hard-code z to zero here
-  static constexpr std::size_t z_index{0};
   const std::unique_ptr<Ui::DialogImageSlice> ui;
   const QVector<sme::common::ImageStack> &imgs;
   const QVector<double> &time;
   const DialogImageSlicePlotData plotData;
+  std::size_t zIndex{0};
   sme::common::ImageStack slice;
   QVector<double> distanceAlongSlice;
   std::vector<std::size_t> sliceArrayIndices;
@@ -66,6 +71,8 @@ private:
   void updateDisplayedSlicedImage();
   void updateSelectedTimepointText();
   void updateConcentrationPlot();
+  [[nodiscard]] QString
+  formatPhysicalPoint(const sme::common::Voxel &voxel) const;
   void saveSlicedImage();
   void cmbSliceType_activated(int index);
   void lblSlice_mouseDown(QPoint point);

--- a/gui/dialogs/dialogimageslice.ui
+++ b/gui/dialogs/dialogimageslice.ui
@@ -62,6 +62,24 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayoutSliceOptions">
+         <item>
+          <widget class="QCheckBox" name="chkGrid">
+           <property name="text">
+            <string>Show &amp;grid</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chkScale">
+           <property name="text">
+            <string>Show &amp;scale</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="lblGeometrySlice">
          <property name="sizePolicy">

--- a/gui/dialogs/dialogimageslice_t.cpp
+++ b/gui/dialogs/dialogimageslice_t.cpp
@@ -17,10 +17,31 @@
 
 using namespace sme::test;
 
+namespace {
+
+double graphMaxValue(const QCPGraph *graph) {
+  const auto &data{*graph->data()};
+  bool haveValue{false};
+  double maxValue{0.0};
+  for (auto it = data.constBegin(); it != data.constEnd(); ++it) {
+    if (!haveValue) {
+      maxValue = it->value;
+      haveValue = true;
+      continue;
+    }
+    maxValue = std::max(maxValue, it->value);
+  }
+  return haveValue ? maxValue : 0.0;
+}
+
+} // namespace
+
 struct DialogImageSliceWidgets {
   explicit DialogImageSliceWidgets(const DialogImageSlice *dialog) {
     GET_DIALOG_WIDGET(QSplitter, splitter);
     GET_DIALOG_WIDGET(QComboBox, cmbSliceType);
+    GET_DIALOG_WIDGET(QCheckBox, chkGrid);
+    GET_DIALOG_WIDGET(QCheckBox, chkScale);
     GET_DIALOG_WIDGET(QCheckBox, chkAspectRatio);
     GET_DIALOG_WIDGET(QCheckBox, chkSmoothInterpolation);
     GET_DIALOG_WIDGET(QCheckBox, chkAutoscaleYAxis);
@@ -33,6 +54,8 @@ struct DialogImageSliceWidgets {
   }
   QSplitter *splitter;
   QComboBox *cmbSliceType;
+  QCheckBox *chkGrid;
+  QCheckBox *chkScale;
   QCheckBox *chkAspectRatio;
   QCheckBox *chkSmoothInterpolation;
   QCheckBox *chkAutoscaleYAxis;
@@ -64,6 +87,8 @@ TEST_CASE("DialogImageSlice",
   REQUIRE(splitterSizes[1] > splitterSizes[0]);
   REQUIRE(splitterSizes[1] >= 1.7 * splitterSizes[0]);
   REQUIRE(splitterSizes[1] <= 2.3 * splitterSizes[0]);
+  REQUIRE(widgets.chkGrid->isChecked() == false);
+  REQUIRE(widgets.chkScale->isChecked() == false);
   REQUIRE(widgets.chkSmoothInterpolation->isChecked() == false);
   REQUIRE(widgets.chkAutoscaleYAxis->isChecked() == false);
   REQUIRE(widgets.chkAutoscaleYAxis->text() == "Autoscale y-axis");
@@ -92,6 +117,13 @@ TEST_CASE("DialogImageSlice",
     sendMouseMove(widgets.lblImage, {40, 32});
     newText = widgets.lblMouseLocation->text();
     REQUIRE(oldText != newText);
+  }
+  SECTION("user enables grid and scale on geometry slice") {
+    auto withoutOverlays{widgets.lblSlice->QLabel::pixmap().toImage()};
+    widgets.chkGrid->setChecked(true);
+    widgets.chkScale->setChecked(true);
+    auto withOverlays{widgets.lblSlice->QLabel::pixmap().toImage()};
+    REQUIRE(withoutOverlays != withOverlays);
   }
   SECTION("user sets slice to horizontal") {
     sendKeyEvents(widgets.cmbSliceType, {"Up"});
@@ -132,6 +164,42 @@ TEST_CASE("DialogImageSlice",
     REQUIRE(img.height() == imgs[0][0].height());
   }
 
+  SECTION("selected z-slice is used for the sliced image") {
+    constexpr QRgb z0t0{0xff112233};
+    constexpr QRgb z1t0{0xff445566};
+    constexpr QRgb z2t0{0xff778899};
+    constexpr QRgb z0t1{0xff99aabb};
+    constexpr QRgb z1t1{0xffccddee};
+    constexpr QRgb z2t1{0xff123abc};
+    sme::common::ImageStack imgGeometry3d({12, 8, 3},
+                                          QImage::Format_ARGB32_Premultiplied);
+    QVector<sme::common::ImageStack> imgs3d;
+    imgs3d.emplace_back(imgGeometry3d.volume(),
+                        QImage::Format_ARGB32_Premultiplied);
+    imgs3d.emplace_back(imgGeometry3d.volume(),
+                        QImage::Format_ARGB32_Premultiplied);
+    imgs3d[0][0].fill(z0t0);
+    imgs3d[0][1].fill(z1t0);
+    imgs3d[0][2].fill(z2t0);
+    imgs3d[1][0].fill(z0t1);
+    imgs3d[1][1].fill(z1t1);
+    imgs3d[1][2].fill(z2t1);
+    QVector<double> time3d{0.0, 0.25};
+    DialogImageSlicePlotData plotData;
+    plotData.zIndex = 1;
+
+    DialogImageSlice dialog3d(imgGeometry3d, imgs3d, time3d, false, plotData);
+    dialog3d.show();
+
+    QImage slice = dialog3d.getSlicedImage();
+    REQUIRE(slice.width() == imgs3d.size());
+    REQUIRE(slice.height() == imgs3d[0][1].height());
+    REQUIRE(slice.pixel(0, 0) == z1t0);
+    REQUIRE(slice.pixel(0, slice.height() - 1) == z1t0);
+    REQUIRE(slice.pixel(1, 0) == z1t1);
+    REQUIRE(slice.pixel(1, slice.height() - 1) == z1t1);
+  }
+
   SECTION("simulation-backed plot updates with timepoint slider") {
     auto model{getExampleModel(Mod::ABtoC)};
     model.getSimulationSettings().times.clear();
@@ -150,6 +218,7 @@ TEST_CASE("DialogImageSlice",
     }
     DialogImageSlicePlotData plotData;
     plotData.simulation = &sim;
+    plotData.geometry = &model.getGeometry();
     plotData.speciesToDraw = {{0}};
     for (const auto &compartmentId : sim.getCompartmentIds()) {
       plotData.compartmentNames.push_back(
@@ -171,7 +240,7 @@ TEST_CASE("DialogImageSlice",
     REQUIRE(plottedWidgets.lblSelectedTimepoint->text().contains("0.01"));
     REQUIRE(plottedWidgets.concentrationPlot->graphCount() == 1);
     REQUIRE(plottedWidgets.concentrationPlot->graph(0)->dataCount() ==
-            model.getGeometry().getImages().volume().height());
+            static_cast<int>(plottedWidgets.lblSlice->getSlicePixels().size()));
     REQUIRE(plottedWidgets.chkSmoothInterpolation->isChecked() == false);
     REQUIRE(plottedWidgets.chkAutoscaleYAxis->isChecked() == false);
     REQUIRE(plottedWidgets.lblImage->getImage()[0] ==
@@ -257,5 +326,67 @@ TEST_CASE("DialogImageSlice",
     REQUIRE(autoscaledYAxisRange.upper ==
             dbl_approx(expectedAutoscaledMaxConcentration));
     REQUIRE(autoscaledYAxisRange.upper < fixedYAxisRange.upper);
+  }
+
+  SECTION("simulation-backed 3d custom slice uses selected z plane") {
+    auto model{getExampleModel(Mod::VerySimpleModel3D)};
+    model.getSimulationSettings().times.clear();
+    model.getSimulationSettings().simulatorType =
+        sme::simulate::SimulatorType::Pixel;
+    sme::simulate::Simulation sim(model);
+    sim.doTimesteps(0.01);
+
+    QVector<double> timepoints;
+    for (double t : sim.getTimePoints()) {
+      timepoints.push_back(t);
+    }
+    QVector<sme::common::ImageStack> concImages;
+    concImages.reserve(static_cast<int>(timepoints.size()));
+    for (std::size_t i = 0; i < static_cast<std::size_t>(timepoints.size());
+         ++i) {
+      concImages.push_back(sim.getConcImage(i));
+    }
+
+    DialogImageSlicePlotData plotData;
+    plotData.simulation = &sim;
+    plotData.geometry = &model.getGeometry();
+    for (const auto &compartmentId : sim.getCompartmentIds()) {
+      plotData.compartmentNames.push_back(
+          model.getCompartments().getName(compartmentId.c_str()));
+    }
+    plotData.timeUnit = model.getUnits().getTime().name;
+    plotData.lengthUnit = model.getUnits().getLength().name;
+    plotData.concentrationUnit = model.getUnits().getConcentration();
+    plotData.timepointIndex = 1;
+    plotData.zIndex = 14;
+
+    DialogImageSlice plottedDialog(model.getGeometry().getImages(), concImages,
+                                   timepoints, false, plotData);
+    plottedDialog.show();
+    DialogImageSliceWidgets plottedWidgets(&plottedDialog);
+
+    sendKeyEvents(plottedWidgets.cmbSliceType, {"Down"});
+
+    REQUIRE(plottedWidgets.concentrationPlot->graphCount() == 5);
+    REQUIRE(graphMaxValue(plottedWidgets.concentrationPlot->graph(0)) > 0.0);
+    REQUIRE(plottedWidgets.concentrationPlot->yAxis->range().upper > 1e-10);
+
+    sendMouseMove(plottedWidgets.lblSlice,
+                  {plottedWidgets.lblSlice->width() / 2,
+                   plottedWidgets.lblSlice->height() / 2});
+    auto sliceText{plottedWidgets.lblMouseLocation->text()};
+    REQUIRE(sliceText.contains("x:"));
+    REQUIRE(sliceText.contains("y:"));
+    REQUIRE(sliceText.contains("z:"));
+
+    sendMouseMove(plottedWidgets.lblImage,
+                  {3 * plottedWidgets.lblImage->width() / 4,
+                   plottedWidgets.lblImage->height() / 2});
+    auto imageText{plottedWidgets.lblMouseLocation->text()};
+    REQUIRE(imageText.contains("x:"));
+    REQUIRE(imageText.contains("y:"));
+    REQUIRE(imageText.contains("z:"));
+    REQUIRE(imageText.contains("t:"));
+    REQUIRE(imageText.contains(model.getUnits().getTime().name));
   }
 }

--- a/gui/tabs/tabsimulate.cpp
+++ b/gui/tabs/tabsimulate.cpp
@@ -451,12 +451,16 @@ void TabSimulate::btnSimulate_clicked() {
 void TabSimulate::btnSliceImage_clicked() {
   DialogImageSlicePlotData plotData;
   plotData.simulation = sim.get();
+  plotData.geometry = &model.getGeometry();
   plotData.compartmentNames = compartmentNames;
   plotData.speciesToDraw = compartmentSpeciesToDraw;
   plotData.timeUnit = model.getUnits().getTime().name;
   plotData.lengthUnit = model.getUnits().getLength().name;
   plotData.concentrationUnit = model.getUnits().getConcentration();
   plotData.timepointIndex = ui->hslideTime->value();
+  if (const auto *zSlider{lblGeometry->getZSlider()}; zSlider != nullptr) {
+    plotData.zIndex = zSlider->value();
+  }
   DialogImageSlice dialog(model.getGeometry().getImages(), images, time,
                           flipYAxis, plotData);
   if (dialog.exec() == QDialog::Accepted) {

--- a/gui/widgets/CMakeLists.txt
+++ b/gui/widgets/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   gui
   PRIVATE plotwrapper.cpp
+          imagerenderutils.cpp
           gpumemoryusagebarwidget.cpp
           memoryusagebarwidget.cpp
           regioncolorslabel.cpp
@@ -16,6 +17,7 @@ if(BUILD_TESTING)
   target_sources(
     gui_tests
     PUBLIC plotwrapper_t.cpp
+           imagerenderutils_t.cpp
            gpumemoryusagebarwidget_t.cpp
            memoryusagebarwidget_t.cpp
            regioncolorslabel_t.cpp

--- a/gui/widgets/imagerenderutils.cpp
+++ b/gui/widgets/imagerenderutils.cpp
@@ -1,0 +1,272 @@
+#include "imagerenderutils.hpp"
+#include <QPainter>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace sme::gui {
+
+namespace {
+
+struct GridSpacing {
+  double physicalWidth{0.0};
+  int pixelStep{1};
+};
+
+static GridSpacing getGridWidth(const common::VolumeF &physicalSize,
+                                const QSize &pixmapSize,
+                                const QSize &imagePixelSize) {
+  constexpr double minWidthPixels{20};
+  // start with grid of width 1 physical unit
+  double gridPixelWidth{static_cast<double>(pixmapSize.width())};
+  double gridPhysicalWidth{physicalSize.width()};
+  // rescale width in pixels to: ~ [1, 2] * minWidthPixels
+  while (gridPixelWidth < minWidthPixels) {
+    gridPhysicalWidth *= 10.0;
+    gridPixelWidth *= 10.0;
+  }
+  while (gridPixelWidth > 10 * minWidthPixels) {
+    gridPhysicalWidth /= 10.0;
+    gridPixelWidth /= 10.0;
+  }
+  if (gridPixelWidth > 8 * minWidthPixels) {
+    gridPhysicalWidth /= 5.0;
+    gridPixelWidth /= 5.0;
+  } else if (gridPixelWidth > 4 * minWidthPixels) {
+    gridPhysicalWidth /= 2.0;
+    gridPixelWidth /= 2.0;
+  }
+  int pixelStep{1};
+  if (imagePixelSize.width() > 0 && pixmapSize.width() > 0) {
+    double pixelDisplayWidth{static_cast<double>(pixmapSize.width()) /
+                             static_cast<double>(imagePixelSize.width())};
+    if (pixelDisplayWidth > 0.0) {
+      double pixelPhysicalWidth{physicalSize.width() /
+                                static_cast<double>(imagePixelSize.width())};
+      double multiple{std::round(gridPixelWidth / pixelDisplayWidth)};
+      if (multiple < 1.0) {
+        multiple = 1.0;
+      }
+      pixelStep = static_cast<int>(multiple);
+      gridPhysicalWidth = multiple * pixelPhysicalWidth;
+    }
+  }
+  return {gridPhysicalWidth, pixelStep};
+}
+
+static QString getGridPointLabel(double value, bool includeUnits,
+                                 const QString &lengthUnits) {
+  auto label{QString::number(value, 'g', 3)};
+  if (includeUnits) {
+    label.append(" ").append(lengthUnits);
+  }
+  return label;
+}
+
+static std::vector<int> getGridEdgePixels(int nPixels, int pixelStep) {
+  std::vector<int> edgePixels;
+  if (nPixels <= 0 || pixelStep <= 0) {
+    return edgePixels;
+  }
+  for (int i = 0; i < nPixels; i += pixelStep) {
+    edgePixels.push_back(i);
+  }
+  return edgePixels;
+}
+
+// Returns pixel positions for scale tick marks, from 0 to nPixels (inclusive).
+// nPixels is one past the last valid pixel index: it represents the far edge
+// of the image and is always included so the full physical extent is labelled.
+static std::vector<int> getScaleEdgePixels(int nPixels, int pixelStep) {
+  if (nPixels <= 0 || pixelStep <= 0) {
+    return {};
+  }
+  auto edgePixels{getGridEdgePixels(nPixels, pixelStep)};
+  if (edgePixels.back() != nPixels) {
+    edgePixels.push_back(nPixels);
+  }
+  return edgePixels;
+}
+
+static int sourceXToPixmapX(int srcX, int pixmapWidth, int imageWidth) {
+  return std::clamp(
+      static_cast<int>(std::lround(static_cast<double>(srcX) *
+                                   static_cast<double>(pixmapWidth) /
+                                   static_cast<double>(imageWidth))),
+      0, pixmapWidth - 1);
+}
+
+static int sourceYToPixmapY(int srcY, int pixmapHeight, int imageHeight,
+                            bool flipYAxis) {
+  if (flipYAxis) {
+    return std::clamp(
+        static_cast<int>(std::lround(static_cast<double>(srcY) *
+                                     static_cast<double>(pixmapHeight) /
+                                     static_cast<double>(imageHeight))),
+        0, pixmapHeight - 1);
+  }
+  return std::clamp(
+      static_cast<int>(std::lround(static_cast<double>(imageHeight - srcY) *
+                                   static_cast<double>(pixmapHeight) /
+                                   static_cast<double>(imageHeight))),
+      0, pixmapHeight - 1);
+}
+
+static QSize getPixmapSize(const QSize &displaySize, double physicalAspectRatio,
+                           Qt::AspectRatioMode aspectRatioMode) {
+  int width{std::max(1, displaySize.width())};
+  int height{std::max(1, displaySize.height())};
+  if (aspectRatioMode == Qt::IgnoreAspectRatio ||
+      !std::isfinite(physicalAspectRatio) || physicalAspectRatio <= 0.0) {
+    return {width, height};
+  }
+  double displayAspectRatio{static_cast<double>(displaySize.width()) /
+                            static_cast<double>(displaySize.height())};
+  if (displayAspectRatio > physicalAspectRatio) {
+    return {std::max(1, static_cast<int>(displaySize.height() *
+                                         physicalAspectRatio)),
+            height};
+  }
+  return {width, std::max(1, static_cast<int>(displaySize.width() /
+                                              physicalAspectRatio))};
+}
+
+} // namespace
+
+RenderedImage renderImageWithOverlays(const QImage &srcImage,
+                                      const QSize &displaySize,
+                                      const ImageRenderOptions &options) {
+  if (srcImage.isNull()) {
+    return {};
+  }
+
+  RenderedImage rendered;
+  rendered.pixmap = QPixmap(displaySize);
+  rendered.pixmap.fill(QColor(0, 0, 0, 0));
+  QPainter p(&rendered.pixmap);
+  bool haveSpaceForScale{false};
+  if (options.drawScale) {
+    int w{p.fontMetrics().horizontalAdvance("8e+88")};
+    int h{p.fontMetrics().height()};
+    // only draw scale if picture is bigger than labels
+    if (displaySize.width() > 2 * w && displaySize.height() > 2 * h) {
+      rendered.offset = {w + options.tickLength, h + options.tickLength};
+      haveSpaceForScale = true;
+    }
+  }
+  QSize availableSize{displaySize};
+  availableSize.rwidth() -= rendered.offset.x();
+  availableSize.rheight() -= rendered.offset.y();
+  rendered.pixmapImageSize = getPixmapSize(availableSize,
+                                           options.physicalSize.width() /
+                                               options.physicalSize.height(),
+                                           options.aspectRatioMode);
+  double sx{static_cast<double>(rendered.pixmapImageSize.width()) /
+            static_cast<double>(srcImage.width())};
+  double sy{static_cast<double>(rendered.pixmapImageSize.height()) /
+            static_cast<double>(srcImage.height())};
+  p.setRenderHint(QPainter::SmoothPixmapTransform,
+                  options.transformationMode == Qt::SmoothTransformation);
+  p.save();
+  p.translate(rendered.offset.x(), 0);
+  p.scale(sx, sy);
+  p.drawImage(QPoint(0, 0), srcImage);
+  p.restore();
+  if (options.drawGrid || (options.drawScale && haveSpaceForScale)) {
+    QPen gridPen(QColor(127, 127, 127));
+    gridPen.setCosmetic(true);
+    p.setPen(gridPen);
+    auto gridSpacing = getGridWidth(options.physicalSize,
+                                    rendered.pixmapImageSize, srcImage.size());
+    int prevTextEnd{-1000};
+    auto xGridEdgePixels{
+        getGridEdgePixels(srcImage.width(), gridSpacing.pixelStep)};
+    if (options.drawGrid) {
+      for (int srcX : xGridEdgePixels) {
+        int x{sourceXToPixmapX(srcX, rendered.pixmapImageSize.width(),
+                               srcImage.width())};
+        p.drawLine(x + rendered.offset.x(), 0, x + rendered.offset.x(),
+                   rendered.pixmapImageSize.height() - 1);
+      }
+    }
+    auto xScaleEdgePixels{
+        getScaleEdgePixels(srcImage.width(), gridSpacing.pixelStep)};
+    double xPixelWidth{options.physicalSize.width() /
+                       static_cast<double>(srcImage.width())};
+    for (int srcX : xScaleEdgePixels) {
+      int x{sourceXToPixmapX(srcX, rendered.pixmapImageSize.width(),
+                             srcImage.width())};
+      if (options.drawScale && haveSpaceForScale) {
+        auto label{
+            getGridPointLabel(options.physicalOrigin.p.x() +
+                                  static_cast<double>(srcX) * xPixelWidth,
+                              srcX == 0, options.lengthUnits)};
+        // paint text label & extend tick mark if there is enough space
+        if (int labelWidth{p.fontMetrics().horizontalAdvance(label)};
+            prevTextEnd + (labelWidth + 1) / 2 + 4 < x &&
+            x + (labelWidth + 1) / 2 <= rendered.pixmapImageSize.width()) {
+          p.drawText(
+              QRect(x + rendered.offset.x() - labelWidth / 2,
+                    rendered.pixmapImageSize.height() - 1 + options.tickLength,
+                    labelWidth, rendered.offset.y() - options.tickLength),
+              Qt::AlignHCenter | Qt::AlignTop, label);
+          p.drawLine(
+              x + rendered.offset.x(), rendered.pixmapImageSize.height() - 1,
+              x + rendered.offset.x(),
+              rendered.pixmapImageSize.height() - 1 + options.tickLength);
+          prevTextEnd = x + (labelWidth + 1) / 2;
+        }
+      }
+    }
+    auto yGridEdgePixels{
+        getGridEdgePixels(srcImage.height(), gridSpacing.pixelStep)};
+    if (options.drawGrid) {
+      for (int srcY : yGridEdgePixels) {
+        int y{sourceYToPixmapY(srcY, rendered.pixmapImageSize.height(),
+                               srcImage.height(), options.flipYAxis)};
+        p.drawLine(rendered.offset.x(), y,
+                   rendered.offset.x() + rendered.pixmapImageSize.width() - 1,
+                   y);
+      }
+    }
+    auto yScaleEdgePixels{
+        getScaleEdgePixels(srcImage.height(), gridSpacing.pixelStep)};
+    double yPixelWidth{options.physicalSize.height() /
+                       static_cast<double>(srcImage.height())};
+    for (int srcY : yScaleEdgePixels) {
+      int y{sourceYToPixmapY(srcY, rendered.pixmapImageSize.height(),
+                             srcImage.height(), options.flipYAxis)};
+      if (options.drawScale && haveSpaceForScale) {
+        auto label{
+            getGridPointLabel(options.physicalOrigin.p.y() +
+                                  static_cast<double>(srcY) * yPixelWidth,
+                              srcY == 0, options.lengthUnits)};
+        p.drawText(QRect(0, y - rendered.offset.y() / 2,
+                         rendered.offset.x() - options.tickLength,
+                         rendered.offset.y()),
+                   Qt::AlignVCenter | Qt::AlignRight, label);
+        p.drawLine(rendered.offset.x() - options.tickLength, y,
+                   rendered.offset.x(), y);
+      }
+    }
+  }
+  if (options.verticalIndicatorSourceX >= 0 &&
+      options.verticalIndicatorSourceX < srcImage.width()) {
+    QPen indicatorPen(Qt::black);
+    indicatorPen.setCosmetic(true);
+    p.setPen(indicatorPen);
+    int x{std::clamp(
+        static_cast<int>(std::lround(
+            (static_cast<double>(options.verticalIndicatorSourceX) + 0.5) *
+            static_cast<double>(rendered.pixmapImageSize.width()) /
+            static_cast<double>(srcImage.width()))) -
+            1,
+        0, rendered.pixmapImageSize.width() - 1)};
+    p.drawLine(rendered.offset.x() + x, 0, rendered.offset.x() + x,
+               rendered.pixmapImageSize.height() - 1);
+  }
+  p.end();
+  return rendered;
+}
+
+} // namespace sme::gui

--- a/gui/widgets/imagerenderutils.hpp
+++ b/gui/widgets/imagerenderutils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "sme/voxel.hpp"
+#include <QImage>
+#include <QPixmap>
+#include <QString>
+
+namespace sme::gui {
+
+struct ImageRenderOptions {
+  Qt::AspectRatioMode aspectRatioMode{Qt::KeepAspectRatio};
+  Qt::TransformationMode transformationMode{Qt::FastTransformation};
+  bool drawGrid{false};
+  bool drawScale{false};
+  bool flipYAxis{false};
+  int verticalIndicatorSourceX{-1};
+  int tickLength{10};
+  common::VoxelF physicalOrigin{0.0, 0.0, 0.0};
+  common::VolumeF physicalSize{1.0, 1.0, 1.0};
+  QString lengthUnits{};
+};
+
+struct RenderedImage {
+  QPixmap pixmap{};
+  QSize pixmapImageSize{};
+  QPoint offset{0, 0};
+};
+
+[[nodiscard]] RenderedImage
+renderImageWithOverlays(const QImage &srcImage, const QSize &displaySize,
+                        const ImageRenderOptions &options);
+
+} // namespace sme::gui

--- a/gui/widgets/imagerenderutils_t.cpp
+++ b/gui/widgets/imagerenderutils_t.cpp
@@ -1,0 +1,181 @@
+#include "catch_wrapper.hpp"
+#include "imagerenderutils.hpp"
+#include <QColor>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+using namespace sme::gui;
+
+TEST_CASE("ImageRenderUtils preserves physical aspect ratio",
+          "[gui/widgets/imagerenderutils][gui/widgets][gui]") {
+  QImage img(4, 4, QImage::Format_RGB32);
+  img.fill(Qt::white);
+
+  ImageRenderOptions opts;
+  opts.aspectRatioMode = Qt::KeepAspectRatio;
+  opts.physicalSize = {4.0, 2.0, 1.0};
+  auto rendered = renderImageWithOverlays(img, {100, 100}, opts);
+  REQUIRE(rendered.offset == QPoint(0, 0));
+  REQUIRE(rendered.pixmapImageSize == QSize(100, 50));
+
+  opts.aspectRatioMode = Qt::IgnoreAspectRatio;
+  rendered = renderImageWithOverlays(img, {100, 100}, opts);
+  REQUIRE(rendered.pixmapImageSize == QSize(100, 100));
+}
+
+TEST_CASE("ImageRenderUtils scale uses origin in labels",
+          "[gui/widgets/imagerenderutils][gui/widgets][gui]") {
+  QImage img(16, 16, QImage::Format_RGB32);
+  img.fill(Qt::black);
+
+  ImageRenderOptions opts;
+  opts.drawScale = true;
+  opts.lengthUnits = "m";
+  opts.physicalSize = {16.0, 16.0, 1.0};
+
+  opts.physicalOrigin = {0.0, 0.0, 0.0};
+  auto zeroOrigin = renderImageWithOverlays(img, {220, 220}, opts);
+
+  opts.physicalOrigin = {7.5, 3.25, 0.0};
+  auto offsetOrigin = renderImageWithOverlays(img, {220, 220}, opts);
+
+  REQUIRE(zeroOrigin.offset.x() > 0);
+  REQUIRE(zeroOrigin.offset.y() > 0);
+  REQUIRE(zeroOrigin.pixmap.toImage() != offsetOrigin.pixmap.toImage());
+}
+
+TEST_CASE("ImageRenderUtils draws vertical indicator",
+          "[gui/widgets/imagerenderutils][gui/widgets][gui]") {
+  QImage img(4, 3, QImage::Format_RGB32);
+  img.fill(Qt::white);
+
+  ImageRenderOptions opts;
+  opts.aspectRatioMode = Qt::IgnoreAspectRatio;
+  auto noIndicator = renderImageWithOverlays(img, {120, 40}, opts);
+
+  opts.verticalIndicatorSourceX = 1;
+  auto withIndicator = renderImageWithOverlays(img, {120, 40}, opts);
+
+  auto getBlackColumns = [](const QImage &rendered) {
+    std::vector<int> cols;
+    int y{rendered.height() / 2};
+    for (int x = 0; x < rendered.width(); ++x) {
+      if (rendered.pixelColor(x, y) == QColor(Qt::black)) {
+        cols.push_back(x);
+      }
+    }
+    return cols;
+  };
+
+  REQUIRE(getBlackColumns(noIndicator.pixmap.toImage()).empty());
+  auto blackColumns = getBlackColumns(withIndicator.pixmap.toImage());
+  REQUIRE(blackColumns.size() == 1);
+  int expectedX{std::clamp(
+      static_cast<int>(std::lround(
+          1.5 * static_cast<double>(withIndicator.pixmapImageSize.width()) /
+          static_cast<double>(img.width()))) -
+          1,
+      0, withIndicator.pixmapImageSize.width() - 1)};
+  REQUIRE(blackColumns[0] == expectedX);
+}
+
+TEST_CASE("ImageRenderUtils grid aligns to source pixels",
+          "[gui/widgets/imagerenderutils][gui/widgets][gui]") {
+  QImage img(5, 5, QImage::Format_RGB32);
+  img.fill(Qt::black);
+
+  ImageRenderOptions opts;
+  opts.drawGrid = true;
+  opts.physicalSize = {5.0, 5.0, 1.0};
+  auto rendered =
+      renderImageWithOverlays(img, {200, 200}, opts).pixmap.toImage();
+
+  int midY{rendered.height() / 2};
+  std::vector<int> gridColumns;
+  auto isGridColor = [](const QColor &c) {
+    return c.red() == 127 && c.green() == 127 && c.blue() == 127;
+  };
+  bool inColumn{false};
+  for (int x = 0; x < rendered.width(); ++x) {
+    bool isGrid{isGridColor(rendered.pixelColor(x, midY))};
+    if (isGrid && !inColumn) {
+      gridColumns.push_back(x);
+      inColumn = true;
+    } else if (!isGrid && inColumn) {
+      inColumn = false;
+    }
+  }
+
+  std::vector<int> gridSourceColumns;
+  for (int x : gridColumns) {
+    int srcX{
+        static_cast<int>(std::lround(static_cast<double>(x * img.width()) /
+                                     static_cast<double>(rendered.width())))};
+    int expectedX{static_cast<int>(
+        std::lround(static_cast<double>(srcX * rendered.width()) /
+                    static_cast<double>(img.width())))};
+    REQUIRE(x == expectedX);
+    if (gridSourceColumns.empty() || srcX != gridSourceColumns.back()) {
+      gridSourceColumns.push_back(srcX);
+    }
+  }
+  REQUIRE(gridSourceColumns.size() == 5);
+}
+
+TEST_CASE("ImageRenderUtils scale tick marks align with grid lines",
+          "[gui/widgets/imagerenderutils][gui/widgets][gui]") {
+  QImage img(100, 100, QImage::Format_RGB32);
+  img.fill(Qt::black);
+
+  ImageRenderOptions opts;
+  opts.drawGrid = true;
+  opts.drawScale = true;
+  opts.physicalSize = {100.0, 100.0, 1.0};
+  auto rendered = renderImageWithOverlays(img, {220, 220}, opts);
+  auto pixmap = rendered.pixmap.toImage();
+
+  auto isGridColor = [](const QColor &c) {
+    return c.red() == 127 && c.green() == 127 && c.blue() == 127;
+  };
+  auto getLinePositions = [&](int fixedCoord, bool horizontalScan) {
+    std::vector<int> positions;
+    bool inLine{false};
+    int limit{horizontalScan ? pixmap.width() : pixmap.height()};
+    for (int i = 0; i < limit; ++i) {
+      QColor color{horizontalScan ? pixmap.pixelColor(i, fixedCoord)
+                                  : pixmap.pixelColor(fixedCoord, i)};
+      bool isLine{isGridColor(color)};
+      if (isLine && !inLine) {
+        positions.push_back(i);
+        inLine = true;
+      } else if (!isLine && inLine) {
+        inLine = false;
+      }
+    }
+    return positions;
+  };
+
+  auto gridColumns{
+      getLinePositions(rendered.pixmapImageSize.height() / 2, true)};
+  auto tickColumns{getLinePositions(
+      rendered.pixmapImageSize.height() - 1 + opts.tickLength / 2, true)};
+  REQUIRE(!gridColumns.empty());
+  // The x-axis may omit the final edge tick if its label would overlap.
+  REQUIRE(tickColumns.size() >= gridColumns.size());
+  for (int x : gridColumns) {
+    REQUIRE(std::find(tickColumns.cbegin(), tickColumns.cend(), x) !=
+            tickColumns.cend());
+  }
+
+  auto gridRows{getLinePositions(
+      rendered.offset.x() + rendered.pixmapImageSize.width() / 2, false)};
+  auto tickRows{
+      getLinePositions(rendered.offset.x() - opts.tickLength / 2, false)};
+  REQUIRE(!gridRows.empty());
+  REQUIRE(tickRows.size() == gridRows.size() + 1);
+  for (int y : gridRows) {
+    REQUIRE(std::find(tickRows.cbegin(), tickRows.cend(), y) !=
+            tickRows.cend());
+  }
+}

--- a/gui/widgets/qlabelmousetracker.cpp
+++ b/gui/widgets/qlabelmousetracker.cpp
@@ -1,4 +1,5 @@
 #include "qlabelmousetracker.hpp"
+#include "imagerenderutils.hpp"
 #include "sme/logger.hpp"
 #include <QPainter>
 #include <algorithm>
@@ -160,234 +161,30 @@ bool QLabelMouseTracker::setCurrentPixel(const QPoint &pos) {
   return true;
 }
 
-struct GridSpacing {
-  double physicalWidth{0.0};
-  int pixelStep{1};
-};
-
-static GridSpacing getGridWidth(const sme::common::VolumeF &physicalSize,
-                                const QSize &pixmapSize,
-                                const QSize &imagePixelSize) {
-  constexpr double minWidthPixels{20};
-  // start with grid of width 1 physical unit
-  double gridPixelWidth{static_cast<double>(pixmapSize.width())};
-  double gridPhysicalWidth{physicalSize.width()};
-  // rescale with in pixels to: ~ [1, 2] * minWidthPixels
-  // hopefully with reasonably nice looking numerical intervals
-  while (gridPixelWidth < minWidthPixels) {
-    gridPhysicalWidth *= 10.0;
-    gridPixelWidth *= 10.0;
-  }
-  while (gridPixelWidth > 10 * minWidthPixels) {
-    gridPhysicalWidth /= 10.0;
-    gridPixelWidth /= 10.0;
-  }
-  if (gridPixelWidth > 8 * minWidthPixels) {
-    gridPhysicalWidth /= 5.0;
-    gridPixelWidth /= 5.0;
-  } else if (gridPixelWidth > 4 * minWidthPixels) {
-    gridPhysicalWidth /= 2.0;
-    gridPixelWidth /= 2.0;
-  }
-  int pixelStep{1};
-  if (imagePixelSize.width() > 0 && pixmapSize.width() > 0) {
-    double pixelDisplayWidth{static_cast<double>(pixmapSize.width()) /
-                             static_cast<double>(imagePixelSize.width())};
-    if (pixelDisplayWidth > 0.0) {
-      double pixelPhysicalWidth{physicalSize.width() /
-                                static_cast<double>(imagePixelSize.width())};
-      double multiple{std::round(gridPixelWidth / pixelDisplayWidth)};
-      if (multiple < 1.0) {
-        multiple = 1.0;
-      }
-      pixelStep = static_cast<int>(multiple);
-      gridPhysicalWidth = multiple * pixelPhysicalWidth;
-    }
-  }
-  return {gridPhysicalWidth, pixelStep};
-}
-
-static QString getGridPointLabel(double value, bool includeUnits,
-                                 const QString &lengthUnits) {
-  auto label{QString::number(value, 'g', 3)};
-  if (includeUnits) {
-    label.append(" ").append(lengthUnits);
-  }
-  return label;
-}
-
-// Returns pixel positions for scale tick marks, from 0 to nPixels (inclusive).
-// nPixels is one past the last valid pixel index: it represents the far edge
-// of the image and is always included so the full physical extent is labelled.
-static std::vector<int> getScaleEdgePixels(int nPixels, int pixelStep) {
-  std::vector<int> edgePixels;
-  if (nPixels <= 0 || pixelStep <= 0) {
-    return edgePixels;
-  }
-  for (int i = 0; i <= nPixels; i += pixelStep) {
-    edgePixels.push_back(i);
-  }
-  if (edgePixels.back() != nPixels) {
-    edgePixels.push_back(nPixels);
-  }
-  return edgePixels;
-}
-
-static QSize getPixmapSize(const QSize &displaySize, double physicalAspectRatio,
-                           Qt::AspectRatioMode aspectRatioMode) {
-  int width{std::max(1, displaySize.width())};
-  int height{std::max(1, displaySize.height())};
-  if (aspectRatioMode == Qt::IgnoreAspectRatio ||
-      !std::isfinite(physicalAspectRatio) || physicalAspectRatio <= 0.0) {
-    return {width, height};
-  }
-  double displayAspectRatio{static_cast<double>(displaySize.width()) /
-                            static_cast<double>(displaySize.height())};
-  if (displayAspectRatio > physicalAspectRatio) {
-    return {std::max(1, static_cast<int>(displaySize.height() *
-                                         physicalAspectRatio)),
-            height};
-  }
-  return {width, std::max(1, static_cast<int>(displaySize.width() /
-                                              physicalAspectRatio))};
-}
-
 void QLabelMouseTracker::resizeImage(const QSize &size) {
   if (image.empty()) {
     this->clear();
     return;
   }
-  pixmap = QPixmap(size);
-  pixmap.fill(QColor(0, 0, 0, 0));
-  offset = {0, 0};
-  QPainter p(&pixmap);
-  bool haveSpaceForScale{false};
-  if (drawScale) {
-    int w{p.fontMetrics().horizontalAdvance("8e+88")};
-    int h{p.fontMetrics().height()};
-    // only draw scale if picture is bigger than labels
-    if (size.width() > 2 * w && size.height() > 2 * h) {
-      offset = {w + tickLength, h + tickLength};
-      haveSpaceForScale = true;
-    }
-  }
-  QSize availableSize{size};
-  availableSize.rwidth() -= offset.x();
-  availableSize.rheight() -= offset.y();
-  pixmapImageSize =
-      getPixmapSize(availableSize, physicalSize.width() / physicalSize.height(),
-                    aspectRatioMode);
   const auto &srcImage{image[currentVoxel.z]};
-  double sx{static_cast<double>(pixmapImageSize.width()) /
-            static_cast<double>(srcImage.width())};
-  double sy{static_cast<double>(pixmapImageSize.height()) /
-            static_cast<double>(srcImage.height())};
-  p.setRenderHint(QPainter::SmoothPixmapTransform,
-                  transformationMode == Qt::SmoothTransformation);
-  p.save();
-  p.translate(offset.x(), 0);
-  p.scale(sx, sy);
-  p.drawImage(QPoint(0, 0), srcImage);
-  p.restore();
+  sme::gui::ImageRenderOptions opts;
+  opts.aspectRatioMode = aspectRatioMode;
+  opts.transformationMode = transformationMode;
+  opts.drawGrid = drawGrid;
+  opts.drawScale = drawScale;
+  opts.flipYAxis = flipYAxis;
+  opts.verticalIndicatorSourceX = verticalIndicatorSourceX;
+  opts.tickLength = tickLength;
+  opts.physicalOrigin = physicalOrigin;
+  opts.physicalSize = physicalSize;
+  opts.lengthUnits = lengthUnits;
+  auto rendered{sme::gui::renderImageWithOverlays(srcImage, size, opts)};
+  pixmap = rendered.pixmap;
+  pixmapImageSize = rendered.pixmapImageSize;
+  offset = rendered.offset;
   SPDLOG_DEBUG("resize -> {}x{}, pixmap -> {}x{}, image -> {}x{}", size.width(),
                size.height(), pixmap.width(), pixmap.height(),
                pixmapImageSize.width(), pixmapImageSize.height());
-  if (drawGrid || (drawScale && haveSpaceForScale)) {
-    QPen gridPen(QColor(127, 127, 127));
-    gridPen.setCosmetic(true);
-    p.setPen(gridPen);
-    auto gridSpacing =
-        getGridWidth(physicalSize, pixmapImageSize, srcImage.size());
-    int prevTextEnd{-1000};
-    int maxXIndex{(srcImage.width() - 1) / gridSpacing.pixelStep};
-    if (drawGrid) {
-      p.save();
-      p.translate(offset.x(), 0);
-      p.scale(sx, sy);
-      for (int i = 0; i <= maxXIndex; ++i) {
-        int srcX{i * gridSpacing.pixelStep};
-        p.drawLine(QPointF(srcX, 0), QPointF(srcX, srcImage.height()));
-      }
-      p.restore();
-    }
-    auto xScaleEdgePixels{
-        getScaleEdgePixels(srcImage.width(), gridSpacing.pixelStep)};
-    double xPixelWidth{physicalSize.width() /
-                       static_cast<double>(srcImage.width())};
-    for (int srcX : xScaleEdgePixels) {
-      int x{std::clamp(static_cast<int>(std::lround(srcX * sx)), 0,
-                       pixmapImageSize.width() - 1)};
-      if (drawScale && haveSpaceForScale) {
-        auto label{getGridPointLabel(
-            physicalOrigin.p.x() + static_cast<double>(srcX) * xPixelWidth,
-            srcX == 0, lengthUnits)};
-        // paint text label & extend tick mark if there is enough space
-        if (int labelWidth{p.fontMetrics().horizontalAdvance(label)};
-            prevTextEnd + (labelWidth + 1) / 2 + 4 < x &&
-            x + (labelWidth + 1) / 2 <= pixmapImageSize.width()) {
-          p.drawText(QRect(x + offset.x() - labelWidth / 2,
-                           pixmapImageSize.height() - 1 + tickLength,
-                           labelWidth, offset.y() - tickLength),
-                     Qt::AlignHCenter | Qt::AlignTop, label);
-          p.drawLine(x + offset.x(), pixmapImageSize.height() - 1,
-                     x + offset.x(), pixmapImageSize.height() - 1 + tickLength);
-          prevTextEnd = x + (labelWidth + 1) / 2;
-        }
-      }
-    }
-    int maxYIndex{(srcImage.height() - 1) / gridSpacing.pixelStep};
-    if (drawGrid) {
-      p.save();
-      p.translate(offset.x(), 0);
-      p.scale(sx, sy);
-      for (int i = 0; i <= maxYIndex; ++i) {
-        int srcY{i * gridSpacing.pixelStep};
-        if (!flipYAxis) {
-          srcY = srcImage.height() - 1 - srcY;
-        }
-        p.drawLine(QPointF(0, srcY), QPointF(srcImage.width(), srcY));
-      }
-      p.restore();
-    }
-    auto yScaleEdgePixels{
-        getScaleEdgePixels(srcImage.height(), gridSpacing.pixelStep)};
-    double yPixelWidth{physicalSize.height() /
-                       static_cast<double>(srcImage.height())};
-    for (int srcY : yScaleEdgePixels) {
-      int y;
-      if (flipYAxis) {
-        y = std::clamp(static_cast<int>(std::lround(srcY * sy)), 0,
-                       pixmapImageSize.height() - 1);
-      } else {
-        y = std::clamp(static_cast<int>(std::lround(
-                           static_cast<double>(srcImage.height() - srcY) * sy)),
-                       0, pixmapImageSize.height() - 1);
-      }
-      if (drawScale && haveSpaceForScale) {
-        auto label{getGridPointLabel(
-            physicalOrigin.p.y() + static_cast<double>(srcY) * yPixelWidth,
-            srcY == 0, lengthUnits)};
-        p.drawText(
-            QRect(0, y - offset.y() / 2, offset.x() - tickLength, offset.y()),
-            Qt::AlignVCenter | Qt::AlignRight, label);
-        p.drawLine(offset.x() - tickLength, y, offset.x(), y);
-      }
-    }
-  }
-  if (verticalIndicatorSourceX >= 0 &&
-      verticalIndicatorSourceX < srcImage.width()) {
-    QPen indicatorPen(Qt::black);
-    indicatorPen.setCosmetic(true);
-    p.setPen(indicatorPen);
-    int x{std::clamp(static_cast<int>(std::lround(
-                         (static_cast<double>(verticalIndicatorSourceX) + 0.5) *
-                         static_cast<double>(pixmapImageSize.width()) /
-                         static_cast<double>(srcImage.width()))) -
-                         1,
-                     0, pixmapImageSize.width() - 1)};
-    p.drawLine(offset.x() + x, 0, offset.x() + x, pixmapImageSize.height() - 1);
-  }
-  p.end();
   this->setPixmap(pixmap);
 }
 

--- a/gui/widgets/qlabelslice.cpp
+++ b/gui/widgets/qlabelslice.cpp
@@ -1,4 +1,5 @@
 #include "qlabelslice.hpp"
+#include "imagerenderutils.hpp"
 #include "sme/logger.hpp"
 
 QLabelSlice::QLabelSlice(QWidget *parent) : QLabel(parent) {
@@ -12,6 +13,8 @@ void QLabelSlice::setImage(const QImage &img, bool invertYAxis) {
   flipYAxis = invertYAxis;
   slicePixels.clear();
   imgOriginal = img.convertToFormat(QImage::Format_RGB32);
+  physicalSize = {static_cast<double>(imgOriginal.width()),
+                  static_cast<double>(imgOriginal.height()), 1.0};
   slicePixels.reserve(static_cast<std::size_t>(imgOriginal.width()) +
                       static_cast<std::size_t>(imgOriginal.height()));
   if (flipYAxis) {
@@ -31,9 +34,36 @@ const QImage &QLabelSlice::getImage() const { return imgSliced; }
 
 void QLabelSlice::setAspectRatioMode(Qt::AspectRatioMode mode) {
   aspectRatioMode = mode;
+  resizeImage(size());
 }
 void QLabelSlice::setTransformationMode(Qt::TransformationMode mode) {
   transformationMode = mode;
+  resizeImage(size());
+}
+
+void QLabelSlice::setPhysicalUnits(const QString &units) {
+  lengthUnits = units;
+  resizeImage(size());
+}
+
+void QLabelSlice::setPhysicalOrigin(const sme::common::VoxelF &origin) {
+  physicalOrigin = origin;
+  resizeImage(size());
+}
+
+void QLabelSlice::setPhysicalSize(const sme::common::VolumeF &size) {
+  physicalSize = size;
+  resizeImage(this->size());
+}
+
+void QLabelSlice::displayGrid(bool enable) {
+  drawGrid = enable;
+  resizeImage(size());
+}
+
+void QLabelSlice::displayScale(bool enable) {
+  drawScale = enable;
+  resizeImage(size());
 }
 
 void QLabelSlice::setSlice(const QPoint &start, const QPoint &end) {
@@ -113,12 +143,14 @@ void QLabelSlice::resizeEvent(QResizeEvent *event) {
 bool QLabelSlice::setPixel(const QMouseEvent *ev, QPoint &pixel) {
   int x{ev->pos().x()};
   int y{ev->pos().y()};
-  if (imgSliced.isNull() || pixmap.isNull() || (x >= pixmap.width()) ||
-      (y >= pixmap.height()) || (x < 0) || (y < 0)) {
+  if (imgSliced.isNull() || pixmap.isNull() || pixmapImageSize.width() <= 0 ||
+      pixmapImageSize.height() <= 0 ||
+      (x >= pixmapImageSize.width() + offset.x()) ||
+      (y >= pixmapImageSize.height()) || (x < offset.x()) || (y < 0)) {
     return false;
   }
-  pixel.setX((imgSliced.width() * x) / pixmap.width());
-  pixel.setY((imgSliced.height() * y) / pixmap.height());
+  pixel.setX((imgSliced.width() * (x - offset.x())) / pixmapImageSize.width());
+  pixel.setY((imgSliced.height() * y) / pixmapImageSize.height());
   if (flipYAxis) {
     pixel.setY(imgSliced.height() - 1 - pixel.y());
   }
@@ -141,8 +173,20 @@ void QLabelSlice::resizeImage(const QSize &size) {
     this->clear();
     return;
   }
-  pixmap = QPixmap::fromImage(
-      imgSliced.scaled(size, aspectRatioMode, transformationMode));
+  sme::gui::ImageRenderOptions opts;
+  opts.aspectRatioMode = aspectRatioMode;
+  opts.transformationMode = transformationMode;
+  opts.drawGrid = drawGrid;
+  opts.drawScale = drawScale;
+  opts.flipYAxis = flipYAxis;
+  opts.tickLength = tickLength;
+  opts.physicalOrigin = physicalOrigin;
+  opts.physicalSize = physicalSize;
+  opts.lengthUnits = lengthUnits;
+  auto rendered{sme::gui::renderImageWithOverlays(imgSliced, size, opts)};
+  pixmap = rendered.pixmap;
+  pixmapImageSize = rendered.pixmapImageSize;
+  offset = rendered.offset;
   SPDLOG_DEBUG("resize -> {}x{}, pixmap -> {}x{}", size.width(), size.height(),
                pixmap.size().width(), pixmap.size().height());
   this->setPixmap(pixmap);

--- a/gui/widgets/qlabelslice.hpp
+++ b/gui/widgets/qlabelslice.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "sme/voxel.hpp"
 #include <QLabel>
 #include <QMouseEvent>
 #include <vector>
@@ -20,6 +21,11 @@ public:
   const QImage &getImage() const;
   void setAspectRatioMode(Qt::AspectRatioMode aspectRatioMode);
   void setTransformationMode(Qt::TransformationMode transformationMode);
+  void setPhysicalUnits(const QString &units);
+  void setPhysicalOrigin(const sme::common::VoxelF &origin);
+  void setPhysicalSize(const sme::common::VolumeF &size);
+  void displayGrid(bool enable);
+  void displayScale(bool enable);
   void setSlice(const QPoint &start, const QPoint &end);
   const std::vector<QPoint> &getSlicePixels() const;
   void setHorizontalSlice(int y);
@@ -44,12 +50,20 @@ private:
   QImage imgOriginal;
   QImage imgSliced;
   QPixmap pixmap;
+  QSize pixmapImageSize;
+  const int tickLength{10};
+  QPoint offset{0, 0};
   QPoint startPixel;
   QPoint currentPixel;
   Qt::AspectRatioMode aspectRatioMode = Qt::KeepAspectRatio;
   Qt::TransformationMode transformationMode = Qt::FastTransformation;
   bool mouseIsDown{false};
+  bool drawGrid{false};
+  bool drawScale{false};
   bool flipYAxis{false};
+  sme::common::VoxelF physicalOrigin{0.0, 0.0, 0.0};
+  sme::common::VolumeF physicalSize{1.0, 1.0, 1.0};
+  QString lengthUnits{};
   bool setPixel(const QMouseEvent *ev, QPoint &pixel);
   void fadeOriginalImage();
   void resizeImage(const QSize &size);

--- a/gui/widgets/qlabelslice_t.cpp
+++ b/gui/widgets/qlabelslice_t.cpp
@@ -125,4 +125,25 @@ TEST_CASE("QLabelSlice",
   REQUIRE(lblSlice.getSlicePixels().size() == 1);
   REQUIRE(lblSlice.getSlicePixels()[0] == QPoint(5, 3));
   REQUIRE(qAlpha(lblSlice.getImage().pixel(5, 3)) == 255);
+
+  SECTION("scale overlay adds ruler margin without breaking hit testing") {
+    lblSlice.resize(200, 120);
+    wait();
+    mouseDownPoints.clear();
+    lblSlice.setPhysicalUnits("m");
+    lblSlice.setPhysicalOrigin({1.0, 2.0, 0.0});
+    lblSlice.setPhysicalSize({20.0, 10.0, 1.0});
+    lblSlice.displayScale(true);
+    wait();
+
+    sendMouseClick(&lblSlice, {1, 40});
+    REQUIRE(mouseDownPoints.empty());
+
+    sendMouseClick(&lblSlice, {120, 40});
+    REQUIRE(mouseDownPoints.size() == 1);
+    REQUIRE(mouseDownPoints[0].x() >= 0);
+    REQUIRE(mouseDownPoints[0].x() < img.width());
+    REQUIRE(mouseDownPoints[0].y() >= 0);
+    REQUIRE(mouseDownPoints[0].y() < img.height());
+  }
 }


### PR DESCRIPTION
- display physical x,y,z,t coordinates on mouseover
- use currently selected z-slice for 3d models
- add optional grid & scale to geometry image on the left
- resolves #577
