### PR TITLE
Add origin info to exported tiffs

### DIFF
--- a/core/common/include/sme/tiff.hpp
+++ b/core/common/include/sme/tiff.hpp
@@ -31,12 +31,14 @@ using TiffDataType = uint16_t;
  * @param imageSize Image dimensions.
  * @param conc Concentration values in image order.
  * @param voxelSize Physical voxel size.
+ * @param physicalOrigin Physical location of the (0,0,0) pixel.
  * @returns Maximum concentration value used to scale TIFF pixel values, or a
  * negative value on failure.
  */
 double writeTIFF(const std::string &filename, const QSize &imageSize,
                  const std::vector<double> &conc,
-                 const sme::common::VolumeF &voxelSize);
+                 const sme::common::VolumeF &voxelSize,
+                 const sme::common::VoxelF &physicalOrigin);
 
 /**
  * @brief Reader for single- or multi-page TIFF images.

--- a/core/common/src/tiff.cpp
+++ b/core/common/src/tiff.cpp
@@ -17,8 +17,8 @@ constexpr TiffDataType TiffDataTypeMaxValue{
 
 double writeTIFF(const std::string &filename, const QSize &imageSize,
                  const std::vector<double> &conc,
-                 const sme::common::VolumeF &voxelSize) {
-  // todo: add ORIGIN to TIFF file!
+                 const sme::common::VolumeF &voxelSize,
+                 const sme::common::VoxelF &physicalOrigin) {
   SPDLOG_TRACE("found {} concentration values", conc.size());
   double maxConc{common::max(conc)};
   SPDLOG_TRACE("  - max value: {}", maxConc);
@@ -73,8 +73,8 @@ double writeTIFF(const std::string &filename, const QSize &imageSize,
   TIFFSetField(tif, TIFFTAG_XRESOLUTION, 1.0 / voxelSize.width());
   TIFFSetField(tif, TIFFTAG_YRESOLUTION, 1.0 / voxelSize.height());
   // NB: location of (0,0) pixel
-  TIFFSetField(tif, TIFFTAG_XPOSITION, 0.0);
-  TIFFSetField(tif, TIFFTAG_YPOSITION, 0.0);
+  TIFFSetField(tif, TIFFTAG_XPOSITION, physicalOrigin.p.x());
+  TIFFSetField(tif, TIFFTAG_YPOSITION, physicalOrigin.p.y());
 
   for (std::size_t y = 0; y < height; y++) {
     int ret = TIFFWriteScanline(tif, tifValues.at(y).data(),

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -237,7 +237,8 @@ static void addCompartment(
         double max = common::writeTIFF(
             tiffFilename.toStdString(),
             f->getCompartment()->getCompartmentImages()[0].size(), conc,
-            model.getGeometry().getVoxelSize());
+            model.getGeometry().getVoxelSize(),
+            model.getGeometry().getPhysicalOrigin());
         tiffs.push_back(sampledFieldName);
         ini.addValue("initial.expression",
                      QString("%1*%2(position_x,position_y)")


### PR DESCRIPTION
- 2d models with non-zero origin and reaction terms involving x,y will now work correctly when exported for external dune simulation
- resolves #412
