### PR TITLE
Display species concentration on mouseover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- species concentration at the mouseover location in the species tab [#122](https://github.com/spatial-model-editor/spatial-model-editor/issues/122)
+
 ### Fixed
 - ImageSlice dialog now uses the currently selected z-slice, mouseover text reports physical `x/y/z/t` values, geometry image has grid and scale overlays [#577](https://github.com/spatial-model-editor/spatial-model-editor/issues/577)
+- exported TIFF files now include geometry origin [#412](https://github.com/spatial-model-editor/spatial-model-editor/issues/412)
 
 ## [1.12.0] - 2026-04-22
 ### Added

--- a/core/model/include/sme/geometry.hpp
+++ b/core/model/include/sme/geometry.hpp
@@ -14,6 +14,7 @@
 #include <QRgb>
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -120,6 +121,11 @@ public:
    * @brief Mapping from full-image voxels to compartment voxel indices.
    */
   [[nodiscard]] const std::vector<std::size_t> &getArrayPoints() const;
+  /**
+   * @brief Compartment voxel index for an image voxel, if inside compartment.
+   */
+  [[nodiscard]] std::optional<std::size_t>
+  getIdx(const common::Voxel &voxel) const;
 };
 
 /**

--- a/core/model/src/geometry.cpp
+++ b/core/model/src/geometry.cpp
@@ -134,6 +134,16 @@ const std::vector<std::size_t> &Compartment::getArrayPoints() const {
   return arrayPoints;
 }
 
+std::optional<std::size_t>
+Compartment::getIdx(const common::Voxel &voxel) const {
+  const auto &volume = images.volume();
+  if (voxel.z >= volume.depth() || !images[voxel.z].valid(voxel.p) ||
+      images[voxel.z].pixelIndex(voxel.p) == 0) {
+    return std::nullopt;
+  }
+  return arrayPoints[common::voxelArrayIndex(volume, voxel, /*invertY=*/true)];
+}
+
 Membrane::Membrane(std::string membraneId, const Compartment *A,
                    const Compartment *B,
                    const std::vector<std::pair<Voxel, Voxel>> *voxelPairs)

--- a/core/model/src/geometry_t.cpp
+++ b/core/model/src/geometry_t.cpp
@@ -128,6 +128,16 @@ TEST_CASE("Geometry: Compartments and Fields",
     REQUIRE(comp.getVoxel(0).p == QPoint(3, 3));
     REQUIRE(comp.getVoxel(1).p == QPoint(3, 4));
 
+    // getIdx: in-compartment voxels return their compartment index
+    REQUIRE(comp.getIdx({3, 3, 0}) == std::optional<std::size_t>(0));
+    REQUIRE(comp.getIdx({3, 4, 0}) == std::optional<std::size_t>(1));
+    // out-of-compartment voxel: nullopt
+    REQUIRE(!comp.getIdx({0, 0, 0}).has_value());
+    // out-of-bounds voxels: nullopt
+    REQUIRE(!comp.getIdx({-1, 0, 0}).has_value());
+    REQUIRE(!comp.getIdx({6, 0, 0}).has_value());
+    REQUIRE(!comp.getIdx({0, 0, 1}).has_value());
+
     geometry::Field field(&comp, "s1");
     field.setUniformConcentration(1.3);
     REQUIRE(field.getConcentration().size() == 2);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -887,7 +887,14 @@ void MainWindow::lblGeometry_mouseOver(const sme::common::Voxel &voxel) {
   if (!model.getGeometry().getHasImage()) {
     return;
   }
-  statusBar()->showMessage(model.getGeometry().getPhysicalPointAsString(voxel));
+  QString message{model.getGeometry().getPhysicalPointAsString(voxel)};
+  if (ui->tabMain->currentWidget() == ui->tabSpecies) {
+    auto concText{tabSpecies->getMouseoverConcentrationText(voxel)};
+    if (!concText.isEmpty()) {
+      message += "  |  " + concText;
+    }
+  }
+  statusBar()->showMessage(message);
 }
 
 void MainWindow::spinGeometryZoom_valueChanged(int value) {

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -92,6 +92,29 @@ TabSpecies::TabSpecies(sme::model::Model &m, QLabelMouseTracker *mouseTracker,
 
 TabSpecies::~TabSpecies() = default;
 
+QString TabSpecies::getMouseoverConcentrationText(
+    const sme::common::Voxel &voxel) const {
+  if (currentSpeciesId.isEmpty()) {
+    return {};
+  }
+  const auto *field = model.getSpecies().getField(currentSpeciesId);
+  if (field == nullptr) {
+    return {};
+  }
+  const auto *comp = field->getCompartment();
+  if (comp == nullptr) {
+    return {};
+  }
+  const auto idx = comp->getIdx(voxel);
+  if (!idx.has_value()) {
+    return {};
+  }
+  return QString("%1 = %2 %3")
+      .arg(model.getSpecies().getName(currentSpeciesId))
+      .arg(field->getConcentration()[*idx])
+      .arg(model.getUnits().getConcentration());
+}
+
 void TabSpecies::loadModelData(const QString &selection) {
   enableWidgets(false);
   // update tree list of species

--- a/gui/tabs/tabspecies.hpp
+++ b/gui/tabs/tabspecies.hpp
@@ -11,6 +11,10 @@ namespace Ui {
 class TabSpecies;
 }
 
+namespace sme::common {
+struct Voxel;
+} // namespace sme::common
+
 namespace sme::model {
 class Model;
 } // namespace sme::model
@@ -27,6 +31,8 @@ public:
                       QVoxelRenderer *voxelRenderer, QWidget *parent = nullptr);
   ~TabSpecies() override;
   void loadModelData(const QString &selection = {});
+  [[nodiscard]] QString
+  getMouseoverConcentrationText(const sme::common::Voxel &voxel) const;
 
 private:
   std::unique_ptr<Ui::TabSpecies> ui;

--- a/gui/tabs/tabspecies_t.cpp
+++ b/gui/tabs/tabspecies_t.cpp
@@ -382,4 +382,29 @@ TEST_CASE("TabSpecies", "[gui/tabs/species][gui/tabs][gui][species]") {
     REQUIRE(listSpecies->currentItem()->parent()->text(0) == "Outside");
     REQUIRE(listSpecies->currentItem()->parent()->childCount() == 1);
   }
+  SECTION("getMouseoverConcentrationText") {
+    // no species selected: empty
+    REQUIRE(tab.getMouseoverConcentrationText({0, 0, 0}).isEmpty());
+
+    model = getExampleModel(Mod::VerySimpleModel);
+    tab.loadModelData();
+    // select B_cell: a spatial species in the Cell compartment
+    sendKeyEvents(listSpecies, {"Down", "Down", "Down", "Down"});
+    REQUIRE(listSpecies->currentItem()->text(0) == "B_cell");
+    const auto cellCompartmentId{model.getCompartments().getIds()[1]};
+    const auto bCellId{model.getSpecies().getIds(cellCompartmentId)[1]};
+    const auto *field{model.getSpecies().getField(bCellId)};
+    REQUIRE(field != nullptr);
+    const auto &voxelsInComp{field->getCompartment()->getVoxels()};
+    REQUIRE(!voxelsInComp.empty());
+    // voxel inside the Cell compartment: returns formatted string
+    const auto inside{tab.getMouseoverConcentrationText(voxelsInComp.front())};
+    REQUIRE(inside.startsWith("B_cell = "));
+    REQUIRE(inside.endsWith(model.getUnits().getConcentration()));
+    // voxel outside any compartment: empty
+    const auto width{model.getGeometry().getImages().volume().width()};
+    const auto height{model.getGeometry().getImages().volume().height()};
+    REQUIRE(tab.getMouseoverConcentrationText({width + 10, height + 10, 0})
+                .isEmpty());
+  }
 }


### PR DESCRIPTION
- in TabSpecies, add species concentration to mouseover status bar text
- add Compartment::getIdx(voxel) helper
- resolves #122
