### PR TITLE
Reduce allowed tolerance for dune-copasi tests

### DIFF
--- a/core/mesh/src/gmsh_t.cpp
+++ b/core/mesh/src/gmsh_t.cpp
@@ -267,109 +267,107 @@ $EndElements
     REQUIRE(!imgWithoutBackground.colorTable().contains(qRgb(0, 0, 0)));
     REQUIRE(imgWithBackground.colorTable().contains(qRgb(0, 0, 0)));
   }
+}
 
-  SECTION("round-trip via duneconverter gmsh export") {
-    constexpr double minMatchingFraction{0.80};
-    for (const auto &modelId :
-         {test::Mod::VerySimpleModel3D, test::Mod::SelKov3D,
-          test::Mod::FitzhughNagumo3D}) {
-      for (const bool includeBackground : {true, false}) {
-        CAPTURE(modelId);
-        CAPTURE(includeBackground);
-        auto model = test::getExampleModel(modelId);
-        const auto &original = model.getGeometry().getImages();
-        REQUIRE(!original.empty());
-        const auto originalVolume = original.volume();
-        const int nMax =
-            std::max({originalVolume.width(), originalVolume.height(),
-                      static_cast<int>(originalVolume.depth())});
-        std::map<QRgb, QRgb> originalToRoundTripColor;
-        const auto &compartmentColors = model.getCompartments().getColors();
-        const common::indexedColors indexedColors;
-        for (int i = 0; i < compartmentColors.size(); ++i) {
-          originalToRoundTripColor[compartmentColors[i]] =
-              indexedColors[static_cast<std::size_t>(i)].rgb();
-        }
+TEST_CASE("Gmsh voxel import round-trip via duneconverter gmsh export",
+          "[core/mesh/gmsh][core/mesh][core][mesh][gmsh][expensive]") {
+  constexpr double minMatchingFraction{0.80};
+  for (const auto &modelId : {test::Mod::VerySimpleModel3D, test::Mod::SelKov3D,
+                              test::Mod::FitzhughNagumo3D}) {
+    for (const bool includeBackground : {true, false}) {
+      CAPTURE(modelId);
+      CAPTURE(includeBackground);
+      auto model = test::getExampleModel(modelId);
+      const auto &original = model.getGeometry().getImages();
+      REQUIRE(!original.empty());
+      const auto originalVolume = original.volume();
+      const int nMax =
+          std::max({originalVolume.width(), originalVolume.height(),
+                    static_cast<int>(originalVolume.depth())});
+      std::map<QRgb, QRgb> originalToRoundTripColor;
+      const auto &compartmentColors = model.getCompartments().getColors();
+      const common::indexedColors indexedColors;
+      for (int i = 0; i < compartmentColors.size(); ++i) {
+        originalToRoundTripColor[compartmentColors[i]] =
+            indexedColors[static_cast<std::size_t>(i)].rgb();
+      }
 
-        const QString iniFilename = QDir::current().filePath("tmp_gmsh_rt.ini");
-        const QString gmshFilename =
-            QDir::current().filePath("tmp_gmsh_rt.msh");
-        QFile::remove(iniFilename);
-        QFile::remove(gmshFilename);
-        simulate::DuneConverter dc(model, {}, true, iniFilename);
-        (void)dc;
-        REQUIRE(QFile::exists(gmshFilename));
+      const QString iniFilename = QDir::current().filePath("tmp_gmsh_rt.ini");
+      const QString gmshFilename = QDir::current().filePath("tmp_gmsh_rt.msh");
+      QFile::remove(iniFilename);
+      QFile::remove(gmshFilename);
+      simulate::DuneConverter dc(model, {}, true, iniFilename);
+      (void)dc;
+      REQUIRE(QFile::exists(gmshFilename));
 
-        auto gmshMesh = mesh::readGMSHMesh(gmshFilename);
-        REQUIRE(gmshMesh.has_value());
-        auto roundTrip =
-            mesh::voxelizeGMSHMesh(*gmshMesh, nMax, includeBackground);
-        REQUIRE(!roundTrip.empty());
+      auto gmshMesh = mesh::readGMSHMesh(gmshFilename);
+      REQUIRE(gmshMesh.has_value());
+      auto roundTrip =
+          mesh::voxelizeGMSHMesh(*gmshMesh, nMax, includeBackground);
+      REQUIRE(!roundTrip.empty());
 
-        common::VoxelF meshMin{std::numeric_limits<double>::max(),
-                               std::numeric_limits<double>::max(),
-                               std::numeric_limits<double>::max()};
-        common::VoxelF meshMax{std::numeric_limits<double>::lowest(),
-                               std::numeric_limits<double>::lowest(),
-                               std::numeric_limits<double>::lowest()};
-        for (const auto &v : gmshMesh->vertices) {
-          meshMin.p.rx() = std::min(meshMin.p.x(), v.p.x());
-          meshMin.p.ry() = std::min(meshMin.p.y(), v.p.y());
-          meshMin.z = std::min(meshMin.z, v.z);
-          meshMax.p.rx() = std::max(meshMax.p.x(), v.p.x());
-          meshMax.p.ry() = std::max(meshMax.p.y(), v.p.y());
-          meshMax.z = std::max(meshMax.z, v.z);
-        }
-        const double w = meshMax.p.x() - meshMin.p.x();
-        const double h = meshMax.p.y() - meshMin.p.y();
-        const double d = meshMax.z - meshMin.z;
-        const auto roundVol = roundTrip.volume();
-        const auto origin = model.getGeometry().getPhysicalOrigin();
-        const auto voxelSize = model.getGeometry().getVoxelSize();
+      common::VoxelF meshMin{std::numeric_limits<double>::max(),
+                             std::numeric_limits<double>::max(),
+                             std::numeric_limits<double>::max()};
+      common::VoxelF meshMax{std::numeric_limits<double>::lowest(),
+                             std::numeric_limits<double>::lowest(),
+                             std::numeric_limits<double>::lowest()};
+      for (const auto &v : gmshMesh->vertices) {
+        meshMin.p.rx() = std::min(meshMin.p.x(), v.p.x());
+        meshMin.p.ry() = std::min(meshMin.p.y(), v.p.y());
+        meshMin.z = std::min(meshMin.z, v.z);
+        meshMax.p.rx() = std::max(meshMax.p.x(), v.p.x());
+        meshMax.p.ry() = std::max(meshMax.p.y(), v.p.y());
+        meshMax.z = std::max(meshMax.z, v.z);
+      }
+      const double w = meshMax.p.x() - meshMin.p.x();
+      const double h = meshMax.p.y() - meshMin.p.y();
+      const double d = meshMax.z - meshMin.z;
+      const auto roundVol = roundTrip.volume();
+      const auto origin = model.getGeometry().getPhysicalOrigin();
+      const auto voxelSize = model.getGeometry().getVoxelSize();
 
-        std::size_t nSame = 0;
-        std::size_t nTotal = roundVol.nVoxels();
-        for (std::size_t z = 0; z < roundVol.depth(); ++z) {
-          double pz = meshMin.z + d * (0.5 + static_cast<double>(z)) /
-                                      static_cast<double>(roundVol.depth());
-          auto oz = static_cast<std::size_t>(
-              common::toVoxelIndex(pz, origin.z, voxelSize.depth(),
-                                   static_cast<int>(originalVolume.depth())));
-          for (int y = 0; y < roundVol.height(); ++y) {
-            double pyBottom = static_cast<double>(roundVol.height() - 1 - y);
-            double py =
-                meshMin.p.y() +
-                h * (0.5 + pyBottom) / static_cast<double>(roundVol.height());
-            int oyBottom = common::toVoxelIndex(
-                py, origin.p.y(), voxelSize.height(), originalVolume.height());
-            int oy = originalVolume.height() - 1 - oyBottom;
-            for (int x = 0; x < roundVol.width(); ++x) {
-              double px =
-                  meshMin.p.x() + w * (0.5 + static_cast<double>(x)) /
-                                      static_cast<double>(roundVol.width());
-              int ox = common::toVoxelIndex(px, origin.p.x(), voxelSize.width(),
-                                            originalVolume.width());
-              auto originalColor = original[oz].pixel(ox, oy);
-              auto mappedColorIter =
-                  originalToRoundTripColor.find(originalColor);
-              auto expectedRoundColor = originalColor;
-              if (mappedColorIter != originalToRoundTripColor.end()) {
-                expectedRoundColor = mappedColorIter->second;
-              }
-              if (roundTrip[z].pixel(x, y) == expectedRoundColor) {
-                ++nSame;
-              }
+      std::size_t nSame = 0;
+      std::size_t nTotal = roundVol.nVoxels();
+      for (std::size_t z = 0; z < roundVol.depth(); ++z) {
+        double pz = meshMin.z + d * (0.5 + static_cast<double>(z)) /
+                                    static_cast<double>(roundVol.depth());
+        auto oz = static_cast<std::size_t>(
+            common::toVoxelIndex(pz, origin.z, voxelSize.depth(),
+                                 static_cast<int>(originalVolume.depth())));
+        for (int y = 0; y < roundVol.height(); ++y) {
+          double pyBottom = static_cast<double>(roundVol.height() - 1 - y);
+          double py =
+              meshMin.p.y() +
+              h * (0.5 + pyBottom) / static_cast<double>(roundVol.height());
+          int oyBottom = common::toVoxelIndex(
+              py, origin.p.y(), voxelSize.height(), originalVolume.height());
+          int oy = originalVolume.height() - 1 - oyBottom;
+          for (int x = 0; x < roundVol.width(); ++x) {
+            double px =
+                meshMin.p.x() + w * (0.5 + static_cast<double>(x)) /
+                                    static_cast<double>(roundVol.width());
+            int ox = common::toVoxelIndex(px, origin.p.x(), voxelSize.width(),
+                                          originalVolume.width());
+            auto originalColor = original[oz].pixel(ox, oy);
+            auto mappedColorIter = originalToRoundTripColor.find(originalColor);
+            auto expectedRoundColor = originalColor;
+            if (mappedColorIter != originalToRoundTripColor.end()) {
+              expectedRoundColor = mappedColorIter->second;
+            }
+            if (roundTrip[z].pixel(x, y) == expectedRoundColor) {
+              ++nSame;
             }
           }
         }
-        CAPTURE(nSame);
-        CAPTURE(nTotal);
-        const double matchingFraction =
-            static_cast<double>(nSame) / static_cast<double>(nTotal);
-        CAPTURE(matchingFraction);
-        CAPTURE(minMatchingFraction);
-        REQUIRE(matchingFraction >= minMatchingFraction);
       }
+      CAPTURE(nSame);
+      CAPTURE(nTotal);
+      const double matchingFraction =
+          static_cast<double>(nSame) / static_cast<double>(nTotal);
+      CAPTURE(matchingFraction);
+      CAPTURE(minMatchingFraction);
+      REQUIRE(matchingFraction >= minMatchingFraction);
     }
   }
 }

--- a/core/model/include/sme/model_reactions.hpp
+++ b/core/model/include/sme/model_reactions.hpp
@@ -113,6 +113,10 @@ public:
    */
   void removeAllInvolvingSpecies(const QString &speciesId);
   /**
+   * @brief Remove all reactions in a location.
+   */
+  void removeAllInLocation(const QString &locationId);
+  /**
    * @brief Set reaction name.
    */
   QString setName(const QString &id, const QString &name);

--- a/core/model/src/model_compartments.cpp
+++ b/core/model/src/model_compartments.cpp
@@ -244,6 +244,12 @@ bool ModelCompartments::remove(const QString &id) {
       orphanedMembraneIds.push_back(m.getId());
     }
   }
+  if (modelReactions != nullptr) {
+    modelReactions->removeAllInLocation(id);
+    for (const auto &mId : orphanedMembraneIds) {
+      modelReactions->removeAllInLocation(mId.c_str());
+    }
+  }
   ids.removeAt(i);
   names.removeAt(i);
   colors.removeAt(i);

--- a/core/model/src/model_reactions.cpp
+++ b/core/model/src/model_reactions.cpp
@@ -426,6 +426,13 @@ void ModelReactions::removeAllInvolvingSpecies(const QString &speciesId) {
   }
 }
 
+void ModelReactions::removeAllInLocation(const QString &locationId) {
+  const auto reactionIdsToRemove{getIds(locationId)};
+  for (const auto &reactionId : reactionIdsToRemove) {
+    remove(reactionId);
+  }
+}
+
 QString ModelReactions::setName(const QString &id, const QString &name) {
   auto i = ids.indexOf(id);
   if (i < 0) {

--- a/core/model/src/model_reactions_t.cpp
+++ b/core/model/src/model_reactions_t.cpp
@@ -371,6 +371,33 @@ TEST_CASE("SBML reactions",
     REQUIRE(m.getReactions().getIds(locations[4]).size() == 2);
     REQUIRE(m.getReactions().getIds(locations[5]).size() == 0);
   }
+  SECTION("Deleting a compartment removes surviving reactions in deleted "
+          "locations") {
+    auto m{getExampleModel(Mod::VerySimpleModel)};
+    auto &reactions{m.getReactions()};
+    reactions.add("orphaned membrane reaction", "c1_c2_membrane", "1");
+    reactions.add("orphaned compartment reaction", "c1", "1");
+    const auto membraneReactionId{reactions.getIds("c1_c2_membrane").back()};
+    const auto compartmentReactionId{reactions.getIds("c1").back()};
+    REQUIRE(reactions.getLocation(membraneReactionId) == "c1_c2_membrane");
+    REQUIRE(reactions.getLocation(compartmentReactionId) == "c1");
+
+    m.getCompartments().remove("c1");
+
+    // These reactions do not involve any deleted species, so they need to be
+    // removed because their locations are being deleted.
+    REQUIRE(reactions.getLocation(membraneReactionId).isEmpty());
+    REQUIRE(reactions.getLocation(compartmentReactionId).isEmpty());
+    REQUIRE_FALSE(
+        reactions.getIds("c1_c2_membrane").contains(membraneReactionId));
+    REQUIRE_FALSE(reactions.getIds("c1").contains(compartmentReactionId));
+
+    auto doc{toSbmlDoc(m)};
+    REQUIRE(doc->getModel()->getReaction(membraneReactionId.toStdString()) ==
+            nullptr);
+    REQUIRE(doc->getModel()->getReaction(compartmentReactionId.toStdString()) ==
+            nullptr);
+  }
   SECTION("SBML Modifer Species: compartment reaction") {
     // note: these are only exported to make the SBML valid, we don't use them
     auto m{getExampleModel(Mod::LiverSimplified)};

--- a/core/simulate/src/cudapixelsim_t.cpp
+++ b/core/simulate/src/cudapixelsim_t.cpp
@@ -415,7 +415,7 @@ TEST_CASE("GPU PixelSim unsupported-feature gating",
 
 TEST_CASE("GPU PixelSim reaction dcdt matches CPU PixelSim for one step",
           "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
-          "[expensive][requires-gpu]") {
+          "[requires-gpu]") {
   auto mCpu{getExampleModel(Mod::ABtoC)};
   auto mGpu{getExampleModel(Mod::ABtoC)};
   for (auto *m : {&mCpu, &mGpu}) {
@@ -453,7 +453,7 @@ TEST_CASE("GPU PixelSim reaction dcdt matches CPU PixelSim for one step",
 
 TEST_CASE("GPU PixelSim diffusion dcdt matches CPU PixelSim for one step",
           "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
-          "[expensive][requires-gpu]") {
+          "[requires-gpu]") {
   auto mCpu{getExampleModel(Mod::SingleCompartmentDiffusion)};
   auto mGpu{getExampleModel(Mod::SingleCompartmentDiffusion)};
   configurePixelBackend(mCpu, simulate::PixelBackendType::CPU, singleStepDt);
@@ -486,7 +486,7 @@ TEST_CASE("GPU PixelSim diffusion dcdt matches CPU PixelSim for one step",
 
 TEST_CASE("GPU PixelSim membrane reactions match CPU for one step",
           "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
-          "[expensive][requires-gpu]") {
+          "[requires-gpu]") {
   auto mCpu{getExampleModel(Mod::VerySimpleModel)};
   auto mGpu{getExampleModel(Mod::VerySimpleModel)};
   configurePixelBackend(mCpu, simulate::PixelBackendType::CPU, singleStepDt);
@@ -574,10 +574,9 @@ TEST_CASE("GPU PixelSim example-model sweep matches CPU for all example models",
   }
 }
 
-TEST_CASE(
-    "GPU PixelSim membrane example model matches CPU after 1s",
-    "[core/simulate/gpupixelsim][core/simulate][core][simulate][expensive]"
-    "[requires-gpu]") {
+TEST_CASE("GPU PixelSim membrane example model matches CPU after 1s",
+          "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
+          "[requires-gpu]") {
   auto mCpu{getExampleModel(Mod::VerySimpleModel)};
   auto mGpu{getExampleModel(Mod::VerySimpleModel)};
   configurePixelBackend(mCpu, simulate::PixelBackendType::CPU,
@@ -615,10 +614,9 @@ TEST_CASE(
                                  multipleStepTolerance);
 }
 
-TEST_CASE(
-    "GPU PixelSim selected example models match CPU after 1s",
-    "[core/simulate/gpupixelsim][core/simulate][core][simulate][expensive]"
-    "[requires-gpu]") {
+TEST_CASE("GPU PixelSim selected example models match CPU after 1s",
+          "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
+          "[requires-gpu]") {
   std::size_t nModelsTested{0};
   for (std::size_t iExample = 0; iExample < longRunExampleModels.size();
        ++iExample) {
@@ -667,10 +665,9 @@ TEST_CASE(
   REQUIRE(nModelsTested > 0);
 }
 
-TEST_CASE(
-    "GPU PixelSim selected example models match CPU after 1s with RK212",
-    "[core/simulate/gpupixelsim][core/simulate][core][simulate][expensive]"
-    "[requires-gpu]") {
+TEST_CASE("GPU PixelSim selected example models match CPU after 1s with RK212",
+          "[core/simulate/gpupixelsim][core/simulate][core][simulate]"
+          "[requires-gpu]") {
   std::size_t nModelsTested{0};
   for (std::size_t iExample = 0; iExample < adaptiveLongRunExampleModels.size();
        ++iExample) {
@@ -806,7 +803,7 @@ TEST_CASE(
 #ifdef SME_WITH_CUDA
 TEST_CASE("CudaPixelSim float precision reaction matches double for one step",
           "[core/simulate/cudapixelsim][core/simulate][core][simulate]"
-          "[expensive][requires-cuda-gpu]") {
+          "[requires-cuda-gpu]") {
   auto mDouble{getExampleModel(Mod::ABtoC)};
   auto mFloat{getExampleModel(Mod::ABtoC)};
   for (auto *m : {&mDouble, &mFloat}) {

--- a/core/simulate/src/duneconverter.cpp
+++ b/core/simulate/src/duneconverter.cpp
@@ -147,6 +147,13 @@ static void addCompartment(
         &diffusionConstantArrays,
     std::unordered_map<std::string, std::vector<std::string>> &speciesNames,
     const QString &compartmentId, std::size_t &simDataCompartmentIndex) {
+  struct MembraneOutflowData {
+    QString otherCompartmentId{};
+    std::vector<std::string> duneSpeciesNames{};
+    std::vector<std::string> rhs{};
+    std::vector<std::vector<std::string>> jacobian{};
+  };
+
   const auto &lengthUnit = model.getUnits().getLength();
   const auto &volumeUnit = model.getUnits().getVolume();
   double volOverL3{model::getVolOverL3(lengthUnit, volumeUnit)};
@@ -204,13 +211,54 @@ static void addCompartment(
     ini.addSection("model", "scalar_field", dummySpeciesName);
     ini.addValue("compartment", compartmentId);
     ini.addValue("initial.expression", "0");
-    // todo: this reaction expression is a hack to avoid timestep -> 0
-    ini.addValue("reaction.expression", "0.1");
-    ini.addValue(
-        QString("reaction.jacobian.%1.expression").arg(dummySpeciesName), "0");
     ini.addValue("storage.expression", "1");
     return;
   }
+
+  std::vector<MembraneOutflowData> membraneOutflows;
+  for (const auto &membrane : model.getMembranes().getMembranes()) {
+    const QString compartmentA = membrane.getCompartmentA()->getId().c_str();
+    const QString compartmentB = membrane.getCompartmentB()->getId().c_str();
+    QString otherCompartmentId;
+    if (compartmentA == compartmentId) {
+      otherCompartmentId = compartmentB;
+    } else if (compartmentB == compartmentId) {
+      otherCompartmentId = compartmentA;
+    }
+    if (otherCompartmentId.isEmpty()) {
+      continue;
+    }
+
+    auto membraneReactions = common::toStdString(
+        model.getReactions().getIds(membrane.getId().c_str()));
+    auto otherSimulatedSpecies = getSimulatedSpecies(model, otherCompartmentId);
+    auto otherDuneSpeciesNames =
+        makeValidDuneSpeciesNames(otherSimulatedSpecies);
+
+    auto membraneSpecies = simulatedSpecies;
+    membraneSpecies.insert(membraneSpecies.end(),
+                           otherSimulatedSpecies.cbegin(),
+                           otherSimulatedSpecies.cend());
+    auto membraneDuneSpecies = duneSpeciesNames;
+    membraneDuneSpecies.insert(membraneDuneSpecies.end(),
+                               otherDuneSpeciesNames.cbegin(),
+                               otherDuneSpeciesNames.cend());
+
+    PdeScaleFactors membraneScaleFactors;
+    membraneScaleFactors.species = volOverL3;
+    membraneScaleFactors.reaction = -1.0;
+    SPDLOG_INFO("  - multiplying species by [vol]/[length]^3 = {}",
+                membraneScaleFactors.species);
+
+    Pde membranePde(&model, membraneSpecies, membraneReactions,
+                    membraneDuneSpecies, membraneScaleFactors,
+                    extraReactionVars, relabelledExtraReactionVars,
+                    substitutions);
+    membraneOutflows.push_back(
+        {otherCompartmentId, std::move(membraneDuneSpecies),
+         membranePde.getRHS(), membranePde.getJacobian()});
+  }
+
   for (std::size_t i = 0; i < nSpecies; ++i) {
     QString name{simulatedSpecies[i].c_str()};
     QString duneName{duneSpeciesNames[i].c_str()};
@@ -340,51 +388,17 @@ static void addCompartment(
     }
 
     // membrane flux terms
-    // todo: should collect membranes outside of this loop over species!
-    for (const auto &membrane : model.getMembranes().getMembranes()) {
-      auto cA = membrane.getCompartmentA()->getId().c_str();
-      auto cB = membrane.getCompartmentB()->getId().c_str();
-      QString otherCompId;
-      if (cA == compartmentId) {
-        otherCompId = cB;
-      } else if (cB == compartmentId) {
-        otherCompId = cA;
-      }
-      if (!otherCompId.isEmpty()) {
-        QString membraneID = membrane.getId().c_str();
-        auto mReacs =
-            common::toStdString(model.getReactions().getIds(membraneID));
-        auto simulatedSpeciesOther = getSimulatedSpecies(model, otherCompId);
-        auto duneSpeciesNamesOther =
-            makeValidDuneSpeciesNames(simulatedSpeciesOther);
-
-        auto mSpecies = simulatedSpecies;
-        for (const auto &s : simulatedSpeciesOther) {
-          mSpecies.push_back(s);
-        }
-        auto mDuneSpecies = duneSpeciesNames;
-        for (const auto &s : duneSpeciesNamesOther) {
-          mDuneSpecies.push_back(s);
-        }
-        PdeScaleFactors mScaleFactors;
-        mScaleFactors.species = volOverL3;
-        mScaleFactors.reaction = -1.0;
-        SPDLOG_INFO("  - multiplying species by [vol]/[length]^3 = {}",
-                    mScaleFactors.species);
-
-        Pde pdeBcs(&model, mSpecies, mReacs, mDuneSpecies, mScaleFactors,
-                   extraReactionVars, relabelledExtraReactionVars,
-                   substitutions);
-        // reaction expression
-        ini.addValue(QString("outflow.%1.expression").arg(otherCompId),
-                     pdeBcs.getRHS()[i].c_str());
-        // reaction expression jacobian
-        for (std::size_t j = 0; j < mDuneSpecies.size(); ++j) {
-          QString lhs = QString("outflow.%1.jacobian.%2.expression")
-                            .arg(otherCompId, mDuneSpecies[j].c_str());
-          QString rhs = pdeBcs.getJacobian()[i][j].c_str();
-          ini.addValue(lhs, rhs);
-        }
+    for (const auto &membraneOutflow : membraneOutflows) {
+      ini.addValue(QString("outflow.%1.expression")
+                       .arg(membraneOutflow.otherCompartmentId),
+                   membraneOutflow.rhs[i].c_str());
+      for (std::size_t j = 0; j < membraneOutflow.duneSpeciesNames.size();
+           ++j) {
+        QString lhs = QString("outflow.%1.jacobian.%2.expression")
+                          .arg(membraneOutflow.otherCompartmentId,
+                               membraneOutflow.duneSpeciesNames[j].c_str());
+        QString rhs = membraneOutflow.jacobian[i][j].c_str();
+        ini.addValue(lhs, rhs);
       }
     }
   }

--- a/core/simulate/src/dunefunction_t.cpp
+++ b/core/simulate/src/dunefunction_t.cpp
@@ -286,7 +286,7 @@ TEST_CASE("DUNE: function 2d - large triangles",
 
 TEST_CASE("DUNE: function 2d - more models, small triangles",
           "[core/simulate/dunefunction][core/"
-          "simulate][core][dunefunction][expensive][dune][2d]") {
+          "simulate][core][dunefunction][dune][2d]") {
   for (auto exampleModel : {Mod::ABtoC, Mod::VerySimpleModel,
                             Mod::LiverSimplified, Mod::LiverCells}) {
     CAPTURE(exampleModel);
@@ -325,7 +325,7 @@ TEST_CASE("DUNE: function 3d", "[core/simulate/dunefunction][core/"
 
 TEST_CASE("DUNE: function 3d - small cell volumes",
           "[core/simulate/dunefunction][core/"
-          "simulate][expensive][core][dunefunction][dune][3d]") {
+          "simulate][core][dunefunction][dune][3d]") {
   for (auto exampleModel :
        {Mod::SingleCompartmentDiffusion3D, Mod::VerySimpleModel3D}) {
     CAPTURE(exampleModel);

--- a/core/simulate/src/dunesim_t.cpp
+++ b/core/simulate/src/dunesim_t.cpp
@@ -1,9 +1,13 @@
 #include "catch_wrapper.hpp"
+#include "dune_headers.hpp"
+#include "dunegrid.hpp"
 #include "dunesim.hpp"
 #include "model_test_utils.hpp"
+#include "sme/mesh2d.hpp"
 #include "sme/model.hpp"
 #include "sme/simulate_options.hpp"
 #include "sme/utils.hpp"
+#include <array>
 #include <locale>
 #include <optional>
 
@@ -32,6 +36,31 @@ std::optional<std::locale> getGermanLocale() {
   return std::nullopt;
 }
 
+using HostGrid2d = Dune::UGGrid<2>;
+using MDGTraits2d = Dune::mdgrid::FewSubDomainsTraits<2, 64>;
+
+template <typename Grid>
+std::vector<double> getAllElementCoordinates(Grid *grid,
+                                             unsigned int subdomain) {
+  std::vector<double> v;
+  auto gridView = grid->subDomain(subdomain).leafGridView();
+  for (const auto &e : elements(gridView)) {
+    for (int i = 0; i < e.geometry().corners(); ++i) {
+      for (double c : e.geometry().corner(i)) {
+        v.push_back(c);
+      }
+    }
+  }
+  return v;
+}
+
+std::array<std::vector<double>, 2>
+getSubdomainElementCoordinates(const mesh::Mesh2d &mesh) {
+  auto duneGrid = simulate::makeDuneGrid<HostGrid2d, MDGTraits2d>(mesh);
+  return {getAllElementCoordinates(duneGrid.first.get(), 0),
+          getAllElementCoordinates(duneGrid.first.get(), 1)};
+}
+
 } // namespace
 
 TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
@@ -44,6 +73,8 @@ TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
     std::vector<std::string> comps{"comp"};
     simulate::DuneSim duneSim(m, comps);
     REQUIRE(duneSim.errorMessage().empty());
+    duneSim.run(0.05, 100e3, {});
+    REQUIRE(duneSim.errorMessage().empty());
   }
   SECTION(
       "Compartment in model has no species, but membrane contains reactions") {
@@ -53,6 +84,14 @@ TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
     m.getSpecies().setInitialConcentration("B_c2", 0.1);
     auto col1{m.getCompartments().getColor("c1")};
     auto col2{m.getCompartments().getColor("c2")};
+    auto &duneOptions{m.getSimulationSettings().options.dune};
+    duneOptions.maxThreads = 1;
+    duneOptions.dt = 0.05;
+    duneOptions.minDt = 0.05;
+    duneOptions.maxDt = 0.05;
+    duneOptions.newtonRelErr = 1e-14;
+    duneOptions.newtonAbsErr = 1e-14;
+    duneOptions.linearSolver = "BiCGSTAB";
     // remove all species from nucleus, but keep compartment in model
     m.getSpecies().remove("A_c3");
     m.getSpecies().remove("B_c3");
@@ -66,6 +105,14 @@ TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
     m.getGeometry().getMesh2d()->setCompartmentMaxTriangleArea(2, 9999);
     REQUIRE(maxPoints.size() == 3);
     REQUIRE(maxAreas.size() == 3);
+    const auto *meshWithEmptyCompartment{m.getGeometry().getMesh2d()};
+    REQUIRE(meshWithEmptyCompartment != nullptr);
+    REQUIRE(meshWithEmptyCompartment->isValid());
+    const std::array<std::size_t, 2> triangleCountsWithEmptyCompartment{
+        meshWithEmptyCompartment->getTriangleIndices()[0].size(),
+        meshWithEmptyCompartment->getTriangleIndices()[1].size()};
+    const auto elementCoordinatesWithEmptyCompartment{
+        getSubdomainElementCoordinates(*meshWithEmptyCompartment)};
     simulate::DuneSim duneSim(m, comps);
     for (std::size_t i = 0; i < 2; ++i) {
       duneSim.run(0.05, 100e3, {});
@@ -88,6 +135,28 @@ TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
     m.getGeometry().getMesh2d()->setBoundaryMaxPoints(2, maxPoints[2]);
     m.getGeometry().getMesh2d()->setCompartmentMaxTriangleArea(0, maxAreas[0]);
     m.getGeometry().getMesh2d()->setCompartmentMaxTriangleArea(1, maxAreas[1]);
+    const auto *meshWithoutEmptyCompartment{m.getGeometry().getMesh2d()};
+    REQUIRE(meshWithoutEmptyCompartment != nullptr);
+    REQUIRE(meshWithoutEmptyCompartment->isValid());
+    const auto &triangleIndicesWithoutEmptyCompartment{
+        meshWithoutEmptyCompartment->getTriangleIndices()};
+    REQUIRE(triangleIndicesWithoutEmptyCompartment.size() == 2);
+    const auto elementCoordinatesWithoutEmptyCompartment{
+        getSubdomainElementCoordinates(*meshWithoutEmptyCompartment)};
+    for (std::size_t iComp = 0; iComp < 2; ++iComp) {
+      CAPTURE(iComp);
+      REQUIRE(triangleCountsWithEmptyCompartment[iComp] ==
+              triangleIndicesWithoutEmptyCompartment[iComp].size());
+      REQUIRE(elementCoordinatesWithEmptyCompartment[iComp].size() ==
+              elementCoordinatesWithoutEmptyCompartment[iComp].size());
+      for (std::size_t i = 0;
+           i < elementCoordinatesWithEmptyCompartment[iComp].size(); ++i) {
+        CAPTURE(i);
+        REQUIRE(
+            elementCoordinatesWithEmptyCompartment[iComp][i] ==
+            dbl_approx(elementCoordinatesWithoutEmptyCompartment[iComp][i]));
+      }
+    }
     comps.pop_back();
     simulate::DuneSim newDuneSim(m, comps);
     for (std::size_t i = 0; i < 2; ++i) {
@@ -107,8 +176,7 @@ TEST_CASE("DuneSim", "[core/simulate/dunesim][core/"
       }
       CAPTURE(sum);
       CAPTURE(diff);
-      // todo: why did this increase from 1e-10 for dune-copasi 2?
-      REQUIRE(diff / sum < 1e-4);
+      REQUIRE(diff / sum < 1e-13);
     }
   }
   SECTION("Callback is provided and used to stop simulation") {

--- a/core/simulate/src/simulate_t.cpp
+++ b/core/simulate/src/simulate_t.cpp
@@ -685,12 +685,6 @@ TEST_CASE("Simulate: very_simple_model, membrane reaction units consistency",
        {simulate::SimulatorType::DUNE, simulate::SimulatorType::Pixel}) {
     double epsilon{1e-8};
     double margin{1e-13};
-    if (simulatorType == simulate::SimulatorType::DUNE) {
-      // todo: why this has increased so much vs dune-copasi 1 (1e-6 epsilon,
-      // 1e-13 margin)
-      margin = 1e-6;
-      epsilon = 1e-2;
-    }
     double simTime{0.025};
     // import model
     auto s1{getExampleModel(Mod::VerySimpleModel)};


### PR DESCRIPTION
- reduce tolerances for dune-copasi tests that were increased for dune-copasi 2
    - some issues appear to have been fixed by https://gitlab.dune-project.org/pdelab/dune-pdelab/-/merge_requests/662
  - remove the non-zero reaction term for the dummy species for empty compartments
    - this was previously needed to avoid the timestep going to zero
    - doesn't seem to be required any more
    - and it was affecting convergence since it is a much larger term than the actual reaction terms
  - resolves #914
  
  also
  
  - update which tests have the [expensive] flag
  - hoist the membrane species list and pde construction out of the loop over species in duneconverter
    - previously this was being re-calculated for every species instead of doing it once per membrane
  - ensure reactions located in a membrane are also removed if that membrane gets removed due to a compartment being deleted
