### PR TITLE
Add mouseover info to math expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - species concentration at the mouseover location in the species tab [#122](https://github.com/spatial-model-editor/spatial-model-editor/issues/122)
+- tooltip in math expression editors describing the symbol or function under the cursor [#560](https://github.com/spatial-model-editor/spatial-model-editor/issues/560)
 
 ### Fixed
 - ImageSlice dialog now uses the currently selected z-slice, mouseover text reports physical `x/y/z/t` values, geometry image has grid and scale overlays [#577](https://github.com/spatial-model-editor/spatial-model-editor/issues/577)

--- a/core/common/include/sme/symbolic_function.hpp
+++ b/core/common/include/sme/symbolic_function.hpp
@@ -25,5 +25,9 @@ struct SymbolicFunction {
    * @brief Function body expression.
    */
   std::string body;
+  /**
+   * @brief Human-readable description of the function (used as tooltip text).
+   */
+  std::string description;
 };
 } // namespace sme::common

--- a/core/model/include/sme/model_parameters.hpp
+++ b/core/model/include/sme/model_parameters.hpp
@@ -24,6 +24,7 @@ class ModelSpecies;
 struct IdName {
   std::string id;
   std::string name;
+  std::string description;
 };
 
 /**
@@ -42,6 +43,7 @@ struct IdNameValue {
   std::string id;
   std::string name;
   double value;
+  std::string description;
 };
 
 /**

--- a/core/model/src/model_functions.cpp
+++ b/core/model/src/model_functions.cpp
@@ -244,6 +244,15 @@ ModelFunctions::getSymbolicFunctions() const {
     }
     fn.body = getExpression(id).toStdString();
     SPDLOG_DEBUG("  - body: {}", fn.body);
+    std::string desc{fn.name + "("};
+    for (std::size_t i = 0; i < fn.args.size(); ++i) {
+      if (i > 0) {
+        desc += ", ";
+      }
+      desc += fn.args[i];
+    }
+    desc += ") = " + fn.body;
+    fn.description = std::move(desc);
   }
   return fns;
 }

--- a/core/model/src/model_parameters.cpp
+++ b/core/model/src/model_parameters.cpp
@@ -333,31 +333,59 @@ void ModelParameters::setSpatialCoordinates(SpatialCoordinates coords) {
               z->getName());
 }
 
+static std::string speciesCompartmentSuffix(const libsbml::Model *model,
+                                            const libsbml::Species *spec) {
+  if (spec->getCompartment().empty()) {
+    return {};
+  }
+  const auto *comp = model->getCompartment(spec->getCompartment());
+  const std::string &compName{comp != nullptr && !comp->getName().empty()
+                                  ? comp->getName()
+                                  : spec->getCompartment()};
+  return " in compartment '" + compName + "'";
+}
+
 std::vector<IdName>
 ModelParameters::getSymbols(const QStringList &compartments) const {
   std::vector<IdName> symbols;
   const auto nCompartments{sbmlModel->getNumCompartments()};
   const auto nSpecies{sbmlModel->getNumSpecies()};
-  symbols.reserve(static_cast<std::size_t>(ids.size()) + 3 +
+  symbols.reserve(static_cast<std::size_t>(ids.size()) + 4 +
                   static_cast<std::size_t>(nCompartments + nSpecies));
   for (int i = 0; i < ids.size(); ++i) {
-    symbols.push_back({ids[i].toStdString(), names[i].toStdString()});
+    const auto &paramId{ids[i]};
+    std::string desc{"Parameter"};
+    if (const auto *param = sbmlModel->getParameter(paramId.toStdString());
+        param != nullptr) {
+      if (sbmlModel->getAssignmentRule(param->getId()) != nullptr) {
+        desc += ", value given by assignment rule";
+      } else {
+        desc += ", value = " + std::to_string(param->getValue());
+      }
+    }
+    symbols.push_back(
+        {paramId.toStdString(), names[i].toStdString(), std::move(desc)});
   }
   for (unsigned i = 0; i < nSpecies; ++i) {
     const auto *spec = sbmlModel->getSpecies(i);
     if (compartments.empty() ||
         compartments.contains(spec->getCompartment().c_str())) {
-      symbols.push_back({spec->getId(), spec->getName()});
+      std::string desc{"Species" + speciesCompartmentSuffix(sbmlModel, spec)};
+      symbols.push_back({spec->getId(), spec->getName(), std::move(desc)});
     }
   }
   for (unsigned i = 0; i < nCompartments; ++i) {
     const auto *comp = sbmlModel->getCompartment(i);
-    symbols.push_back({comp->getId(), comp->getName()});
+    std::string desc{"Compartment, size = " + std::to_string(comp->getSize())};
+    symbols.push_back({comp->getId(), comp->getName(), std::move(desc)});
   }
-  symbols.push_back({spatialCoordinates.x.id, spatialCoordinates.x.name});
-  symbols.push_back({spatialCoordinates.y.id, spatialCoordinates.y.name});
-  symbols.push_back({spatialCoordinates.z.id, spatialCoordinates.z.name});
-  symbols.push_back({"time", "t"});
+  symbols.push_back({spatialCoordinates.x.id, spatialCoordinates.x.name,
+                     "Spatial x-coordinate"});
+  symbols.push_back({spatialCoordinates.y.id, spatialCoordinates.y.name,
+                     "Spatial y-coordinate"});
+  symbols.push_back({spatialCoordinates.z.id, spatialCoordinates.z.name,
+                     "Spatial z-coordinate"});
+  symbols.push_back({"time", "t", "Simulation time"});
   return symbols;
 }
 
@@ -403,7 +431,11 @@ std::vector<IdNameValue> ModelParameters::getGlobalConstants() const {
     if (getIsSpeciesConstant(spec) && !isSpatialSpecies(spec)) {
       SPDLOG_TRACE("found scalar constant species {}", spec->getId());
       double init_conc = spec->getInitialConcentration();
-      constants.push_back({spec->getId(), spec->getName(), init_conc});
+      std::string desc{
+          "Constant species" + speciesCompartmentSuffix(sbmlModel, spec) +
+          ", initial concentration = " + std::to_string(init_conc)};
+      constants.push_back(
+          {spec->getId(), spec->getName(), init_conc, std::move(desc)});
       SPDLOG_TRACE("parameter {} = {}", spec->getId(), init_conc);
     }
   }
@@ -413,7 +445,8 @@ std::vector<IdNameValue> ModelParameters::getGlobalConstants() const {
     if (isConstantParameter(param)) {
       SPDLOG_TRACE("parameter {} = {}", param->getId(), param->getValue());
       constants.push_back(
-          {param->getId(), param->getName(), param->getValue()});
+          {param->getId(), param->getName(), param->getValue(),
+           "Parameter, value = " + std::to_string(param->getValue())});
     }
   }
   // also get compartment volumes (the compartmentID may be used in the
@@ -422,7 +455,9 @@ std::vector<IdNameValue> ModelParameters::getGlobalConstants() const {
   for (unsigned int k = 0; k < sbmlModel->getNumCompartments(); ++k) {
     const auto *comp = sbmlModel->getCompartment(k);
     SPDLOG_TRACE("parameter {} = {}", comp->getId(), comp->getSize());
-    constants.push_back({comp->getId(), comp->getName(), comp->getSize()});
+    constants.push_back(
+        {comp->getId(), comp->getName(), comp->getSize(),
+         "Compartment, size = " + std::to_string(comp->getSize())});
   }
   return constants;
 }

--- a/gui/dialogs/dialoganalytic.cpp
+++ b/gui/dialogs/dialoganalytic.cpp
@@ -51,11 +51,14 @@ DialogAnalytic::DialogAnalytic(
   // add x,y,z variables
   const auto &spatialCoordinates{modelParameters.getSpatialCoordinates()};
   ui->txtExpression->addVariable(spatialCoordinates.x.id,
-                                 spatialCoordinates.x.name);
+                                 spatialCoordinates.x.name,
+                                 "Spatial x-coordinate");
   ui->txtExpression->addVariable(spatialCoordinates.y.id,
-                                 spatialCoordinates.y.name);
+                                 spatialCoordinates.y.name,
+                                 "Spatial y-coordinate");
   ui->txtExpression->addVariable(spatialCoordinates.z.id,
-                                 spatialCoordinates.z.name);
+                                 spatialCoordinates.z.name,
+                                 "Spatial z-coordinate");
   for (const auto &function : modelFunctions.getSymbolicFunctions()) {
     ui->txtExpression->addFunction(function);
   }

--- a/gui/tabs/tabfunctions.cpp
+++ b/gui/tabs/tabfunctions.cpp
@@ -65,7 +65,9 @@ void TabFunctions::listFunctions_currentRowChanged(int row) {
   auto args = funcs.getArguments(id);
   // reset variables to only built-in functions
   ui->txtFunctionDef->reset();
-  ui->txtFunctionDef->setVariables(sme::common::toStdString(args));
+  for (const auto &arg : args) {
+    ui->txtFunctionDef->addVariable(arg.toStdString(), {}, "Function argument");
+  }
   // add model functions
   for (const auto &function : model.getFunctions().getSymbolicFunctions()) {
     ui->txtFunctionDef->addFunction(function);
@@ -132,7 +134,8 @@ void TabFunctions::btnAddFunctionParam_clicked() {
     SPDLOG_INFO("Adding parameter {}", param.toStdString());
     auto argId = model.getFunctions().addArgument(currentFunctionId, param);
     ui->listFunctionParams->addItem(argId);
-    ui->txtFunctionDef->addVariable(param.toStdString());
+    ui->txtFunctionDef->addVariable(param.toStdString(), {},
+                                    "Function argument");
     ui->listFunctionParams->setCurrentRow(ui->listFunctionParams->count() - 1);
   }
 }

--- a/gui/tabs/tabparameters.cpp
+++ b/gui/tabs/tabparameters.cpp
@@ -29,8 +29,8 @@ void TabParameters::loadModelData(const QString &selection) {
   ui->listParameters->clear();
   ui->txtExpression->clearVariables();
   ui->txtExpression->reset();
-  for (const auto &[id, name] : model.getParameters().getSymbols()) {
-    ui->txtExpression->addVariable(id, name);
+  for (const auto &symbol : model.getParameters().getSymbols()) {
+    ui->txtExpression->addVariable(symbol.id, symbol.name, symbol.description);
   }
   for (const auto &function : model.getFunctions().getSymbolicFunctions()) {
     ui->txtExpression->addFunction(function);

--- a/gui/tabs/tabreactions.cpp
+++ b/gui/tabs/tabreactions.cpp
@@ -14,6 +14,10 @@ QDoubleSpinBoxNoScroll::QDoubleSpinBoxNoScroll(QWidget *parent)
 
 void QDoubleSpinBoxNoScroll::wheelEvent(QWheelEvent *event) { event->ignore(); }
 
+static std::string reactionParamDescription(double value) {
+  return QString("Reaction parameter, value = %1").arg(value).toStdString();
+}
+
 TabReactions::TabReactions(sme::model::Model &m,
                            QLabelMouseTracker *mouseTracker,
                            QVoxelRenderer *voxelRenderer, QWidget *parent)
@@ -185,9 +189,9 @@ void TabReactions::listReactions_currentItemChanged(QTreeWidgetItem *current,
   ui->cmbReactionLocation->setCurrentIndex(static_cast<int>(locationIndex));
   ui->txtReactionRate->reset();
   // add model parameters
-  for (const auto &[id, name] :
-       model.getParameters().getSymbols(compartments)) {
-    ui->txtReactionRate->addVariable(id, name);
+  for (const auto &symbol : model.getParameters().getSymbols(compartments)) {
+    ui->txtReactionRate->addVariable(symbol.id, symbol.name,
+                                     symbol.description);
   }
   // add model functions
   for (const auto &function : model.getFunctions().getSymbolicFunctions()) {
@@ -198,9 +202,12 @@ void TabReactions::listReactions_currentItemChanged(QTreeWidgetItem *current,
     auto *comp = new QTreeWidgetItem;
     comp->setText(0, model.getCompartments().getName(compID));
     ui->listReactionSpecies->addTopLevelItem(comp);
+    auto compName = model.getCompartments().getName(compID);
     for (const auto &sId : model.getSpecies().getIds(compID)) {
       auto sName = model.getSpecies().getName(sId);
-      ui->txtReactionRate->addVariable(sId.toStdString(), sName.toStdString());
+      ui->txtReactionRate->addVariable(
+          sId.toStdString(), sName.toStdString(),
+          QString("Species in compartment '%1'").arg(compName).toStdString());
       auto *item = new QTreeWidgetItem;
       item->setText(0, sName);
       auto *spinBox = new QDoubleSpinBoxNoScroll(ui->listReactionSpecies);
@@ -243,7 +250,8 @@ void TabReactions::listReactions_currentItemChanged(QTreeWidgetItem *current,
     ui->listReactionParams->setRowCount(n + 1);
     ui->listReactionParams->setItem(n, 0, itemName);
     ui->listReactionParams->setItem(n, 1, itemValue);
-    ui->txtReactionRate->addVariable(paramId.toStdString(), name.toStdString());
+    ui->txtReactionRate->addVariable(paramId.toStdString(), name.toStdString(),
+                                     reactionParamDescription(value));
   }
   ui->listReactionParams->blockSignals(false);
   ui->txtReactionRate->importVariableMath(
@@ -338,10 +346,12 @@ void TabReactions::listReactionParams_cellChanged(int row, int column) {
       ui->listReactionParams->blockSignals(false);
     }
     // update math expression with new parameter name
+    double currentValue{reactions.getParameterValue(currentReacId, paramId)};
     ui->txtReactionRate->blockSignals(true);
     ui->txtReactionRate->removeVariable(paramId.toStdString());
     ui->txtReactionRate->addVariable(paramId.toStdString(),
-                                     newName.toStdString());
+                                     newName.toStdString(),
+                                     reactionParamDescription(currentValue));
     ui->txtReactionRate->blockSignals(false);
     ui->txtReactionRate->importVariableMath(
         model.getReactions().getRateExpression(currentReacId).toStdString());
@@ -355,6 +365,9 @@ void TabReactions::listReactionParams_cellChanged(int row, int column) {
     if (isValidDouble) {
       item->setBackground({});
       reactions.setParameterValue(currentReacId, paramId, value);
+      auto paramName{reactions.getParameterName(currentReacId, paramId)};
+      ui->txtReactionRate->setDescription(paramName.toStdString(),
+                                          reactionParamDescription(value));
     } else {
       SPDLOG_WARN("Invalid number ignored: '{}'", item->text().toStdString());
       item->setBackground(Qt::red);
@@ -380,7 +393,8 @@ void TabReactions::btnAddReactionParam_clicked() {
   ui->listReactionParams->setRowCount(n + 1);
   ui->listReactionParams->setItem(n, 0, itemName);
   ui->listReactionParams->setItem(n, 1, itemValue);
-  ui->txtReactionRate->addVariable(id.toStdString(), uniqueName.toStdString());
+  ui->txtReactionRate->addVariable(id.toStdString(), uniqueName.toStdString(),
+                                   reactionParamDescription(0));
   ui->listReactionParams->setCurrentItem(itemValue);
   ui->btnRemoveReactionParam->setEnabled(true);
   ui->listReactionParams->blockSignals(false);

--- a/gui/tabs/tabspecies.cpp
+++ b/gui/tabs/tabspecies.cpp
@@ -535,7 +535,7 @@ void TabSpecies::updateCrossDiffusionWidgets() {
     txtExpression->setMaximumHeight(35);
     txtExpression->setMinimumHeight(30);
     for (const auto &symbol : symbols) {
-      txtExpression->addVariable(symbol.id, symbol.name);
+      txtExpression->addVariable(symbol.id, symbol.name, symbol.description);
     }
     for (const auto &function : functions) {
       txtExpression->addFunction(function);

--- a/gui/widgets/qplaintextmathedit.cpp
+++ b/gui/widgets/qplaintextmathedit.cpp
@@ -3,8 +3,10 @@
 #include "sme/utils.hpp"
 #include <QAbstractItemModel>
 #include <QAbstractItemView>
+#include <QHelpEvent>
 #include <QScrollBar>
 #include <QString>
+#include <QToolTip>
 #include <algorithm>
 #include <limits>
 
@@ -48,6 +50,9 @@ const std::vector<std::string> &QPlainTextMathEdit::getVariables() const {
 }
 
 void QPlainTextMathEdit::clearVariables() {
+  for (const auto &[var, displayName] : mapVarsToDisplayNames) {
+    mapDisplayNamesToDescriptions.erase(displayName);
+  }
   vars.clear();
   mapDisplayNamesToVars.clear();
   mapVarsToDisplayNames.clear();
@@ -104,7 +109,8 @@ static void appendQuotedName(QTextCursor &tc, const QString &name) {
 }
 
 void QPlainTextMathEdit::addVariable(const std::string &variable,
-                                     const std::string &displayName) {
+                                     const std::string &displayName,
+                                     const std::string &description) {
   SPDLOG_TRACE("adding var: {}", variable);
   vars.push_back(variable);
   auto name{displayName};
@@ -114,6 +120,9 @@ void QPlainTextMathEdit::addVariable(const std::string &variable,
   SPDLOG_TRACE("  -> display name {}", name);
   mapDisplayNamesToVars[name] = variable;
   mapVarsToDisplayNames[variable] = name;
+  if (!description.empty()) {
+    mapDisplayNamesToDescriptions[name] = description;
+  }
   updateCompleter();
   qPlainTextEdit_textChanged();
 }
@@ -126,6 +135,7 @@ void QPlainTextMathEdit::removeVariable(const std::string &variable) {
     const auto &displayName{iter->second};
     SPDLOG_TRACE("  -> display name {}", displayName);
     mapDisplayNamesToVars.erase(displayName);
+    mapDisplayNamesToDescriptions.erase(displayName);
     mapVarsToDisplayNames.erase(iter);
   }
   qPlainTextEdit_textChanged();
@@ -168,6 +178,9 @@ void QPlainTextMathEdit::addFunction(
   SPDLOG_TRACE("  -> display name {}", function.name);
   mapDisplayNamesToFuncs[function.name] = function.id;
   mapFuncsToDisplayNames[function.id] = function.name;
+  if (!function.description.empty()) {
+    mapDisplayNamesToDescriptions[function.name] = function.description;
+  }
   updateCompleter();
   qPlainTextEdit_textChanged();
 }
@@ -179,6 +192,7 @@ void QPlainTextMathEdit::removeFunction(const std::string &functionId) {
     std::string displayName = iter->second;
     SPDLOG_TRACE("  -> display name {}", displayName);
     mapDisplayNamesToFuncs.erase(displayName);
+    mapDisplayNamesToDescriptions.erase(displayName);
     mapFuncsToDisplayNames.erase(iter);
   }
   functions.erase(std::remove_if(functions.begin(), functions.end(),
@@ -198,6 +212,7 @@ void QPlainTextMathEdit::setConstants(
     if (auto iter = mapVarsToDisplayNames.find(c.first);
         iter != mapVarsToDisplayNames.end()) {
       mapDisplayNamesToVars.erase(iter->second);
+      mapDisplayNamesToDescriptions.erase(iter->second);
       mapVarsToDisplayNames.erase(iter);
     }
   }
@@ -206,9 +221,30 @@ void QPlainTextMathEdit::setConstants(
     consts.emplace_back(c.id, c.value);
     mapDisplayNamesToVars[c.name] = c.id;
     mapVarsToDisplayNames[c.id] = c.name;
+    if (!c.description.empty()) {
+      mapDisplayNamesToDescriptions[c.name] = c.description;
+    }
   }
   updateCompleter();
   qPlainTextEdit_textChanged();
+}
+
+void QPlainTextMathEdit::setDescription(const std::string &displayName,
+                                        const std::string &description) {
+  if (description.empty()) {
+    mapDisplayNamesToDescriptions.erase(displayName);
+  } else {
+    mapDisplayNamesToDescriptions[displayName] = description;
+  }
+}
+
+std::string
+QPlainTextMathEdit::getDescription(const std::string &displayName) const {
+  if (auto it{mapDisplayNamesToDescriptions.find(displayName)};
+      it != mapDisplayNamesToDescriptions.cend()) {
+    return it->second;
+  }
+  return {};
 }
 
 void QPlainTextMathEdit::updateCompleter() {
@@ -429,10 +465,14 @@ void QPlainTextMathEdit::qPlainTextEdit_cursorPositionChanged() {
   setExtraSelections({s});
 }
 
-QString QPlainTextMathEdit::getCurrentWord() {
-  auto expr{toPlainText()};
-  auto tc{textCursor()};
-  const auto pos{tc.position()};
+struct WordSelection {
+  QString word;
+  qsizetype startPos;
+  qsizetype endPos;
+};
+
+static WordSelection findWordAt(const QString &expr, QTextCursor cursor) {
+  const auto pos{cursor.position()};
   bool inQuotes{false};
   auto quoteEndPos{expr.indexOf(quoteChar)};
   auto quoteStartPos{quoteEndPos};
@@ -442,16 +482,21 @@ QString QPlainTextMathEdit::getCurrentWord() {
     quoteEndPos = expr.indexOf(quoteChar, quoteStartPos + 1);
   }
   if (inQuotes) {
-    // if quoted: word is everything inside the quotes
-    currentWordStartPos = quoteStartPos;
-    currentWordEndPos = quoteEndPos;
-    return expr.mid(quoteStartPos + 1, quoteEndPos - quoteStartPos - 1);
+    // word is the text between the quotes (or everything after an unterminated
+    // open quote, in which case mid() returns to end of string)
+    return {expr.mid(quoteStartPos + 1, quoteEndPos - quoteStartPos - 1),
+            quoteStartPos, quoteEndPos};
   }
-  // otherwise use normal Qt word selection
-  tc.select(QTextCursor::WordUnderCursor);
-  currentWordStartPos = tc.selectionStart();
-  currentWordEndPos = tc.selectionEnd();
-  return tc.selectedText();
+  cursor.select(QTextCursor::WordUnderCursor);
+  return {cursor.selectedText(), cursor.selectionStart(),
+          cursor.selectionEnd()};
+}
+
+QString QPlainTextMathEdit::getCurrentWord() {
+  auto sel{findWordAt(toPlainText(), textCursor())};
+  currentWordStartPos = sel.startPos;
+  currentWordEndPos = sel.endPos;
+  return sel.word;
 }
 
 void QPlainTextMathEdit::insertCompletion(const QString &completion) {
@@ -467,6 +512,42 @@ void QPlainTextMathEdit::insertCompletion(const QString &completion) {
   tc.removeSelectedText();
   appendQuotedName(tc, completion);
   setTextCursor(tc);
+}
+
+std::string
+QPlainTextMathEdit::symbolAtViewportPos(const QPoint &viewportPos) const {
+  auto cursor{cursorForPosition(viewportPos)};
+  auto sel{findWordAt(toPlainText(), cursor)};
+  // reject hovers that snapped to a word boundary from beyond the text:
+  // require the viewport x to lie within the selected word's bounding rect
+  auto startCursor{cursor};
+  startCursor.setPosition(static_cast<int>(sel.startPos));
+  auto endCursor{cursor};
+  endCursor.setPosition(static_cast<int>(std::max(sel.endPos, sel.startPos)));
+  const auto leftEdge{cursorRect(startCursor).left()};
+  const auto rightEdge{cursorRect(endCursor).right()};
+  if (viewportPos.x() < leftEdge || viewportPos.x() > rightEdge) {
+    return {};
+  }
+  return sel.word.toStdString();
+}
+
+bool QPlainTextMathEdit::viewportEvent(QEvent *e) {
+  if (e->type() == QEvent::ToolTip) {
+    auto *helpEvent = static_cast<QHelpEvent *>(e);
+    auto symbol{symbolAtViewportPos(helpEvent->pos())};
+    if (auto it{mapDisplayNamesToDescriptions.find(symbol)};
+        !symbol.empty() && it != mapDisplayNamesToDescriptions.cend()) {
+      QString tooltip{
+          QString("<b>%1</b><br>%2")
+              .arg(QString::fromStdString(symbol).toHtmlEscaped(),
+                   QString::fromStdString(it->second).toHtmlEscaped())};
+      QToolTip::showText(helpEvent->globalPos(), tooltip, viewport());
+      return true;
+    }
+    QToolTip::hideText();
+  }
+  return QPlainTextEdit::viewportEvent(e);
 }
 
 void QPlainTextMathEdit::keyPressEvent(QKeyEvent *e) {

--- a/gui/widgets/qplaintextmathedit.hpp
+++ b/gui/widgets/qplaintextmathedit.hpp
@@ -30,12 +30,16 @@ public:
   void clearVariables();
   void setVariables(const std::vector<std::string> &variables);
   void addVariable(const std::string &variable,
-                   const std::string &displayName = {});
+                   const std::string &displayName = {},
+                   const std::string &description = {});
   void removeVariable(const std::string &variable);
   void reset();
   void addFunction(const sme::common::SymbolicFunction &function);
   void removeFunction(const std::string &functionId);
   void setConstants(const std::vector<sme::model::IdNameValue> &constants = {});
+  void setDescription(const std::string &displayName,
+                      const std::string &description);
+  std::string getDescription(const std::string &displayName) const;
   void updateCompleter();
 
 signals:
@@ -57,6 +61,7 @@ private:
   StringStringMap mapDisplayNamesToVars;
   StringStringMap mapFuncsToDisplayNames;
   StringStringMap mapDisplayNamesToFuncs;
+  StringStringMap mapDisplayNamesToDescriptions;
   QString currentDisplayMath;
   std::string currentVariableMath;
   QString currentErrorMessage;
@@ -72,4 +77,6 @@ private:
   QString getCurrentWord();
   void insertCompletion(const QString &completion);
   void keyPressEvent(QKeyEvent *e) override;
+  bool viewportEvent(QEvent *e) override;
+  std::string symbolAtViewportPos(const QPoint &viewportPos) const;
 };

--- a/gui/widgets/qplaintextmathedit_t.cpp
+++ b/gui/widgets/qplaintextmathedit_t.cpp
@@ -299,6 +299,37 @@ TEST_CASE("QPlainTextMathEdit", "[gui/widgets/qplaintextmathedit][gui/"
     REQUIRE_THAT(mathEdit.getErrorMessage().toStdString(),
                  ContainsSubstring("Variable 'K' not found"));
   }
+  SECTION("symbol descriptions") {
+    mathEdit.show();
+    mathEdit.clearVariables();
+    // variable with description
+    mathEdit.addVariable("x_id", "X", "Spatial x-coordinate");
+    REQUIRE(mathEdit.getDescription("X") == "Spatial x-coordinate");
+    // variable without description
+    mathEdit.addVariable("y_id", "Y");
+    REQUIRE(mathEdit.getDescription("Y").empty());
+    // unknown display name
+    REQUIRE(mathEdit.getDescription("not_a_symbol").empty());
+    // removing variable also removes its description
+    mathEdit.removeVariable("x_id");
+    REQUIRE(mathEdit.getDescription("X").empty());
+    // function description (taken from SymbolicFunction.description)
+    sme::common::SymbolicFunction f;
+    f.id = "f_id";
+    f.name = "F";
+    f.args = {"a", "b"};
+    f.body = "a + b";
+    f.description = "F(a, b) = a + b";
+    mathEdit.addFunction(f);
+    REQUIRE(mathEdit.getDescription("F") == "F(a, b) = a + b");
+    mathEdit.removeFunction("f_id");
+    REQUIRE(mathEdit.getDescription("F").empty());
+    // setConstants populates and clears descriptions
+    mathEdit.setConstants({{"k_id", "K", 2.0, "Parameter, value = 2"}});
+    REQUIRE(mathEdit.getDescription("K") == "Parameter, value = 2");
+    mathEdit.setConstants({});
+    REQUIRE(mathEdit.getDescription("K").empty());
+  }
   SECTION("expression that parses but doesn't compile") {
     // https://github.com/spatial-model-editor/spatial-model-editor/issues/805
     mathEdit.show();


### PR DESCRIPTION
- add `description` field to SymbolicFunction, ModelSpecies, IdNameValue
- display this on mouseover in QPlainTextMathEdit
- resolves #560
