### PR TITLE
Use Q_EMIT instead of emit Qt keyword

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: spatial-model-editor/setup-ci@2026.03.30
         with:
-          sme_deps: '2026.04.17'
+          sme_deps: '2026.04.30'
           cache_id: ${{ matrix.script }}
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: spatial-model-editor/setup-ci@2026.03.30
         with:
-          sme_deps: '2026.04.17'
+          sme_deps: '2026.04.30'
           cache_id: ${{ matrix.target }}
       - uses: actions/checkout@v6
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ get_target_property(
   Qt6::Core
   LOCATION)
 message(STATUS "Found QtCore: ${QtCore_location}")
+set(SME_QT_NO_KEYWORD_DEFS QT_NO_SIGNALS_SLOTS_KEYWORDS QT_NO_EMIT)
 
 # enable Qt utils: moc, uic, rcc
 set(CMAKE_AUTOMOC ON)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -227,7 +227,10 @@ target_link_libraries(
          Qt::Core
          Pagmo::pagmo)
 
-target_compile_definitions(core PUBLIC ${SME_EXTRA_CORE_DEFS})
+target_compile_definitions(
+  core
+  PUBLIC ${SME_QT_NO_KEYWORD_DEFS}
+  PUBLIC ${SME_EXTRA_CORE_DEFS})
 
 if(BUILD_TESTING)
   target_link_libraries(

--- a/core/simulate/include/sme/optimize.hpp
+++ b/core/simulate/include/sme/optimize.hpp
@@ -5,18 +5,11 @@
 #include "sme/simulate.hpp"
 #include <memory>
 #include <mutex>
+#include <oneapi/tbb/concurrent_queue.h>
 #include <optional>
 #include <pagmo/algorithm.hpp>
 #include <pagmo/archipelago.hpp>
 #include <pagmo/population.hpp>
-// Qt defines emit keyword which interferes with a tbb emit() function
-#ifdef emit
-#undef emit
-#include <oneapi/tbb/concurrent_queue.h>
-#define emit // restore the Qt empty definition of "emit"
-#else
-#include <oneapi/tbb/concurrent_queue.h>
-#endif
 
 namespace sme::simulate {
 

--- a/core/simulate/src/dune_headers.hpp
+++ b/core/simulate/src/dune_headers.hpp
@@ -30,9 +30,6 @@
 #endif
 #endif
 
-// Qt defines emit keyword which interferes with a tbb emit() function
-#undef emit
-
 #include <dune-copasi-config.hh>
 
 #include <dune/copasi/common/stepper.hh>
@@ -58,8 +55,6 @@
 #include <dune/common/parallel/mpihelper.hh>
 #include <dune/common/parametertree.hh>
 #include <dune/common/parametertreeparser.hh>
-
-#define emit // restore the Qt empty definition of "emit"
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/core/simulate/src/pixelsim_impl.cpp
+++ b/core/simulate/src/pixelsim_impl.cpp
@@ -12,19 +12,10 @@
 #include <cmath>
 #include <cstdlib>
 #include <memory>
+#include <oneapi/tbb/global_control.h>
+#include <oneapi/tbb/parallel_for.h>
+#include <oneapi/tbb/tick_count.h>
 #include <utility>
-// Qt defines emit keyword which interferes with a tbb emit() function
-#ifdef emit
-#undef emit
-#include <oneapi/tbb/global_control.h>
-#include <oneapi/tbb/parallel_for.h>
-#include <oneapi/tbb/tick_count.h>
-#define emit // restore the Qt empty definition of "emit"
-#else
-#include <oneapi/tbb/global_control.h>
-#include <oneapi/tbb/parallel_for.h>
-#include <oneapi/tbb/tick_count.h>
-#endif
 
 namespace sme::simulate {
 

--- a/gui/tabs/tabgeometry.cpp
+++ b/gui/tabs/tabgeometry.cpp
@@ -161,7 +161,7 @@ void TabGeometry::lblGeometry_mouseClicked(QRgb col, sme::common::Voxel point) {
     QGuiApplication::restoreOverrideCursor();
     enableTabs();
     loadModelData(ui->listCompartments->currentItem()->text());
-    emit modelGeometryChanged();
+    Q_EMIT modelGeometryChanged();
     return;
   }
   // display compartment the user just clicked on
@@ -182,7 +182,7 @@ void TabGeometry::btnAddCompartment_clicked() {
     ui->tabCompartmentGeometry->setCurrentIndex(0);
     enableTabs();
     loadModelData(newCompartmentName);
-    emit modelGeometryChanged();
+    Q_EMIT modelGeometryChanged();
   }
 }
 
@@ -204,13 +204,13 @@ void TabGeometry::btnRemoveCompartment_clicked() {
     ui->tabCompartmentGeometry->setCurrentIndex(0);
     enableTabs();
     loadModelData();
-    emit modelGeometryChanged();
+    Q_EMIT modelGeometryChanged();
   }
 }
 
 void TabGeometry::btnChangeCompartment_clicked() {
   if (!(model.getIsValid() && model.getGeometry().getHasImage())) {
-    emit invalidModelOrNoGeometryImage();
+    Q_EMIT invalidModelOrNoGeometryImage();
     SPDLOG_DEBUG("invalid geometry and/or model: ignoring");
     return;
   }

--- a/gui/tabs/tabgeometry.hpp
+++ b/gui/tabs/tabgeometry.hpp
@@ -33,7 +33,7 @@ public:
   void enableTabs();
   void invertYAxis(bool enable);
 
-signals:
+Q_SIGNALS:
   void invalidModelOrNoGeometryImage();
   void modelGeometryChanged();
 

--- a/gui/widgets/qlabelmousetracker.cpp
+++ b/gui/widgets/qlabelmousetracker.cpp
@@ -115,13 +115,13 @@ void QLabelMouseTracker::mousePressEvent(QMouseEvent *ev) {
       maskIndex = static_cast<int>(
           maskImage[currentVoxel.z].pixel(currentVoxel.p) & RGB_MASK);
     }
-    emit mouseClicked(color, currentVoxel);
+    Q_EMIT mouseClicked(color, currentVoxel);
   }
 }
 
 void QLabelMouseTracker::mouseMoveEvent(QMouseEvent *ev) {
   if (setCurrentPixel(ev->pos())) {
-    emit mouseOver(currentVoxel);
+    Q_EMIT mouseOver(currentVoxel);
   }
 }
 
@@ -132,7 +132,7 @@ void QLabelMouseTracker::mouseDoubleClickEvent(QMouseEvent *ev) {
 }
 
 void QLabelMouseTracker::wheelEvent(QWheelEvent *ev) {
-  emit mouseWheelEvent(ev);
+  Q_EMIT mouseWheelEvent(ev);
 }
 
 void QLabelMouseTracker::resizeEvent(QResizeEvent *event) {

--- a/gui/widgets/qlabelmousetracker.hpp
+++ b/gui/widgets/qlabelmousetracker.hpp
@@ -45,7 +45,7 @@ public:
   void displayScale(bool enable);
   void invertYAxis(bool enable);
 
-signals:
+Q_SIGNALS:
   void mouseClicked(QRgb col, sme::common::Voxel voxel);
   void mouseOver(const sme::common::Voxel &voxel);
   void mouseWheelEvent(QWheelEvent *ev);

--- a/gui/widgets/qlabelslice.cpp
+++ b/gui/widgets/qlabelslice.cpp
@@ -103,7 +103,7 @@ void QLabelSlice::mousePressEvent(QMouseEvent *ev) {
   if (ev->buttons() != Qt::NoButton && setPixel(ev, startPixel)) {
     currentPixel = startPixel;
     mouseIsDown = true;
-    emit mouseDown(currentPixel);
+    Q_EMIT mouseDown(currentPixel);
   }
 }
 
@@ -111,10 +111,10 @@ void QLabelSlice::mouseMoveEvent(QMouseEvent *ev) {
   if (!setPixel(ev, currentPixel)) {
     return;
   }
-  emit mouseOver(currentPixel);
+  Q_EMIT mouseOver(currentPixel);
   if (mouseIsDown) {
     SPDLOG_TRACE("mouseDown ({},{})", currentPixel.x(), currentPixel.y());
-    emit mouseDown(currentPixel);
+    Q_EMIT mouseDown(currentPixel);
   }
 }
 
@@ -122,7 +122,7 @@ void QLabelSlice::mouseReleaseEvent(QMouseEvent *ev) {
   if (mouseIsDown) {
     SPDLOG_TRACE("sliceDrawn ({},{})->({},{})", startPixel.x(), startPixel.y(),
                  currentPixel.x(), currentPixel.y());
-    emit sliceDrawn(startPixel, currentPixel);
+    Q_EMIT sliceDrawn(startPixel, currentPixel);
   }
   ev->accept();
   mouseIsDown = false;
@@ -131,7 +131,7 @@ void QLabelSlice::mouseReleaseEvent(QMouseEvent *ev) {
 void QLabelSlice::mouseDoubleClickEvent(QMouseEvent *ev) { ev->accept(); }
 
 void QLabelSlice::wheelEvent(QWheelEvent *ev) {
-  emit mouseWheelEvent(ev->angleDelta().y());
+  Q_EMIT mouseWheelEvent(ev->angleDelta().y());
 }
 
 void QLabelSlice::resizeEvent(QResizeEvent *event) {

--- a/gui/widgets/qlabelslice.hpp
+++ b/gui/widgets/qlabelslice.hpp
@@ -31,7 +31,7 @@ public:
   void setHorizontalSlice(int y);
   void setVerticalSlice(int x);
 
-signals:
+Q_SIGNALS:
   void sliceDrawn(QPoint start, QPoint end);
   void mouseOver(QPoint point);
   void mouseDown(QPoint point);

--- a/gui/widgets/qmeshrenderer.cpp
+++ b/gui/widgets/qmeshrenderer.cpp
@@ -194,7 +194,7 @@ void QMeshRenderer::mouseReleaseEvent(QMouseEvent *ev) {
       auto compartmentIndex =
           static_cast<int>(std::distance(actors.begin(), iter));
       SPDLOG_TRACE("Click on compartmentIndex {}", compartmentIndex);
-      emit mouseClicked(compartmentIndex);
+      Q_EMIT mouseClicked(compartmentIndex);
     }
   }
 }

--- a/gui/widgets/qmeshrenderer.hpp
+++ b/gui/widgets/qmeshrenderer.hpp
@@ -35,7 +35,7 @@ public:
   void setRenderMode(RenderMode mode);
   void clear();
 
-signals:
+Q_SIGNALS:
   void mouseClicked(int compartmentIndex);
 
 protected:

--- a/gui/widgets/qplaintextmathedit.cpp
+++ b/gui/widgets/qplaintextmathedit.cpp
@@ -417,7 +417,8 @@ void QPlainTextMathEdit::qPlainTextEdit_textChanged() {
       currentDisplayMath = variablesToDisplayNames(currentVariableMath).c_str();
     }
   }
-  emit mathChanged(currentDisplayMath, expressionIsValid, currentErrorMessage);
+  Q_EMIT mathChanged(currentDisplayMath, expressionIsValid,
+                     currentErrorMessage);
 }
 
 static std::pair<int, bool> getClosingBracket(const QString &expr, int pos,

--- a/gui/widgets/qplaintextmathedit.hpp
+++ b/gui/widgets/qplaintextmathedit.hpp
@@ -42,7 +42,7 @@ public:
   std::string getDescription(const std::string &displayName) const;
   void updateCompleter();
 
-signals:
+Q_SIGNALS:
   void mathChanged(const QString &math, bool valid,
                    const QString &errorMessage);
 

--- a/gui/widgets/qvoxelrenderer.cpp
+++ b/gui/widgets/qvoxelrenderer.cpp
@@ -153,7 +153,7 @@ void QVoxelRenderer::mousePressEvent(QMouseEvent *ev) {
           qRgb(imageDataArray->GetValue(idx), imageDataArray->GetValue(idx + 1),
                imageDataArray->GetValue(idx + 2));
       SPDLOG_DEBUG("voxel ({},{},{}) -> color {:x}", x, y, z, col);
-      emit mouseClicked(col, sme::common::Voxel{x, y, z});
+      Q_EMIT mouseClicked(col, sme::common::Voxel{x, y, z});
     }
   }
 }

--- a/gui/widgets/qvoxelrenderer.hpp
+++ b/gui/widgets/qvoxelrenderer.hpp
@@ -25,7 +25,7 @@ public:
   void renderOnClippingPaneChange(SmeVtkWidget *smeVtkWidget);
   inline vtkPlane *getClippingPlane() { return clippingPlane.Get(); }
 
-signals:
+Q_SIGNALS:
   void mouseClicked(QRgb col, sme::common::Voxel voxel);
 
 protected:


### PR DESCRIPTION
- also for slots and signals
- add QT_NO_SIGNALS_SLOTS_KEYWORDS and QT_NO_EMIT compile flags
  - this prevents Qt from #defining emit etc
- remove previous #undef emit workaround
  - was needed to avoid #define emit from qt mangling tbb use of emit
- bump sme_deps to 2026.04.30 to get a qcustomplotlib version with a similar patch applied
- resolves #723
