### PR TITLE
Improve feature integration into optimizer

### DIFF
--- a/core/simulate/include/sme/optimize_options.hpp
+++ b/core/simulate/include/sme/optimize_options.hpp
@@ -58,7 +58,7 @@ struct OptParam {
 /**
  * @brief Types of costs that can be used in optimization
  */
-enum class OptCostType { Concentration, ConcentrationDcdt, Feature };
+enum class OptCostType { Unused, Concentration, ConcentrationDcdt, Feature };
 
 /**
  * @brief Types of differences that can be used in costs

--- a/core/simulate/src/optimize.cpp
+++ b/core/simulate/src/optimize.cpp
@@ -76,9 +76,9 @@ getOptTimesteps(const OptimizeOptions &options) {
   return optTimesteps;
 }
 
-static FeatureOptCost resolveFeatureOptCost(const sme::model::Model &model,
-                                            const OptCost &optCost,
-                                            const common::Volume &imageSize) {
+FeatureOptCost resolveFeatureOptCost(const sme::model::Model &model,
+                                     const OptCost &optCost,
+                                     const common::Volume &imageSize) {
   FeatureOptCost featureOptCost;
   if (optCost.featureId.empty()) {
     featureOptCost.errorMessage =

--- a/core/simulate/src/optimize_impl.hpp
+++ b/core/simulate/src/optimize_impl.hpp
@@ -11,6 +11,10 @@ namespace sme::simulate {
 void applyParameters(const pagmo::vector_double &values,
                      sme::model::Model *model);
 
+FeatureOptCost resolveFeatureOptCost(const sme::model::Model &model,
+                                     const OptCost &optCost,
+                                     const common::Volume &imageSize);
+
 double calculateCosts(const OptConstData &optConstData,
                       const std::vector<std::size_t> &optCostIndices,
                       const sme::simulate::Simulation &sim,

--- a/core/simulate/src/optimize_impl_t.cpp
+++ b/core/simulate/src/optimize_impl_t.cpp
@@ -39,34 +39,8 @@ makeOptConstData(const model::Model &model,
     if (optCost.optCostType != simulate::OptCostType::Feature) {
       continue;
     }
-    const auto featureIndex =
-        model.getFeatures().getIndexFromId(optCost.featureId);
-    if (featureIndex >= model.getFeatures().size()) {
-      continue;
-    }
-    auto &featureOptCost = optConstData.featureOptCosts[i];
-    featureOptCost.feature = model.getFeatures().getFeatures()[featureIndex];
-    featureOptCost.voxelRegions =
-        model.getFeatures().getVoxelRegions(featureIndex);
-    const auto *comp = model.getCompartments().getCompartment(
-        featureOptCost.feature.compartmentId.c_str());
-    if (comp == nullptr) {
-      continue;
-    }
-    std::vector<double> targetConcentrations(comp->nVoxels(), 0.0);
-    const auto &voxels = comp->getVoxels();
-    for (std::size_t j = 0; j < voxels.size(); ++j) {
-      const auto imageIndex =
-          common::voxelArrayIndex(optConstData.imageSize, voxels[j], true);
-      featureOptCost.imageIndices.push_back(imageIndex);
-      if (!optCost.targetValues.empty()) {
-        targetConcentrations[j] = optCost.targetValues[imageIndex];
-      }
-    }
-    featureOptCost.targetFeatureValues =
-        simulate::evaluateFeature(featureOptCost.feature, targetConcentrations,
-                                  featureOptCost.voxelRegions);
-    featureOptCost.valid = true;
+    optConstData.featureOptCosts[i] =
+        simulate::resolveFeatureOptCost(model, optCost, optConstData.imageSize);
   }
   return optConstData;
 }
@@ -404,7 +378,7 @@ TEST_CASE("Optimize calculateCosts: invalid target values",
       simulate::calculateCosts({optCostInvalid}, {0}, sim, currentTargets));
 }
 
-TEST_CASE("Optimize calculateCosts: feature target values",
+TEST_CASE("Optimize calculateCosts: selected feature derives target from image",
           "[core/simulate/optimize][core/simulate][core][optimize]") {
   auto model{getExampleModel(Mod::ABtoC)};
   model.getSimulationSettings().simulatorType =
@@ -412,21 +386,19 @@ TEST_CASE("Optimize calculateCosts: feature target values",
   model.getSpecies().setInitialConcentration("A", 0.73);
   const auto *comp{model.getSpecies().getField("A")->getCompartment()};
   simulate::RoiSettings roi;
-  roi.roiType = simulate::RoiType::Analytic;
-  roi.expression = "1";
-  auto featureIndex = model.getFeatures().add("mean_A", comp->getId(), "A", roi,
-                                              simulate::ReductionOp::Average);
+  roi.roiType = simulate::RoiType::AxisSlices;
+  roi.numRegions = 2;
+  simulate::setRoiParameterInt(roi, simulate::roi_param::axis, 0);
+  auto featureIndex = model.getFeatures().add(
+      "mean_A_by_x", comp->getId(), "A", roi, simulate::ReductionOp::Average);
   simulate::Simulation sim(model);
-  const auto compImgWidth{comp->getCompartmentImages()[0].width()};
-  const auto compImgHeight{comp->getCompartmentImages()[0].height()};
-  std::vector<double> target(
-      static_cast<std::size_t>(compImgWidth * compImgHeight), 0.0);
-  constexpr double targetPixel{2.0};
-  for (const auto &voxel : comp->getVoxels()) {
-    target[static_cast<std::size_t>(voxel.p.x()) +
-           static_cast<std::size_t>(compImgWidth) *
-               static_cast<std::size_t>(compImgHeight - 1 - voxel.p.y())] =
-        targetPixel;
+  const auto imageSize{model.getGeometry().getImages().volume()};
+  std::vector<double> target(imageSize.nVoxels(), 0.0);
+  const auto &voxels = comp->getVoxels();
+  const auto &voxelRegions = model.getFeatures().getVoxelRegions(featureIndex);
+  for (std::size_t i = 0; i < voxels.size(); ++i) {
+    const auto imageIndex = common::voxelArrayIndex(imageSize, voxels[i], true);
+    target[imageIndex] = voxelRegions[i] == 1 ? 2.0 : 4.0;
   }
 
   simulate::OptCost optCostFeature{};
@@ -440,10 +412,17 @@ TEST_CASE("Optimize calculateCosts: feature target values",
   optCostFeature.featureId = model.getFeatures().getFeatures()[featureIndex].id;
 
   auto optConstData = makeOptConstData(model, {optCostFeature});
+  REQUIRE(optConstData.featureOptCosts[0].valid);
+  REQUIRE(optConstData.featureOptCosts[0].targetFeatureValues.size() == 2);
+  REQUIRE(optConstData.featureOptCosts[0].targetFeatureValues[0] ==
+          dbl_approx(2.0));
+  REQUIRE(optConstData.featureOptCosts[0].targetFeatureValues[1] ==
+          dbl_approx(4.0));
   std::vector<std::vector<double>> currentTargets(1, std::vector<double>{});
-  REQUIRE(
-      simulate::calculateCosts(optConstData, {0}, sim, currentTargets) ==
-      Catch::Approx((targetPixel - 0.73) * (targetPixel - 0.73)).margin(1e-12));
+  const double expectedCost{(2.0 - 0.73) * (2.0 - 0.73) +
+                            (4.0 - 0.73) * (4.0 - 0.73)};
+  REQUIRE(simulate::calculateCosts(optConstData, {0}, sim, currentTargets) ==
+          Catch::Approx(expectedCost).margin(1e-12));
   REQUIRE(currentTargets[0] ==
           sim.getConcArray(sim.getTimePoints().size() - 1, 0, 0));
 

--- a/gui/dialogs/dialogimagedata.cpp
+++ b/gui/dialogs/dialogimagedata.cpp
@@ -1,5 +1,6 @@
 #include "dialogimagedata.hpp"
 #include "guiutils.hpp"
+#include "sme/feature_eval.hpp"
 #include "sme/logger.hpp"
 #include "sme/model_units.hpp"
 #include "ui_dialogimagedata.h"
@@ -7,6 +8,7 @@
 #include <QInputDialog>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QStringList>
 #include <QToolTip>
 
 static QString quantityNameFor(DialogImageDataDataType dataType) {
@@ -32,7 +34,8 @@ static QString quantityTitleName(DialogImageDataDataType dataType) {
 DialogImageData::DialogImageData(
     const std::vector<double> &dataArray,
     const sme::model::SpeciesGeometry &speciesGeometry, bool invertYAxis,
-    DialogImageDataDataType dataType, QWidget *parent)
+    DialogImageDataDataType dataType,
+    const DialogImageDataFeaturePreview *featurePreview_, QWidget *parent)
     : QDialog(parent), ui{std::make_unique<Ui::DialogImageData>()},
       voxelSize(speciesGeometry.voxelSize),
       voxels(speciesGeometry.compartmentVoxels),
@@ -42,6 +45,12 @@ DialogImageData::DialogImageData(
       qpi(speciesGeometry.compartmentImageSize,
           speciesGeometry.compartmentVoxels) {
   ui->setupUi(this);
+  if (featurePreview_ != nullptr) {
+    featurePreview = *featurePreview_;
+  }
+  ui->lineFeatureValue->setVisible(featurePreview.has_value());
+  ui->lblFeatureValueLabel->setVisible(featurePreview.has_value());
+  ui->lblFeatureValue->setVisible(featurePreview.has_value());
   ui->lblImage->setZSlider(ui->slideZIndex);
   const auto &units = speciesGeometry.modelUnits;
   lengthUnit = units.getLength().name;
@@ -232,6 +241,32 @@ void DialogImageData::updateImageFromData() {
                            QColor(intensity, intensity, intensity).rgb());
   }
   ui->lblImage->setImage(imgs);
+  updateFeatureValueLabel();
+}
+
+void DialogImageData::updateFeatureValueLabel() {
+  if (!featurePreview.has_value()) {
+    return;
+  }
+  const auto featureValues{sme::simulate::evaluateFeature(
+      featurePreview->feature, data, featurePreview->voxelRegions)};
+  if (featureValues.empty()) {
+    ui->lblFeatureValue->setText("n/a");
+    return;
+  }
+  if (featureValues.size() == 1) {
+    ui->lblFeatureValueLabel->setText("Computed feature value:");
+    ui->lblFeatureValue->setText(toQStr(featureValues.front()));
+    return;
+  }
+  QStringList valueTexts;
+  for (std::size_t i = 0; i < featureValues.size(); ++i) {
+    valueTexts.push_back(QString("Region %1: %2")
+                             .arg(static_cast<qulonglong>(i + 1))
+                             .arg(toQStr(featureValues[i])));
+  }
+  ui->lblFeatureValueLabel->setText("Computed feature values:");
+  ui->lblFeatureValue->setText(valueTexts.join("\n"));
 }
 
 void DialogImageData::rescaleData(double newMin, double newMax) {
@@ -258,6 +293,7 @@ void DialogImageData::rescaleData(double newMin, double newMax) {
                    return newMin +
                           (newMax - newMin) * (c - oldMin) / (oldMax - oldMin);
                  });
+  updateFeatureValueLabel();
 }
 
 void DialogImageData::gaussianFilter(const sme::common::Voxel &direction,

--- a/gui/dialogs/dialogimagedata.hpp
+++ b/gui/dialogs/dialogimagedata.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "sme/feature_options.hpp"
 #include "sme/geometry_utils.hpp"
 #include "sme/image_stack.hpp"
 #include "sme/model.hpp"
 #include "sme/utils.hpp"
 #include <QDialog>
 #include <memory>
+#include <optional>
 
 namespace Ui {
 class DialogImageData;
@@ -17,6 +19,11 @@ enum class DialogImageDataDataType {
   DiffusionConstant
 };
 
+struct DialogImageDataFeaturePreview {
+  sme::simulate::FeatureDefinition feature;
+  std::vector<std::size_t> voxelRegions;
+};
+
 class DialogImageData : public QDialog {
   Q_OBJECT
 
@@ -26,6 +33,7 @@ public:
       const sme::model::SpeciesGeometry &speciesGeometry,
       bool invertYAxis = false,
       DialogImageDataDataType dataType = DialogImageDataDataType::Concentration,
+      const DialogImageDataFeaturePreview *featurePreview = nullptr,
       QWidget *parent = nullptr);
   ~DialogImageData() override;
   const std::vector<double> &getData() const;
@@ -47,12 +55,14 @@ private:
   sme::common::ImageStack imgs;
   sme::geometry::VoxelIndexer qpi;
   std::vector<double> data;
+  std::optional<DialogImageDataFeaturePreview> featurePreview;
 
   sme::common::VoxelF physicalPoint(const sme::common::Voxel &voxel) const;
   std::size_t pointToArrayIndex(const sme::common::Voxel &voxel) const;
   void importArray(const std::vector<double> &concentrationArray);
   void importImage(const sme::common::ImageStack &concentrationImage);
   void updateImageFromData();
+  void updateFeatureValueLabel();
   void rescaleData(double newMin, double newMax);
   void gaussianFilter(const sme::common::Voxel &direction, double sigma);
   void smoothData();

--- a/gui/dialogs/dialogimagedata.ui
+++ b/gui/dialogs/dialogimagedata.ui
@@ -181,6 +181,36 @@
         </widget>
        </item>
        <item row="17" column="0" colspan="2">
+        <widget class="Line" name="lineFeatureValue">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0" colspan="2">
+        <widget class="QLabel" name="lblFeatureValueLabel">
+         <property name="text">
+          <string>Computed feature value:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0" colspan="2">
+        <widget class="QLabel" name="lblFeatureValue">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="0" colspan="2">
         <widget class="QLabel" name="lblConcentration">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">

--- a/gui/dialogs/dialogimagedata_t.cpp
+++ b/gui/dialogs/dialogimagedata_t.cpp
@@ -30,6 +30,8 @@ struct DialogImageDataWidgets {
     GET_DIALOG_WIDGET(QPushButton, btnSmoothImage);
     GET_DIALOG_WIDGET(QSlider, slideZIndex);
     GET_DIALOG_WIDGET(QLabelMouseTracker, lblImage);
+    GET_DIALOG_WIDGET(QLabel, lblFeatureValueLabel);
+    GET_DIALOG_WIDGET(QLabel, lblFeatureValue);
     GET_DIALOG_WIDGET(QLabel, lblConcentration);
   }
   QLabel *lblMinConcLabel;
@@ -44,6 +46,8 @@ struct DialogImageDataWidgets {
   QPushButton *btnSmoothImage;
   QSlider *slideZIndex;
   QLabelMouseTracker *lblImage;
+  QLabel *lblFeatureValueLabel;
+  QLabel *lblFeatureValue;
   QLabel *lblConcentration;
 };
 
@@ -136,6 +140,22 @@ TEST_CASE("DialogImageData", "[gui/dialogs/concentrationimage][gui/"
     for (auto i : outsideArrayIndices) {
       REQUIRE(a[i] == dbl_approx(0.0));
     }
+  }
+  SECTION("feature preview displays computed feature value") {
+    std::vector<double> arr{5.0, 0.0, 0.0, 3.0, 0.0, 0.0, 1.0, 99.0, 0.0};
+    sme::simulate::FeatureDefinition feature;
+    feature.roi.numRegions = 1;
+    feature.reduction = sme::simulate::ReductionOp::Average;
+    DialogImageDataFeaturePreview featurePreview{feature, {1, 1, 1, 0}};
+    DialogImageData dia(arr, specGeom, false,
+                        DialogImageDataDataType::Concentration,
+                        &featurePreview);
+    dia.show();
+    wait();
+    DialogImageDataWidgets widgets(&dia);
+    REQUIRE(widgets.lblFeatureValueLabel->text() ==
+            "Computed feature value:");
+    REQUIRE(widgets.lblFeatureValue->text() == "3");
   }
   SECTION("min changed to valid value") {
     // initial range 0-1

--- a/gui/dialogs/dialogimagedata_t.cpp
+++ b/gui/dialogs/dialogimagedata_t.cpp
@@ -153,8 +153,7 @@ TEST_CASE("DialogImageData", "[gui/dialogs/concentrationimage][gui/"
     dia.show();
     wait();
     DialogImageDataWidgets widgets(&dia);
-    REQUIRE(widgets.lblFeatureValueLabel->text() ==
-            "Computed feature value:");
+    REQUIRE(widgets.lblFeatureValueLabel->text() == "Computed feature value:");
     REQUIRE(widgets.lblFeatureValue->text() == "3");
   }
   SECTION("min changed to valid value") {

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -109,8 +109,6 @@ void DialogOptCost::populateTargetTypes() {
   ui->cmbCostType->blockSignals(true);
   ui->cmbCostType->clear();
   m_targetTypeItems.push_back(
-      {sme::simulate::OptCostType::Unused, {}, "Unused"});
-  m_targetTypeItems.push_back(
       {sme::simulate::OptCostType::Concentration, {}, "Concentration"});
   m_targetTypeItems.push_back({sme::simulate::OptCostType::ConcentrationDcdt,
                                {},
@@ -192,29 +190,52 @@ void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
   }
   populateTargetTypes();
   populateFeatureTypes();
+  // Re-apply mutual-exclusion state after repopulating combo contents.
+  cmbFeature_currentIndexChanged(ui->cmbFeature->currentIndex());
   updateImage();
 }
 
 void DialogOptCost::cmbFeature_currentIndexChanged(int index) {
-
-  populateFeatureTypes();
+  if (index < 0 ||
+      static_cast<std::size_t>(index) >= m_featureTypeItems.size()) {
+    return;
+  }
+  const auto &item = m_featureTypeItems[static_cast<std::size_t>(index)];
+  if (item.optCostType == sme::simulate::OptCostType::Feature) {
+    // A concrete feature selection owns the target type: lock cost type combo.
+    m_optCost.optCostType = sme::simulate::OptCostType::Feature;
+    m_optCost.featureId = item.featureId;
+    ui->cmbCostType->setEnabled(false);
+  } else {
+    // "Unused" means feature targeting is inactive: fall back to cost type combo.
+    m_optCost.featureId.clear();
+    ui->cmbCostType->setEnabled(true);
+    const auto costTypeIndex{ui->cmbCostType->currentIndex()};
+    if (costTypeIndex >= 0 &&
+        static_cast<std::size_t>(costTypeIndex) < m_targetTypeItems.size()) {
+      m_optCost.optCostType =
+          m_targetTypeItems[static_cast<std::size_t>(costTypeIndex)].optCostType;
+    }
+  }
+  updateTargetValuesLabel();
 }
 
 void DialogOptCost::cmbCostType_currentIndexChanged(int index) {
+  const auto featureIndex{ui->cmbFeature->currentIndex()};
+  // Ignore cost-type changes while a feature target is active.
+  if (featureIndex >= 0 &&
+      static_cast<std::size_t>(featureIndex) < m_featureTypeItems.size() &&
+      m_featureTypeItems[static_cast<std::size_t>(featureIndex)].optCostType ==
+          sme::simulate::OptCostType::Feature) {
+    return;
+  }
   if (index < 0 ||
       static_cast<std::size_t>(index) >= m_targetTypeItems.size()) {
     return;
   }
   const auto &item = m_targetTypeItems[static_cast<std::size_t>(index)];
   m_optCost.optCostType = item.optCostType;
-
-  // TODO: check out what's going on here, this is messing with features but I
-  // don´t think it should
-  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature) {
-    m_optCost.featureId = item.featureId;
-  } else {
-    m_optCost.featureId.clear();
-  }
+  m_optCost.featureId.clear();
   updateTargetValuesLabel();
 }
 

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -2,6 +2,7 @@
 #include "dialogimagedata.hpp"
 #include "ui_dialogoptcost.h"
 #include <QMessageBox>
+#include <optional>
 
 static QString toQStr(double x) { return QString::number(x, 'g', 14); }
 
@@ -205,16 +206,25 @@ void DialogOptCost::cmbFeature_currentIndexChanged(int index) {
     // A concrete feature selection owns the target type: lock cost type combo.
     m_optCost.optCostType = sme::simulate::OptCostType::Feature;
     m_optCost.featureId = item.featureId;
+    for (int i = 0; i < static_cast<int>(m_targetTypeItems.size()); ++i) {
+      if (m_targetTypeItems[static_cast<std::size_t>(i)].optCostType ==
+          sme::simulate::OptCostType::Concentration) {
+        ui->cmbCostType->setCurrentIndex(i);
+        break;
+      }
+    }
     ui->cmbCostType->setEnabled(false);
   } else {
-    // "Unused" means feature targeting is inactive: fall back to cost type combo.
+    // "Unused" means feature targeting is inactive: fall back to cost type
+    // combo.
     m_optCost.featureId.clear();
     ui->cmbCostType->setEnabled(true);
     const auto costTypeIndex{ui->cmbCostType->currentIndex()};
     if (costTypeIndex >= 0 &&
         static_cast<std::size_t>(costTypeIndex) < m_targetTypeItems.size()) {
       m_optCost.optCostType =
-          m_targetTypeItems[static_cast<std::size_t>(costTypeIndex)].optCostType;
+          m_targetTypeItems[static_cast<std::size_t>(costTypeIndex)]
+              .optCostType;
     }
   }
   updateTargetValuesLabel();
@@ -255,10 +265,20 @@ void DialogOptCost::btnEditTargetValues_clicked() {
   if (m_optCost.optCostType == sme::simulate::OptCostType::ConcentrationDcdt) {
     dataType = DialogImageDataDataType::ConcentrationRateOfChange;
   }
+  std::optional<DialogImageDataFeaturePreview> featurePreview;
+  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature) {
+    const auto featureIndex{
+        m_model.getFeatures().getIndexFromId(m_optCost.featureId)};
+    if (featureIndex < m_model.getFeatures().size()) {
+      featurePreview = {m_model.getFeatures().getFeatures()[featureIndex],
+                        m_model.getFeatures().getVoxelRegions(featureIndex)};
+    }
+  }
   try {
     DialogImageData dialog(m_optCost.targetValues,
                            m_model.getSpeciesGeometry(m_optCost.id.c_str()),
-                           m_model.getDisplayOptions().invertYAxis, dataType);
+                           m_model.getDisplayOptions().invertYAxis, dataType,
+                           featurePreview ? &*featurePreview : nullptr);
     if (dialog.exec() == QDialog::Accepted) {
       m_optCost.targetValues = dialog.getImageArray();
       updateImage();
@@ -283,6 +303,11 @@ void DialogOptCost::txtEpsilon_editingFinished() {
 }
 
 void DialogOptCost::updateTargetValuesLabel() {
+  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature) {
+    ui->lblTargetValuesLabel->setText("Source\nconcentration:");
+    ui->btnEditTargetValues->setText("Edit Concentration to Derive Target");
+    return;
+  }
   const auto text{targetValuesText(m_optCost.optCostType)};
   ui->lblTargetValuesLabel->setText(
       QString("%1:").arg(targetValuesText(m_optCost.optCostType, true)));

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -110,33 +110,56 @@ void DialogOptCost::populateTargetTypes() {
   m_targetTypeItems.push_back({sme::simulate::OptCostType::ConcentrationDcdt,
                                {},
                                "Rate of change of concentration"});
-  const auto featureIndex =
-      m_model.getFeatures().getIndexFromId(m_optCost.featureId);
-  const auto &features = m_model.getFeatures().getFeatures();
-  for (const auto &feature : features) {
-    if (feature.speciesId != m_optCost.id) {
-      continue;
-    }
-    m_targetTypeItems.push_back(
-        {sme::simulate::OptCostType::Feature, feature.id,
-         QString("Feature: %1").arg(QString::fromStdString(feature.name))});
-  }
-  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature &&
-      (m_optCost.featureId.empty() || featureIndex >= features.size())) {
-    m_targetTypeItems.push_back(
-        {sme::simulate::OptCostType::Feature, m_optCost.featureId,
-         QString("Feature: <missing> (%1)")
-             .arg(QString::fromStdString(m_optCost.featureId))});
-  }
+
   int selectedIndex{0};
   for (int i = 0; i < static_cast<int>(m_targetTypeItems.size()); ++i) {
     const auto &item = m_targetTypeItems[static_cast<std::size_t>(i)];
     ui->cmbCostType->addItem(item.label);
     const bool sameType = item.optCostType == m_optCost.optCostType;
+
+    if (sameType) {
+      selectedIndex = i;
+    }
+  }
+  ui->cmbCostType->setCurrentIndex(selectedIndex);
+  ui->cmbCostType->blockSignals(false);
+  updateTargetValuesLabel();
+}
+
+void DialogOptCost::populateFeatureTypes() {
+  m_featureTypeItems.clear();
+  ui->cmbCostType->blockSignals(true);
+  ui->cmbCostType->clear();
+
+  const auto featureIndex =
+      m_model.getFeatures().getIndexFromId(m_optCost.featureId);
+  const auto &features = m_model.getFeatures().getFeatures();
+
+  for (const auto &feature : features) {
+    if (feature.speciesId != m_optCost.id) {
+      continue;
+    }
+    m_featureTypeItems.push_back(
+        {sme::simulate::OptCostType::Feature, feature.id,
+         QString("Feature: %1").arg(QString::fromStdString(feature.name))});
+  }
+
+  if (m_optCost.optCostType == sme::simulate::OptCostType::Feature &&
+      (m_optCost.featureId.empty() || featureIndex >= features.size())) {
+    m_featureTypeItems.push_back(
+        {sme::simulate::OptCostType::Feature, m_optCost.featureId,
+         QString("Feature: <missing> (%1)")
+             .arg(QString::fromStdString(m_optCost.featureId))});
+  }
+
+  int selectedIndex{0};
+  for (int i = 0; i < static_cast<int>(m_featureTypeItems.size()); ++i) {
+    const auto &item = m_featureTypeItems[static_cast<std::size_t>(i)];
+    ui->cmbCostType->addItem(item.label);
     const bool sameFeature =
         item.optCostType != sme::simulate::OptCostType::Feature ||
         item.featureId == m_optCost.featureId;
-    if (sameType && sameFeature) {
+    if (sameFeature) {
       selectedIndex = i;
     }
   }

--- a/gui/dialogs/dialogoptcost.cpp
+++ b/gui/dialogs/dialogoptcost.cpp
@@ -68,6 +68,8 @@ DialogOptCost::DialogOptCost(
     }
     connect(ui->cmbSpecies, &QComboBox::currentIndexChanged, this,
             &DialogOptCost::cmbSpecies_currentIndexChanged);
+    connect(ui->cmbFeature, &QComboBox::currentIndexChanged, this,
+            &DialogOptCost::cmbFeature_currentIndexChanged);
     connect(ui->cmbCostType, &QComboBox::currentIndexChanged, this,
             &DialogOptCost::cmbCostType_currentIndexChanged);
     connect(ui->cmbDiffType, &QComboBox::currentIndexChanged, this,
@@ -80,6 +82,7 @@ DialogOptCost::DialogOptCost(
             &DialogOptCost::txtWeight_editingFinished);
     connect(ui->txtEpsilon, &QLineEdit::editingFinished, this,
             &DialogOptCost::txtEpsilon_editingFinished);
+
     ui->cmbDiffType->setCurrentIndex(toIndex(m_optCost.optCostDiffType));
     ui->txtSimulationTime->setText(QString::number(m_optCost.simulationTime));
     ui->txtWeight->setText(QString::number(m_optCost.weight));
@@ -106,6 +109,8 @@ void DialogOptCost::populateTargetTypes() {
   ui->cmbCostType->blockSignals(true);
   ui->cmbCostType->clear();
   m_targetTypeItems.push_back(
+      {sme::simulate::OptCostType::Unused, {}, "Unused"});
+  m_targetTypeItems.push_back(
       {sme::simulate::OptCostType::Concentration, {}, "Concentration"});
   m_targetTypeItems.push_back({sme::simulate::OptCostType::ConcentrationDcdt,
                                {},
@@ -128,14 +133,18 @@ void DialogOptCost::populateTargetTypes() {
 
 void DialogOptCost::populateFeatureTypes() {
   m_featureTypeItems.clear();
-  ui->cmbCostType->blockSignals(true);
-  ui->cmbCostType->clear();
+  m_featureTypeItems.push_back(
+      {sme::simulate::OptCostType::Unused, {}, "Unused"});
+  ui->cmbFeature->blockSignals(true);
+  ui->cmbFeature->clear();
 
   const auto featureIndex =
       m_model.getFeatures().getIndexFromId(m_optCost.featureId);
   const auto &features = m_model.getFeatures().getFeatures();
 
   for (const auto &feature : features) {
+    // only allow features to be shown that belong to the currently selected
+    // species
     if (feature.speciesId != m_optCost.id) {
       continue;
     }
@@ -143,7 +152,7 @@ void DialogOptCost::populateFeatureTypes() {
         {sme::simulate::OptCostType::Feature, feature.id,
          QString("Feature: %1").arg(QString::fromStdString(feature.name))});
   }
-
+  // TODO: what's this doing?
   if (m_optCost.optCostType == sme::simulate::OptCostType::Feature &&
       (m_optCost.featureId.empty() || featureIndex >= features.size())) {
     m_featureTypeItems.push_back(
@@ -155,7 +164,7 @@ void DialogOptCost::populateFeatureTypes() {
   int selectedIndex{0};
   for (int i = 0; i < static_cast<int>(m_featureTypeItems.size()); ++i) {
     const auto &item = m_featureTypeItems[static_cast<std::size_t>(i)];
-    ui->cmbCostType->addItem(item.label);
+    ui->cmbFeature->addItem(item.label);
     const bool sameFeature =
         item.optCostType != sme::simulate::OptCostType::Feature ||
         item.featureId == m_optCost.featureId;
@@ -163,9 +172,8 @@ void DialogOptCost::populateFeatureTypes() {
       selectedIndex = i;
     }
   }
-  ui->cmbCostType->setCurrentIndex(selectedIndex);
-  ui->cmbCostType->blockSignals(false);
-  updateTargetValuesLabel();
+  ui->cmbFeature->setCurrentIndex(selectedIndex);
+  ui->cmbFeature->blockSignals(false);
 }
 
 void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
@@ -183,7 +191,13 @@ void DialogOptCost::cmbSpecies_currentIndexChanged(int index) {
                                sme::simulate::OptCostDiffType::Relative);
   }
   populateTargetTypes();
+  populateFeatureTypes();
   updateImage();
+}
+
+void DialogOptCost::cmbFeature_currentIndexChanged(int index) {
+
+  populateFeatureTypes();
 }
 
 void DialogOptCost::cmbCostType_currentIndexChanged(int index) {
@@ -193,6 +207,9 @@ void DialogOptCost::cmbCostType_currentIndexChanged(int index) {
   }
   const auto &item = m_targetTypeItems[static_cast<std::size_t>(index)];
   m_optCost.optCostType = item.optCostType;
+
+  // TODO: check out what's going on here, this is messing with features but I
+  // don´t think it should
   if (m_optCost.optCostType == sme::simulate::OptCostType::Feature) {
     m_optCost.featureId = item.featureId;
   } else {

--- a/gui/dialogs/dialogoptcost.hpp
+++ b/gui/dialogs/dialogoptcost.hpp
@@ -32,7 +32,9 @@ private:
   std::unique_ptr<Ui::DialogOptCost> ui;
   sme::simulate::OptCost m_optCost;
   std::vector<TargetTypeItem> m_targetTypeItems;
+  std::vector<TargetTypeItem> m_featureTypeItems;
   void cmbSpecies_currentIndexChanged(int index);
+  void cmbFeature_currentIndexChanged(int index);
   void cmbCostType_currentIndexChanged(int index);
   void cmbDiffType_currentIndexChanged(int index);
   void txtSimulationTime_editingFinished();
@@ -40,6 +42,7 @@ private:
   void txtWeight_editingFinished();
   void txtEpsilon_editingFinished();
   void populateTargetTypes();
+  void populateFeatureTypes();
   void updateTargetValuesLabel();
   void updateImage();
 };

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -225,7 +225,7 @@
       </widget>
      </item>
      <item row="2" column="0" alignment="Qt::AlignRight">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="lblFeatureValuesLabel">
        <property name="text">
         <string>Feature:</string>
        </property>
@@ -255,6 +255,7 @@
  <tabstops>
   <tabstop>cmbSpecies</tabstop>
   <tabstop>cmbCostType</tabstop>
+  <tabstop>cmbFeature</tabstop>
   <tabstop>txtSimulationTime</tabstop>
   <tabstop>btnEditTargetValues</tabstop>
   <tabstop>cmbDiffType</tabstop>

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -28,6 +28,19 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="4" column="0" rowspan="2">
+      <widget class="QLabel" name="lblTargetValuesLabel">
+       <property name="toolTip">
+        <string>Preview of the target values used for this optimization target</string>
+       </property>
+       <property name="text">
+        <string>Concentration:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="lblSpeciesLabel">
        <property name="toolTip">
@@ -41,7 +54,20 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="8" column="0">
+      <widget class="QLabel" name="lblEpsilonLabel">
+       <property name="toolTip">
+        <string>Small value used when computing relative differences</string>
+       </property>
+       <property name="text">
+        <string>Epsilon:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
       <widget class="QComboBox" name="cmbSpecies">
        <property name="toolTip">
         <string>Select the species whose values will be matched</string>
@@ -51,57 +77,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblCostTypeLabel">
-       <property name="toolTip">
-        <string>Choose whether to match concentration, rate of change, or a feature</string>
-       </property>
-       <property name="text">
-        <string>Target type:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="cmbCostType">
-       <property name="toolTip">
-        <string>Choose whether to match concentration, rate of change, or a feature</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Concentration</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Rate of change of concentration</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="lblSimulationTimeLabel">
-       <property name="toolTip">
-        <string>Simulation time at which this target is evaluated</string>
-       </property>
-       <property name="text">
-        <string>Simulation time:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="txtSimulationTime">
-       <property name="toolTip">
-        <string>Simulation time at which this target is evaluated</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
+     <item row="4" column="2">
       <widget class="QLabelMouseTracker" name="lblImage" native="true">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -121,17 +97,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QPushButton" name="btnEditTargetValues">
-       <property name="toolTip">
-        <string>Edit the target values image used for this optimization target</string>
-       </property>
-       <property name="text">
-        <string>Edit Concentration</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="lblDiffTypeLabel">
        <property name="toolTip">
         <string>Choose whether differences are measured absolutely or relatively</string>
@@ -144,7 +110,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="2">
       <widget class="QComboBox" name="cmbDiffType">
        <property name="toolTip">
         <string>Choose whether differences are measured absolutely or relatively</string>
@@ -161,7 +127,43 @@
        </item>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblCostTypeLabel">
+       <property name="toolTip">
+        <string>Choose whether to match concentration, rate of change, or a feature</string>
+       </property>
+       <property name="text">
+        <string>Target type:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblSimulationTimeLabel">
+       <property name="toolTip">
+        <string>Simulation time at which this target is evaluated</string>
+       </property>
+       <property name="text">
+        <string>Simulation time:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QPushButton" name="btnEditTargetValues">
+       <property name="toolTip">
+        <string>Edit the target values image used for this optimization target</string>
+       </property>
+       <property name="text">
+        <string>Edit Concentration</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
       <widget class="QLabel" name="lblWeightLabel">
        <property name="toolTip">
         <string>Weight applied to this target in the overall optimization cost</string>
@@ -174,43 +176,58 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="1" column="2">
+      <widget class="QComboBox" name="cmbCostType">
+       <property name="toolTip">
+        <string>Choose whether to match concentration or rate of change. This is mutually exclusive with features.´</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Concentration</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Rate of change of concentration</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="7" column="2">
       <widget class="QLineEdit" name="txtWeight">
        <property name="toolTip">
         <string>Weight applied to this target in the overall optimization cost</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="lblEpsilonLabel">
+     <item row="3" column="2">
+      <widget class="QLineEdit" name="txtSimulationTime">
        <property name="toolTip">
-        <string>Small value used when computing relative differences</string>
-       </property>
-       <property name="text">
-        <string>Epsilon:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <string>Simulation time at which this target is evaluated</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="2">
       <widget class="QLineEdit" name="txtEpsilon">
        <property name="toolTip">
         <string>Small value used when computing relative differences</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" rowspan="2">
-      <widget class="QLabel" name="lblTargetValuesLabel">
+     <item row="2" column="2">
+      <widget class="QComboBox" name="cmbFeature">
        <property name="toolTip">
-        <string>Preview of the target values used for this optimization target</string>
+        <string>Select from the features associated with the selected Species. This is mutually exclusive with 'Target type'. </string>
        </property>
+       <property name="maxVisibleItems">
+        <number>99</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" alignment="Qt::AlignRight">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Concentration:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <string>Feature:</string>
        </property>
       </widget>
      </item>

--- a/gui/dialogs/dialogoptcost.ui
+++ b/gui/dialogs/dialogoptcost.ui
@@ -156,10 +156,10 @@
      <item row="5" column="2">
       <widget class="QPushButton" name="btnEditTargetValues">
        <property name="toolTip">
-        <string>Edit the target values image used for this optimization target</string>
+        <string>Edit the target values image used for this optimization target. For feature targets, this is the concentration image used to derive the feature value.</string>
        </property>
        <property name="text">
-        <string>Edit Concentration</string>
+        <string>Edit Target</string>
        </property>
       </widget>
      </item>
@@ -179,7 +179,7 @@
      <item row="1" column="2">
       <widget class="QComboBox" name="cmbCostType">
        <property name="toolTip">
-        <string>Choose whether to match concentration or rate of change. This is mutually exclusive with features.´</string>
+        <string>Choose whether to match concentration or rate of change. Feature targets are derived from concentration images, so this is locked to concentration when a feature is selected.</string>
        </property>
        <item>
         <property name="text">
@@ -217,7 +217,7 @@
      <item row="2" column="2">
       <widget class="QComboBox" name="cmbFeature">
        <property name="toolTip">
-        <string>Select from the features associated with the selected Species. This is mutually exclusive with 'Target type'. </string>
+        <string>Select from the features associated with the selected species. Feature targets are derived from concentration images.</string>
        </property>
        <property name="maxVisibleItems">
         <number>99</number>

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -15,6 +15,7 @@ struct DialogOptCostWidgets {
   explicit DialogOptCostWidgets(const DialogOptCost *dialog) {
     GET_DIALOG_WIDGET(QComboBox, cmbSpecies);
     GET_DIALOG_WIDGET(QComboBox, cmbCostType);
+    GET_DIALOG_WIDGET(QComboBox, cmbFeature);
     GET_DIALOG_WIDGET(QLabel, lblTargetValuesLabel);
     GET_DIALOG_WIDGET(QLineEdit, txtSimulationTime);
     GET_DIALOG_WIDGET(QPushButton, btnEditTargetValues);
@@ -24,6 +25,7 @@ struct DialogOptCostWidgets {
   }
   QComboBox *cmbSpecies;
   QComboBox *cmbCostType;
+  QComboBox *cmbFeature;
   QLabel *lblTargetValuesLabel;
   QLineEdit *txtSimulationTime;
   QPushButton *btnEditTargetValues;
@@ -311,7 +313,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
   }
-  SECTION("matching features appear in target type list") {
+  SECTION("feature selection mode is mutually exclusive with target type mode") {
     simulate::RoiSettings roi;
     roi.roiType = simulate::RoiType::Analytic;
     auto compId = model.getSpecies().getField("Mt")->getCompartment()->getId();
@@ -320,18 +322,64 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     DialogOptCost dia(model, defaultOptCosts, &defaultOptCosts[1]);
     DialogOptCostWidgets widgets(&dia);
     dia.show();
-    REQUIRE(widgets.cmbCostType->count() == 3);
+
+    REQUIRE(widgets.cmbCostType->count() == 2);
     REQUIRE(widgets.cmbCostType->itemText(0) == "Concentration");
     REQUIRE(widgets.cmbCostType->itemText(1) ==
             "Rate of change of concentration");
-    REQUIRE(widgets.cmbCostType->itemText(2) == "Feature: peripheral Mt");
-    widgets.cmbCostType->setCurrentIndex(2);
+    REQUIRE(widgets.cmbFeature->count() == 2);
+    REQUIRE(widgets.cmbFeature->itemText(0) == "Unused");
+    REQUIRE(widgets.cmbFeature->itemText(1) == "Feature: peripheral Mt");
+
+    widgets.cmbCostType->setCurrentIndex(1);
+    REQUIRE(dia.getOptCost().optCostType ==
+            simulate::OptCostType::ConcentrationDcdt);
+    REQUIRE(dia.getOptCost().featureId.empty());
+
+    widgets.cmbFeature->setCurrentIndex(1);
+    REQUIRE(widgets.cmbCostType->isEnabled() == false);
     REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
     REQUIRE(dia.getOptCost().featureId ==
             model.getFeatures().getFeatures()[featureIndex].id);
     REQUIRE(widgets.lblTargetValuesLabel->text() == "Concentration:");
     REQUIRE(widgets.btnEditTargetValues->text() == "Edit Concentration");
-    widgets.cmbSpecies->setCurrentIndex(0);
-    REQUIRE(widgets.cmbCostType->count() == 2);
+
+    // switching cost type while feature mode is active should be ignored
+    widgets.cmbCostType->setCurrentIndex(0);
+    REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
+    REQUIRE(dia.getOptCost().featureId ==
+            model.getFeatures().getFeatures()[featureIndex].id);
+
+    widgets.cmbFeature->setCurrentIndex(0);
+    REQUIRE(widgets.cmbCostType->isEnabled());
+    REQUIRE(dia.getOptCost().featureId.empty());
+    REQUIRE(dia.getOptCost().optCostType ==
+            simulate::OptCostType::Concentration);
+
+    widgets.cmbSpecies->setCurrentIndex(0); // P0
+    REQUIRE(widgets.cmbFeature->count() == 1);
+    REQUIRE(widgets.cmbFeature->itemText(0) == "Unused");
+  }
+  SECTION("pre-selected feature target starts in feature mode") {
+    simulate::RoiSettings roi;
+    roi.roiType = simulate::RoiType::Analytic;
+    auto compId = model.getSpecies().getField("Mt")->getCompartment()->getId();
+    auto featureIndex = model.getFeatures().add(
+        "mean Mt", compId, "Mt", roi, simulate::ReductionOp::Average);
+    auto initialOptCost = defaultOptCosts[1];
+    initialOptCost.optCostType = simulate::OptCostType::Feature;
+    initialOptCost.featureId = model.getFeatures().getFeatures()[featureIndex].id;
+
+    DialogOptCost dia(model, defaultOptCosts, &initialOptCost);
+    DialogOptCostWidgets widgets(&dia);
+    dia.show();
+
+    REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
+    REQUIRE(dia.getOptCost().featureId ==
+            model.getFeatures().getFeatures()[featureIndex].id);
+    REQUIRE(widgets.cmbCostType->isEnabled() == false);
+    REQUIRE(widgets.cmbFeature->count() == 2);
+    REQUIRE(widgets.cmbFeature->itemText(1) == "Feature: mean Mt");
+    REQUIRE(widgets.cmbFeature->currentIndex() == 1);
   }
 }

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -338,17 +338,20 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
 
     widgets.cmbFeature->setCurrentIndex(1);
     REQUIRE(widgets.cmbCostType->isEnabled() == false);
+    REQUIRE(widgets.cmbCostType->currentText() == "Concentration");
     REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
     REQUIRE(dia.getOptCost().featureId ==
             model.getFeatures().getFeatures()[featureIndex].id);
-    REQUIRE(widgets.lblTargetValuesLabel->text() == "Concentration:");
-    REQUIRE(widgets.btnEditTargetValues->text() == "Edit Concentration");
+    REQUIRE(widgets.lblTargetValuesLabel->text() == "Source\nconcentration:");
+    REQUIRE(widgets.btnEditTargetValues->text() ==
+            "Edit Concentration to Derive Target");
 
     // switching cost type while feature mode is active should be ignored
     widgets.cmbCostType->setCurrentIndex(0);
     REQUIRE(dia.getOptCost().optCostType == simulate::OptCostType::Feature);
     REQUIRE(dia.getOptCost().featureId ==
             model.getFeatures().getFeatures()[featureIndex].id);
+    REQUIRE(widgets.cmbCostType->currentText() == "Concentration");
 
     widgets.cmbFeature->setCurrentIndex(0);
     REQUIRE(widgets.cmbCostType->isEnabled());
@@ -378,6 +381,7 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().featureId ==
             model.getFeatures().getFeatures()[featureIndex].id);
     REQUIRE(widgets.cmbCostType->isEnabled() == false);
+    REQUIRE(widgets.cmbCostType->currentText() == "Concentration");
     REQUIRE(widgets.cmbFeature->count() == 2);
     REQUIRE(widgets.cmbFeature->itemText(1) == "Feature: mean Mt");
     REQUIRE(widgets.cmbFeature->currentIndex() == 1);

--- a/gui/dialogs/dialogoptcost_t.cpp
+++ b/gui/dialogs/dialogoptcost_t.cpp
@@ -313,7 +313,8 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     REQUIRE(dia.getOptCost().optCostDiffType ==
             simulate::OptCostDiffType::Relative);
   }
-  SECTION("feature selection mode is mutually exclusive with target type mode") {
+  SECTION(
+      "feature selection mode is mutually exclusive with target type mode") {
     simulate::RoiSettings roi;
     roi.roiType = simulate::RoiType::Analytic;
     auto compId = model.getSpecies().getField("Mt")->getCompartment()->getId();
@@ -367,11 +368,12 @@ TEST_CASE("DialogOptCost", "[gui/dialogs/optcost][gui/"
     simulate::RoiSettings roi;
     roi.roiType = simulate::RoiType::Analytic;
     auto compId = model.getSpecies().getField("Mt")->getCompartment()->getId();
-    auto featureIndex = model.getFeatures().add(
-        "mean Mt", compId, "Mt", roi, simulate::ReductionOp::Average);
+    auto featureIndex = model.getFeatures().add("mean Mt", compId, "Mt", roi,
+                                                simulate::ReductionOp::Average);
     auto initialOptCost = defaultOptCosts[1];
     initialOptCost.optCostType = simulate::OptCostType::Feature;
-    initialOptCost.featureId = model.getFeatures().getFeatures()[featureIndex].id;
+    initialOptCost.featureId =
+        model.getFeatures().getFeatures()[featureIndex].id;
 
     DialogOptCost dia(model, defaultOptCosts, &initialOptCost);
     DialogOptCostWidgets widgets(&dia);


### PR DESCRIPTION
implements discussion points for integrating the 
- makes features its own dropdown to select 
- makes them mutually exclusive with concentration targets in the gui so users don't get confused which target is optimized on 
- sets the target to 'concentration' when features is selected b/c afaik features only act on concentrations, not on dc/dt
- uses a supplied concentration image for computing the feature target 
- in `edit target` 
   - add a display to show the value of the selected feature as computed from a supplied concentration image 
   - change the button label when a feature is selected to reflect that the feature will be derived from the supplied concentration and concentration is not directly the target 
   - change some tool tips to document the semantics of features vs concentrations in the optimizer 
